### PR TITLE
Correct a divide by zero error causing a crash in CGRect frame later

### DIFF
--- a/WordPressCom-Stats-iOS/WPStatsGraphBarCell.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphBarCell.m
@@ -49,7 +49,11 @@
         NSInteger value = [category[@"value"] integerValue];
         NSString *name = category[@"name"];
         
-        CGFloat percentHeight = self.maximumY == 0.0 ? 0.0 : value / self.maximumY;
+        CGFloat percentHeight = 0.0;
+        if (self.maximumY != 0.0) {
+            percentHeight = value / self.maximumY;
+        }
+        
         CGFloat height = floorf((CGRectGetHeight(self.contentView.bounds) - 20.0) * percentHeight);
         CGFloat offsetY = CGRectGetHeight(self.contentView.bounds) - (height + 20.0);
         


### PR DESCRIPTION
Fixes a crash with frame calculation when no data points exist for a site.
