### PR TITLE
Reload individual rows instead of an entire section for subsection

### DIFF
--- a/WordPressCom-Stats-iOS/StatsGroup.h
+++ b/WordPressCom-Stats-iOS/StatsGroup.h
@@ -3,7 +3,6 @@
 @interface StatsGroup : NSObject
 
 @property (nonatomic, strong)   NSArray *items; // StatsItem
-@property (nonatomic, assign)   BOOL moreItemsExist;
 @property (nonatomic, copy)     NSString *titlePrimary;
 @property (nonatomic, copy)     NSString *titleSecondary;
 @property (nonatomic, strong)   NSURL *iconUrl;


### PR DESCRIPTION
Closes #81 

Instead of reloading the entire section when the segmented control changes, only reload the title row and delete/insert the rest of the rows.  The "after" animation below was captured before the additional action of reloading the title row was completed.
## Before

![before](https://cloud.githubusercontent.com/assets/373903/5527634/d4496fc4-89c5-11e4-824e-de53a5be4c3d.gif)
## After

![after](https://cloud.githubusercontent.com/assets/373903/5527635/d44f07c2-89c5-11e4-923c-26159ab8f4b7.gif)
