### PR TITLE
Localized graph legend labels

### DIFF
--- a/StatsDemo/StatsDemo/WPSAppDelegate.m
+++ b/StatsDemo/StatsDemo/WPSAppDelegate.m
@@ -7,14 +7,20 @@
 //
 
 #import "WPSAppDelegate.h"
+#import <DDLog.h>
+#import "DDTTYLogger.h"
+#import "DDASLLogger.h"
 
-int ddLogLevel = LOG_LEVEL_INFO;
+int ddLogLevel = LOG_LEVEL_VERBOSE;
 
 @implementation WPSAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     // Override point for customization after application launch.
+    [DDLog addLogger:[DDASLLogger sharedInstance]];
+    [DDLog addLogger:[DDTTYLogger sharedInstance]];
+
     return YES;
 }
 							

--- a/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
@@ -94,9 +94,8 @@ static NSString *const GraphBackgroundView = @"GraphBackgroundView";
 {
     if ([kind isEqualToString:UICollectionElementKindSectionHeader]) {
         WPStatsGraphLegendView *legend = [collectionView dequeueReusableSupplementaryViewOfKind:kind withReuseIdentifier:LegendView forIndexPath:indexPath];
-        // FIXME - These category titles ARE NOT LOCALIZABLE
-        [legend addCategory:StatsViewsCategory withColor:[WPStyleGuide statsLighterBlue]];
-        [legend addCategory:StatsVisitorsCategory withColor:[WPStyleGuide statsDarkerBlue]];
+        [legend addCategory:NSLocalizedString(@"Views", @"Views Category in Site Stats") withColor:[WPStyleGuide statsLighterBlue]];
+        [legend addCategory:NSLocalizedString(@"Visitors", @"Visitors Category in Site Stats") withColor:[WPStyleGuide statsDarkerBlue]];
         [legend finishedAddingCategories];
 
         return legend;


### PR DESCRIPTION
Fixes #24 

Turned the labels in the graph legend into localizable strings.  Since we're hard coding the category keys for the collections elsewhere, this is sufficient for now.
