### PR TITLE
Fix Y-axis start point for graph cells

### DIFF
--- a/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
@@ -140,7 +140,7 @@ static NSString *const GraphBackgroundView = @"GraphBackgroundView";
 - (CGSize)collectionView:(UICollectionView *)collectionView layout:(UICollectionViewLayout*)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath *)indexPath
 {
     CGFloat width = 30.0f;
-    CGFloat height = CGRectGetHeight(collectionView.frame) - 25.0;
+    CGFloat height = CGRectGetHeight(collectionView.frame) - 24.0;
     
     CGSize size = CGSizeMake(width, height);
     


### PR DESCRIPTION
Closes #54 

Removes whitespace under the graph column by adjusting the starting point by one unit.

iPad Retina:
![image](https://cloud.githubusercontent.com/assets/235010/4338619/1dddac44-401b-11e4-8fc8-342975d6b977.png)

iPad 2:
![image](https://cloud.githubusercontent.com/assets/235010/4338629/3649c1e6-401b-11e4-9731-5039839b0fb3.png)

iPhone 5:
![image](https://cloud.githubusercontent.com/assets/235010/4338637/46447c62-401b-11e4-927c-67525145903b.png)
