### PR TITLE
Localized all numbers coming from API call

### DIFF
--- a/WordPressCom-Stats-iOS/StatsSummary.h
+++ b/WordPressCom-Stats-iOS/StatsSummary.h
@@ -19,9 +19,9 @@ typedef NS_ENUM(NSInteger, StatsSummaryType) {
 @property (nonatomic, strong) NSDate *date;
 @property (nonatomic, assign) StatsPeriodUnit periodUnit;
 @property (nonatomic, copy)   NSString *label;
-@property (nonatomic, strong) NSNumber *views;
-@property (nonatomic, strong) NSNumber *visitors;
-@property (nonatomic, strong) NSNumber *likes;
-@property (nonatomic, strong) NSNumber *comments;
+@property (nonatomic, strong) NSString *views;
+@property (nonatomic, strong) NSString *visitors;
+@property (nonatomic, strong) NSString *likes;
+@property (nonatomic, strong) NSString *comments;
 
 @end

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -586,7 +586,7 @@ static CGFloat const kNoResultsHeight = 100.0f;
         {
             iconLabel.text = @"";
             textLabel.text = NSLocalizedString(@"Views", @"");
-            valueLabel.text = summary.views.stringValue;
+            valueLabel.text = summary.views;
             break;
         }
             
@@ -594,7 +594,7 @@ static CGFloat const kNoResultsHeight = 100.0f;
         {
             iconLabel.text = @"";
             textLabel.text = NSLocalizedString(@"Visitors", @"");
-            valueLabel.text = summary.visitors.stringValue;
+            valueLabel.text = summary.visitors;
             break;
         }
             
@@ -602,7 +602,7 @@ static CGFloat const kNoResultsHeight = 100.0f;
         {
             iconLabel.text = @"";
             textLabel.text = NSLocalizedString(@"Likes", @"");
-            valueLabel.text = summary.likes.stringValue;
+            valueLabel.text = summary.likes;
             break;
         }
             
@@ -610,7 +610,7 @@ static CGFloat const kNoResultsHeight = 100.0f;
         {
             iconLabel.text = @"";
             textLabel.text = NSLocalizedString(@"Comments", @"");
-            valueLabel.text = summary.comments.stringValue;
+            valueLabel.text = summary.comments;
             break;
         }
             

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -83,7 +83,7 @@
             visitsCompletion(visits);
         }
     }
-                  postsCompletionHandler:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                  postsCompletionHandler:^(NSArray *items, NSString *totalViews, NSString *otherViews)
     {
         postsResult.items = items;
         postsResult.titlePrimary = NSLocalizedString(@"Posts & Pages", @"Title for stats section for Posts & Pages");
@@ -92,7 +92,7 @@
             postsCompletion(postsResult);
         }
     }
-              referrersCompletionHandler:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+              referrersCompletionHandler:^(NSArray *items, NSString *totalViews, NSString *otherViews)
     {
         referrersResult.items = items;
         
@@ -100,7 +100,7 @@
             referrersCompletion(referrersResult);
         }
     }
-                 clicksCompletionHandler:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                 clicksCompletionHandler:^(NSArray *items, NSString *totalViews, NSString *otherViews)
     {
         clicksResult.items = items;
         
@@ -108,7 +108,7 @@
             clicksCompletion(clicksResult);
         }
     }
-                countryCompletionHandler:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                countryCompletionHandler:^(NSArray *items, NSString *totalViews, NSString *otherViews)
     {
         countriesResult.items = items;
         
@@ -116,7 +116,7 @@
             countryCompletion(countriesResult);
         }
     }
-                  videosCompetionHandler:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                  videosCompetionHandler:^(NSArray *items, NSString *totalViews, NSString *otherViews)
     {
         videosResult.items = items;
         
@@ -124,7 +124,7 @@
             videosCompletion(videosResult);
         }
     }
-                      commentsCompletion:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                      commentsCompletion:^(NSArray *items, NSString *totalViews, NSString *otherViews)
     {
         commentsResult.items = items;
         
@@ -132,7 +132,7 @@
             commentsCompletion(commentsResult);
         }
     }
