### PR TITLE
Fix Y-axis step calculation in graphs

### DIFF
--- a/WordPressCom-Stats-iOS/WPStatsGraphBarCell.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphBarCell.m
@@ -37,19 +37,6 @@
 - (void)finishedSettingProperties
 {
     self.barsWithColors = [NSMutableArray new];
-    
-    // Y axis line markers and values
-    // Round up and extend past max value to the next 10s
-    NSUInteger yAxisTicks = self.numberOfYValues;
-    NSUInteger stepValue = 1;
-    
-    if (self.maximumY > 0) {
-        CGFloat s = (CGFloat)self.maximumY/(CGFloat)yAxisTicks;
-        long len = (long)(double)log10(s);
-        long div = (long)(double)pow(10, len);
-        stepValue = ceil(s / div) * div;
-    }
-    self.maximumY = stepValue * yAxisTicks;
 
     // For each subsequent category, inset the bar a set amount
     __block CGFloat inset = 0.0;

--- a/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
@@ -19,6 +19,7 @@ static NSString *const CategoryBarCell = @"CategoryBarCell";
 static NSString *const LegendView = @"LegendView";
 static NSString *const FooterView = @"FooterView";
 static NSString *const GraphBackgroundView = @"GraphBackgroundView";
+static NSInteger const RecommendedYAxisTicks = 7;
 
 @implementation WPStatsGraphViewController
 
@@ -29,6 +30,7 @@ static NSString *const GraphBackgroundView = @"GraphBackgroundView";
     if (self) {
         _flowLayout = layout;
         _numberOfYValues = 7;
+        _maximumY = 0;
     }
     return self;
 }
@@ -192,8 +194,23 @@ static NSString *const GraphBackgroundView = @"GraphBackgroundView";
             maximumY = [number floatValue];
         }
     }
-    
-    self.maximumY = maximumY;
+
+    // Y axis line markers and values
+    // Round up and extend past max value to the next step
+    NSUInteger yAxisTicks = RecommendedYAxisTicks;
+    NSUInteger stepValue = 1;
+
+    if (maximumY > 0) {
+        CGFloat s = (CGFloat)maximumY/(CGFloat)yAxisTicks;
+        long len = (long)(double)log10(s);
+        long div = (long)(double)pow(10, len);
+        stepValue = ceil(s / div) * div;
+
+        // Adjust yAxisTicks to accomodate ticks and maximum without too much padding
+        yAxisTicks = ceil( maximumY / stepValue ) + 1;
+        self.maximumY = stepValue * yAxisTicks;
+        self.numberOfYValues = yAxisTicks;
+    }
     
     NSUInteger countViews = [categoryData[StatsViewsCategory] count];
     NSUInteger countVisitors = [categoryData[StatsVisitorsCategory] count];


### PR DESCRIPTION
Closes #32 

Y-axis calculations previously dictated a set number of ticks, which sometimes led to cells having too much whitespace at the top, or overrunning the top of the graph. This commit allows the number of ticks to adjust to fit the maximum height of the graph.

Each graph cell calculated its maximum height and Y-axis ticks; this commit moves that calculation to the graph background to avoid rerunning those calculations for each cell.