-                tagsCategoriesCompletion:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                tagsCategoriesCompletion:^(NSArray *items, NSString *totalViews, NSString *otherViews)
     {
         tagsCategoriesResult.items = items;
         
@@ -140,7 +140,7 @@
             tagsCategoriesCompletion(tagsCategoriesResult);
         }
     }
-                     followersCompletion:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                     followersCompletion:^(NSArray *items, NSString *totalViews, NSString *otherViews)
     {
         followersResult.items = items;
         
@@ -148,7 +148,7 @@
             followersCompletion(followersResult);
         }
     }
-                     publicizeCompletion:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                     publicizeCompletion:^(NSArray *items, NSString *totalViews, NSString *otherViews)
     {
         publicizeResult.items = items;
         

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
@@ -4,7 +4,7 @@
 
 typedef void (^StatsRemoteSummaryCompletion)(StatsSummary *summary);
 typedef void (^StatsRemoteVisitsCompletion)(StatsVisits *visits);
-typedef void (^StatsRemoteItemsCompletion)(NSArray *items, NSNumber *totalViews, NSNumber *otherViews);
+typedef void (^StatsRemoteItemsCompletion)(NSArray *items, NSString *totalViews, NSString *otherViews);
 
 @interface WPStatsServiceRemote : NSObject
 

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
@@ -40,10 +40,10 @@
         XCTAssertNotNil(summary, @"summary should not be nil.");
         XCTAssertNotNil(summary.date);
         XCTAssertTrue(summary.periodUnit == StatsPeriodUnitDay);
-        XCTAssertTrue([summary.views isEqualToNumber:@56]);
-        XCTAssertTrue([summary.visitors isEqualToNumber:@44]);
-        XCTAssertTrue([summary.likes isEqualToNumber:@1]);
-        XCTAssertTrue([summary.comments isEqualToNumber:@3]);
+        XCTAssertTrue([summary.views isEqualToString:@"56"]);
+        XCTAssertTrue([summary.visitors isEqualToString:@"44"]);
+        XCTAssertTrue([summary.likes isEqualToString:@"1"]);
+        XCTAssertTrue([summary.comments isEqualToString:@"3"]);
         
         [expectation fulfill];
     } failureHandler:^(NSError *error) {
@@ -75,10 +75,10 @@
          
          StatsSummary *firstSummary = visits.statsData[0];
          XCTAssertNotNil(firstSummary.date);
-         XCTAssertTrue([firstSummary.views isEqualToNumber:@58]);
-         XCTAssertTrue([firstSummary.visitors isEqualToNumber:@39]);
-         XCTAssertTrue([firstSummary.likes isEqualToNumber:@1]);
-         XCTAssertTrue([firstSummary.comments isEqualToNumber:@3]);
+         XCTAssertTrue([firstSummary.views isEqualToString:@"58"]);
+         XCTAssertTrue([firstSummary.visitors isEqualToString:@"39"]);
+         XCTAssertTrue([firstSummary.likes isEqualToString:@"1"]);
+         XCTAssertTrue([firstSummary.comments isEqualToString:@"3"]);
          
          [expectation fulfill];
      } failureHandler:^(NSError *error) {
@@ -111,10 +111,10 @@
          
          StatsSummary *firstSummary = visits.statsData[0];
          XCTAssertNotNil(firstSummary.date);
-         XCTAssertTrue([firstSummary.views isEqualToNumber:@7808]);
-         XCTAssertTrue([firstSummary.visitors isEqualToNumber:@4331]);
-         XCTAssertTrue([firstSummary.likes isEqualToNumber:@0]);
-         XCTAssertTrue([firstSummary.comments isEqualToNumber:@0]);
+         XCTAssertTrue([firstSummary.views isEqualToString:@"7,808"]);
+         XCTAssertTrue([firstSummary.visitors isEqualToString:@"4,331"]);
+         XCTAssertTrue([firstSummary.likes isEqualToString:@"0"]);
+         XCTAssertTrue([firstSummary.comments isEqualToString:@"0"]);
          
          [expectation fulfill];
      } failureHandler:^(NSError *error) {
@@ -137,7 +137,7 @@
     
     [self.subject fetchPostsStatsForDate:[NSDate date]
                                  andUnit:StatsPeriodUnitDay
-                   withCompletionHandler:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                   withCompletionHandler:^(NSArray *items, NSString *totalViews, NSString *otherViews)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
          XCTAssertNotNil(totalViews, @"There should be a number provided.");
@@ -175,7 +175,7 @@
     
     [self.subject fetchPostsStatsForDate:[NSDate date]
                                  andUnit:StatsPeriodUnitDay
-                   withCompletionHandler:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                   withCompletionHandler:^(NSArray *items, NSString *totalViews, NSString *otherViews)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
          XCTAssertNotNil(totalViews, @"There should be a number provided.");
@@ -185,7 +185,7 @@
          StatsItem *item = items[0];
          XCTAssertTrue([item.itemID isEqualToNumber:@39806]);
          XCTAssertTrue([item.label isEqualToString:@"Home"]);
-         XCTAssertTrue([item.value isEqualToString:@"2420"]);
+         XCTAssertTrue([item.value isEqualToString:@"2,420"]);
          XCTAssertEqual(1, item.actions.count);
          
          StatsItemAction *action = item.actions[0];
@@ -213,7 +213,7 @@
     
     [self.subject fetchReferrersStatsForDate:[NSDate date]
                                      andUnit:StatsPeriodUnitDay
-                       withCompletionHandler:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                       withCompletionHandler:^(NSArray *items, NSString *totalViews, NSString *otherViews)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
          XCTAssertNotNil(totalViews, @"There should be a number provided.");
@@ -293,11 +293,11 @@
     
     [self.subject fetchReferrersStatsForDate:[NSDate date]
                                      andUnit:StatsPeriodUnitDay
-                       withCompletionHandler:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                       withCompletionHandler:^(NSArray *items, NSString *totalViews, NSString *otherViews)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
-         XCTAssertTrue([@2161 isEqualToNumber:totalViews]);
-         XCTAssertTrue([@938 isEqualToNumber:otherViews]);
+         XCTAssertTrue([@"2,161" isEqualToString:totalViews]);
+         XCTAssertTrue([@"938" isEqualToString:otherViews]);
          
          XCTAssertEqual(10, items.count);
          
@@ -380,7 +380,7 @@
     
     [self.subject fetchClicksStatsForDate:[NSDate date]
                                   andUnit:StatsPeriodUnitDay
-                    withCompletionHandler:^(NSArray *items, NSNumber *totalClicks, NSNumber *otherClicks)
+                    withCompletionHandler:^(NSArray *items, NSString *totalClicks, NSString *otherClicks)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
          XCTAssertNotNil(totalClicks, @"There should be a number provided.");
@@ -433,11 +433,11 @@
     
     [self.subject fetchClicksStatsForDate:[NSDate date]
                                   andUnit:StatsPeriodUnitMonth
-                    withCompletionHandler:^(NSArray *items, NSNumber *totalClicks, NSNumber *otherClicks)
+                    withCompletionHandler:^(NSArray *items, NSString *totalClicks, NSString *otherClicks)
      {
          XCTAssertNotNil(items);
-         XCTAssertTrue([@9 isEqualToNumber:totalClicks]);
-         XCTAssertTrue([@0 isEqualToNumber:otherClicks]);
+         XCTAssertTrue([@"9" isEqualToString:totalClicks]);
+         XCTAssertTrue([@"0" isEqualToString:otherClicks]);
          
          XCTAssertEqual(6, items.count);
          
@@ -494,7 +494,7 @@
     
     [self.subject fetchCountryStatsForDate:[NSDate date]
                                    andUnit:StatsPeriodUnitDay
-                     withCompletionHandler:^(NSArray *items, NSNumber *totalViews, NSNumber *otherViews)
+                     withCompletionHandler:^(NSArray *items, NSString *totalViews, NSString *otherViews)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
          XCTAssertNotNil(totalViews, @"There should be a number provided.");


### PR DESCRIPTION
Closes #76 

All numbers being displayed on the stats screens are now localized to the device locale settings.  This adds items like commas and periods when appropriate.  Updated the unit tests to account for the changes - all passed.
