### PR TITLE
Basic error handling

### DIFF
--- a/WordPressCom-Stats-iOS/StatsGroup.h
+++ b/WordPressCom-Stats-iOS/StatsGroup.h
@@ -11,6 +11,7 @@
 @property (nonatomic, copy)     NSString *totalCount;
 
 @property (nonatomic, assign, getter=isExpanded) BOOL expanded;
+@property (nonatomic, assign) BOOL errorWhileRetrieving;
 @property (nonatomic, readonly) NSUInteger numberOfRows;
 @property (nonatomic, assign) NSUInteger offsetRows;
 

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -400,7 +400,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     
     [self.statsService retrieveAllStatsForDates:@[self.selectedDate]
                                         andUnit:self.selectedPeriodUnit
-                    withVisitsCompletionHandler:^(StatsVisits *visits)
+                    withVisitsCompletionHandler:^(StatsVisits *visits, NSError *error)
      {
          if (skipGraph) {
              return;
@@ -423,7 +423,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
          NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(self.selectedSummaryType + 1) inSection:sectionNumber];
          [self.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
      }
-                        eventsCompletionHandler:^(StatsGroup *group)
+                        eventsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetWithoutGroupHeader;
          self.sectionData[@(StatsSectionEvents)] = group;
@@ -436,7 +436,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
          
          [self.tableView endUpdates];
      }
-                         postsCompletionHandler:^(StatsGroup *group)
+                         postsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
          self.sectionData[@(StatsSectionPosts)] = group;
@@ -449,7 +449,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
          
          [self.tableView endUpdates];
      }
-                     referrersCompletionHandler:^(StatsGroup *group)
+                     referrersCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
          self.sectionData[@(StatsSectionReferrers)] = group;
@@ -462,7 +462,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
          
          [self.tableView endUpdates];
      }
-                        clicksCompletionHandler:^(StatsGroup *group)
+                        clicksCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
          self.sectionData[@(StatsSectionClicks)] = group;
@@ -475,7 +475,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
          
          [self.tableView endUpdates];
      }
-                       countryCompletionHandler:^(StatsGroup *group)
+                       countryCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
          self.sectionData[@(StatsSectionCountry)] = group;
@@ -488,7 +488,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
          
          [self.tableView endUpdates];
      }
-                        videosCompletionHandler:^(StatsGroup *group)
+                        videosCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
          self.sectionData[@(StatsSectionVideos)] = group;
@@ -501,7 +501,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
          
          [self.tableView endUpdates];
      }
-                commentsAuthorCompletionHandler:^(StatsGroup *group)
+                commentsAuthorCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetWithGroupSelector;
          self.sectionData[@(StatsSectionComments)][@(StatsSubSectionCommentsByAuthor)] = group;
@@ -516,7 +516,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
              [self.tableView endUpdates];
          }
      }
-                commentsPostsCompletionHandler:^(StatsGroup *group)
+                commentsPostsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetWithGroupSelector;
          self.sectionData[@(StatsSectionComments)][@(StatsSubSectionCommentsByPosts)] = group;
@@ -531,7 +531,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
              [self.tableView endUpdates];
          }
      }
-                tagsCategoriesCompletionHandler:^(StatsGroup *group)
+                tagsCategoriesCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
          self.sectionData[@(StatsSectionTagsCategories)] = group;
@@ -544,7 +544,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
          
          [self.tableView endUpdates];
      }
-               followersDotComCompletionHandler:^(StatsGroup *group)
+               followersDotComCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetWithGroupSelectorAndTotal;
          self.sectionData[@(StatsSectionFollowers)][@(StatsSubSectionFollowersDotCom)] = group;
@@ -559,7 +559,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
              [self.tableView endUpdates];
          }
      }
-                followersEmailCompletionHandler:^(StatsGroup *group)
+                followersEmailCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetWithGroupSelectorAndTotal;
          self.sectionData[@(StatsSectionFollowers)][@(StatsSubSectionFollowersEmail)] = group;
@@ -574,7 +574,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
              [self.tableView endUpdates];
          }
      }
-                     publicizeCompletionHandler:^(StatsGroup *group)
+                     publicizeCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
          self.sectionData[@(StatsSectionPublicize)] = group;
@@ -591,10 +591,6 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
      {
          self.syncing = NO;
          [self.refreshControl endRefreshing];
-     }
-                          overallFailureHandler:^(NSError *error)
-     {
-         DDLogError(@"Error when syncing: %@", error);
      }];
 }
 

--- a/WordPressCom-Stats-iOS/StatsVisits.h
+++ b/WordPressCom-Stats-iOS/StatsVisits.h
@@ -10,4 +10,6 @@
 @property (nonatomic, strong) NSArray *statsData;
 @property (nonatomic, strong) NSDictionary *statsDataByDate;
 
+@property (nonatomic, assign) BOOL errorWhileRetrieving;
+
 @end

--- a/WordPressCom-Stats-iOS/WPStatsService.h
+++ b/WordPressCom-Stats-iOS/WPStatsService.h
@@ -3,9 +3,9 @@
 #import "StatsVisits.h"
 #import "StatsGroup.h"
 
-typedef void (^StatsSummaryCompletion)(StatsSummary *summary);
-typedef void (^StatsVisitsCompletion)(StatsVisits *visits);
-typedef void (^StatsItemsCompletion)(StatsGroup *group);
+typedef void (^StatsSummaryCompletion)(StatsSummary *summary, NSError *error);
+typedef void (^StatsVisitsCompletion)(StatsVisits *visits, NSError *error);
+typedef void (^StatsItemsCompletion)(StatsGroup *group, NSError *error);
 
 @class WPStatsServiceRemote;
 
@@ -30,8 +30,7 @@ typedef void (^StatsItemsCompletion)(StatsGroup *group);
 followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
  followersEmailCompletionHandler:(StatsItemsCompletion)followersEmailCompletion
       publicizeCompletionHandler:(StatsItemsCompletion)publicizeCompletion
-     andOverallCompletionHandler:(void (^)())completionHandler
-           overallFailureHandler:(void (^)(NSError *error))failureHandler;
+     andOverallCompletionHandler:(void (^)())completionHandler;
 
 - (void)retrieveTodayStatsWithCompletionHandler:(void (^)(StatsSummaryCompletion *))completion failureHandler:(void (^)(NSError *))failureHandler;
 

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -51,19 +51,10 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
  followersEmailCompletionHandler:(StatsItemsCompletion)followersEmailCompletion
       publicizeCompletionHandler:(StatsItemsCompletion)publicizeCompletion
      andOverallCompletionHandler:(void (^)())completionHandler
-           overallFailureHandler:(void (^)(NSError *error))failureHandler
 {
     if (!completionHandler) {
         return;
     }
-    
-    void (^failure)(NSError *error) = ^void (NSError *error) {
-        DDLogError(@"Error while retrieving stats: %@", error);
-
-        if (failureHandler) {
-            failureHandler(error);
-        }
-    };
     
     NSMutableArray *endDates = [NSMutableArray new];
     for (NSDate *date in dates) {
@@ -71,125 +62,133 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
         [endDates addObject:endDate];
     }
 
-    __block StatsVisits *visitsResult = nil;
     [self.remote batchFetchStatsForDates:endDates
                                  andUnit:unit
-             withVisitsCompletionHandler:^(StatsVisits *visits)
+             withVisitsCompletionHandler:^(StatsVisits *visits, NSError *error)
     {
-        visitsResult = visits;
-        
         if (visitsCompletion) {
-            visitsCompletion(visits);
+            visitsCompletion(visits, error);
         }
     }
-                 eventsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                 eventsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          StatsGroup *eventsResult = [StatsGroup new];
          eventsResult.items = items;
          eventsResult.moreItemsExist = moreViewsAvailable;
+         eventsResult.errorWhileRetrieving = error != nil;
          
          if (eventsCompletion) {
-             eventsCompletion(eventsResult);
+             eventsCompletion(eventsResult, error);
          }
      }
-                  postsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                  postsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          StatsGroup *postsResult = [StatsGroup new];
          postsResult.items = items;
          postsResult.titlePrimary = NSLocalizedString(@"Posts & Pages", @"Title for stats section for Posts & Pages");
          postsResult.moreItemsExist = moreViewsAvailable;
+         postsResult.errorWhileRetrieving = error != nil;
          
          if (postsCompletion) {
-             postsCompletion(postsResult);
+             postsCompletion(postsResult, error);
          }
      }
-              referrersCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+              referrersCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
     {
         StatsGroup *referrersResult = [StatsGroup new];
         referrersResult.items = items;
         referrersResult.moreItemsExist = moreViewsAvailable;
+        referrersResult.errorWhileRetrieving = error != nil;
         
         if (referrersCompletion) {
-            referrersCompletion(referrersResult);
+            referrersCompletion(referrersResult, error);
         }
     }
-                 clicksCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                 clicksCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
     {
         StatsGroup *clicksResult = [StatsGroup new];
         clicksResult.items = items;
         clicksResult.moreItemsExist = moreViewsAvailable;
+        clicksResult.errorWhileRetrieving = error != nil;
         
         if (clicksCompletion) {
-            clicksCompletion(clicksResult);
+            clicksCompletion(clicksResult, error);
         }
     }
-                countryCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                countryCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
     {
         StatsGroup *countriesResult = [StatsGroup new];
         countriesResult.items = items;
         countriesResult.moreItemsExist = moreViewsAvailable;
-        
+        countriesResult.errorWhileRetrieving = error != nil;
+
         if (countryCompletion) {
-            countryCompletion(countriesResult);
+            countryCompletion(countriesResult, error);
         }
     }
-                 videosCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                 videosCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
     {
         StatsGroup *videosResult = [StatsGroup new];
         videosResult.items = items;
         videosResult.moreItemsExist = moreViewsAvailable;
-        
+        videosResult.errorWhileRetrieving = error != nil;
+
         if (videosCompletion) {
-            videosCompletion(videosResult);
+            videosCompletion(videosResult, error);
         }
     }
-               commentsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+               commentsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
     {
         StatsGroup *commentsAuthorsResult = [StatsGroup new];
         commentsAuthorsResult.items = items.firstObject;
+        commentsAuthorsResult.errorWhileRetrieving = error != nil;
         StatsGroup *commentsPostsResult = [StatsGroup new];
         commentsPostsResult.items = items.lastObject;
+        commentsPostsResult.errorWhileRetrieving = error != nil;
         
         if (commentsAuthorsCompletion) {
-            commentsAuthorsCompletion(commentsAuthorsResult);
+            commentsAuthorsCompletion(commentsAuthorsResult, error);
         }
         
         if (commentsPostsResult) {
-            commentsPostsCompletion(commentsPostsResult);
+            commentsPostsCompletion(commentsPostsResult, error);
         }
     }
-         tagsCategoriesCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+         tagsCategoriesCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
     {
         StatsGroup *tagsCategoriesResult = [StatsGroup new];
         tagsCategoriesResult.items = items;
         tagsCategoriesResult.moreItemsExist = moreViewsAvailable;
-        
+        tagsCategoriesResult.errorWhileRetrieving = error != nil;
+
         if (tagsCategoriesCompletion) {
-            tagsCategoriesCompletion(tagsCategoriesResult);
+            tagsCategoriesCompletion(tagsCategoriesResult, error);
         }
     }
-        followersDotComCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+        followersDotComCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          StatsGroup *followersDotComResult = [StatsGroup new];
          followersDotComResult.items = items;
          followersDotComResult.moreItemsExist = moreViewsAvailable;
          followersDotComResult.totalCount = totalViews;
-         
+         followersDotComResult.errorWhileRetrieving = error != nil;
+
          for (StatsItem *item in items) {
              NSString *age = [self dateAgeForDate:item.date];
              item.value = age;
          }
          
          if (followersDotComCompletion) {
-             followersDotComCompletion(followersDotComResult);
+             followersDotComCompletion(followersDotComResult, error);
          }
      }
-         followersEmailCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+         followersEmailCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          StatsGroup *followersEmailResult = [StatsGroup new];
          followersEmailResult.items = items;
          followersEmailResult.moreItemsExist = moreViewsAvailable;
          followersEmailResult.totalCount = totalViews;
+         followersEmailResult.errorWhileRetrieving = error != nil;
 
          for (StatsItem *item in items) {
              NSString *age = [self dateAgeForDate:item.date];
@@ -197,24 +196,24 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
          }
          
          if (followersEmailCompletion) {
-             followersEmailCompletion(followersEmailResult);
+             followersEmailCompletion(followersEmailResult, error);
          }
      }
-              publicizeCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+              publicizeCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
     {
         StatsGroup *publicizeResult = [StatsGroup new];
         publicizeResult.items = items;
         publicizeResult.moreItemsExist = moreViewsAvailable;
-        
+        publicizeResult.errorWhileRetrieving = error != nil;
+
         if (publicizeCompletion) {
-            publicizeCompletion(publicizeResult);
+            publicizeCompletion(publicizeResult, nil);
         }
     }
              andOverallCompletionHandler:^
     {
         completionHandler();
-    }
-                   overallFailureHandler:failure];
+    }];
 }
 
 

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
@@ -2,9 +2,9 @@
 #import "StatsSummary.h"
 #import "StatsVisits.h"
 
-typedef void (^StatsRemoteSummaryCompletion)(StatsSummary *summary);
-typedef void (^StatsRemoteVisitsCompletion)(StatsVisits *visits);
-typedef void (^StatsRemoteItemsCompletion)(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable);
+typedef void (^StatsRemoteSummaryCompletion)(StatsSummary *summary, NSError *error);
+typedef void (^StatsRemoteVisitsCompletion)(StatsVisits *visits, NSError *error);
+typedef void (^StatsRemoteItemsCompletion)(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error);
 
 typedef NS_ENUM(NSUInteger, StatsFollowerType) {
     StatsFollowerTypeDotCom,
@@ -50,61 +50,49 @@ tagsCategoriesCompletionHandler:(StatsRemoteItemsCompletion)tagsCategoriesComple
 followersDotComCompletionHandler:(StatsRemoteItemsCompletion)followersDotComCompletion
 followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailCompletion
      publicizeCompletionHandler:(StatsRemoteItemsCompletion)publicizeCompletion
-    andOverallCompletionHandler:(void (^)())completionHandler
-          overallFailureHandler:(void (^)(NSError *error))failureHandler;
+    andOverallCompletionHandler:(void (^)())completionHandler;
 
 - (void)fetchSummaryStatsForDate:(NSDate *)date
-           withCompletionHandler:(StatsRemoteSummaryCompletion)completionHandler
-                  failureHandler:(void (^)(NSError *error))failureHandler;
+           withCompletionHandler:(StatsRemoteSummaryCompletion)completionHandler;
 
 - (void)fetchVisitsStatsForDate:(NSDate *)date
                         andUnit:(StatsPeriodUnit)unit
-          withCompletionHandler:(StatsRemoteVisitsCompletion)completionHandler
-                 failureHandler:(void (^)(NSError *error))failureHandler;
+          withCompletionHandler:(StatsRemoteVisitsCompletion)completionHandler;
 
 - (void)fetchPostsStatsForDate:(NSDate *)date
                        andUnit:(StatsPeriodUnit)unit
-         withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                failureHandler:(void (^)(NSError *error))failureHandler;
+         withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
 
 - (void)fetchReferrersStatsForDate:(NSDate *)date
                            andUnit:(StatsPeriodUnit)unit
-             withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                    failureHandler:(void (^)(NSError *error))failureHandler;
+             withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
 
 - (void)fetchClicksStatsForDate:(NSDate *)date
                         andUnit:(StatsPeriodUnit)unit
-          withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                 failureHandler:(void (^)(NSError *error))failureHandler;
+          withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
 
 - (void)fetchCountryStatsForDate:(NSDate *)date
                          andUnit:(StatsPeriodUnit)unit
-           withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                  failureHandler:(void (^)(NSError *error))failureHandler;
+           withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
 
 - (void)fetchVideosStatsForDate:(NSDate *)date
                         andUnit:(StatsPeriodUnit)unit
-          withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                 failureHandler:(void (^)(NSError *error))failureHandler;
+          withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
 
 - (void)fetchCommentsStatsForDate:(NSDate *)date
                           andUnit:(StatsPeriodUnit)unit
-            withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                   failureHandler:(void (^)(NSError *error))failureHandler;
+            withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
 
 - (void)fetchTagsCategoriesStatsForDate:(NSDate *)date
                                 andUnit:(StatsPeriodUnit)unit
-                  withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                         failureHandler:(void (^)(NSError *error))failureHandler;
+                  withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
 
 - (void)fetchFollowersStatsForFollowerType:(StatsFollowerType)followerType
                                       date:(NSDate *)date
                                    andUnit:(StatsPeriodUnit)unit
-                     withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                            failureHandler:(void (^)(NSError *error))failureHandler;
+                     withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
 
 - (void)fetchPublicizeStatsForDate:(NSDate *)date
                            andUnit:(StatsPeriodUnit)unit
-             withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                    failureHandler:(void (^)(NSError *error))failureHandler;
+             withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
 @end

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -7,7 +7,7 @@
 #import <NSObject+SafeExpectations.h>
 #import <NSString+XMLExtensions.h>
 
-static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.wordpress.com/rest/v1.1";
+static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.wordpress.com/rest/v1.2";
 
 @interface WPStatsServiceRemote ()
 
@@ -80,46 +80,45 @@ followersDotComCompletionHandler:(StatsRemoteItemsCompletion)followersDotComComp
 followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailCompletion
      publicizeCompletionHandler:(StatsRemoteItemsCompletion)publicizeCompletion
     andOverallCompletionHandler:(void (^)())completionHandler
-          overallFailureHandler:(void (^)(NSError *error))failureHandler
 {
     NSMutableArray *mutableOperations = [NSMutableArray new];
     
     for (NSDate *date in dates) {
         if (visitsCompletion) {
-            [mutableOperations addObject:[self operationForVisitsForDate:date andUnit:unit withCompletionHandler:visitsCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForVisitsForDate:date andUnit:unit withCompletionHandler:visitsCompletion]];
         }
         if (eventsCompletion) {
-            [mutableOperations addObject:[self operationForEventsForDate:date andUnit:unit withCompletionHandler:eventsCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForEventsForDate:date andUnit:unit withCompletionHandler:eventsCompletion]];
         }
         if (postsCompletion) {
-            [mutableOperations addObject:[self operationForPostsForDate:date andUnit:unit withCompletionHandler:postsCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForPostsForDate:date andUnit:unit withCompletionHandler:postsCompletion]];
         }
         if (referrersCompletion) {
-            [mutableOperations addObject:[self operationForReferrersForDate:date andUnit:unit withCompletionHandler:referrersCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForReferrersForDate:date andUnit:unit withCompletionHandler:referrersCompletion]];
         }
         if (clicksCompletion) {
-            [mutableOperations addObject:[self operationForClicksForDate:date andUnit:unit withCompletionHandler:clicksCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForClicksForDate:date andUnit:unit withCompletionHandler:clicksCompletion]];
         }
         if (countryCompletion) {
-            [mutableOperations addObject:[self operationForCountryForDate:date andUnit:unit withCompletionHandler:countryCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForCountryForDate:date andUnit:unit withCompletionHandler:countryCompletion]];
         }
         if (videosCompletion) {
-            [mutableOperations addObject:[self operationForVideosForDate:date andUnit:unit withCompletionHandler:videosCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForVideosForDate:date andUnit:unit withCompletionHandler:videosCompletion]];
         }
         if (commentsCompletion) {
-            [mutableOperations addObject:[self operationForCommentsForDate:date andUnit:unit withCompletionHandler:commentsCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForCommentsForDate:date andUnit:unit withCompletionHandler:commentsCompletion]];
         }
         if (tagsCategoriesCompletion) {
-            [mutableOperations addObject:[self operationForTagsCategoriesForDate:date andUnit:unit withCompletionHandler:tagsCategoriesCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForTagsCategoriesForDate:date andUnit:unit withCompletionHandler:tagsCategoriesCompletion]];
         }
         if (followersDotComCompletion) {
-            [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeDotCom forDate:date andUnit:unit withCompletionHandler:followersDotComCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeDotCom forDate:date andUnit:unit withCompletionHandler:followersDotComCompletion]];
         }
         if (followersEmailCompletion) {
-            [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeEmail forDate:date andUnit:unit withCompletionHandler:followersEmailCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeEmail forDate:date andUnit:unit withCompletionHandler:followersEmailCompletion]];
         }
         if (publicizeCompletion) {
-            [mutableOperations addObject:[self operationForPublicizeForDate:date andUnit:unit withCompletionHandler:publicizeCompletion failureHandler:nil]];
+            [mutableOperations addObject:[self operationForPublicizeForDate:date andUnit:unit withCompletionHandler:publicizeCompletion]];
         }
     }
     
@@ -136,9 +135,8 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 
 - (void)fetchSummaryStatsForDate:(NSDate *)date
            withCompletionHandler:(StatsRemoteSummaryCompletion)completionHandler
-                  failureHandler:(void (^)(NSError *error))failureHandler
 {
-    AFHTTPRequestOperation *operation = [self operationForSummaryForDate:date andUnit:StatsPeriodUnitDay withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForSummaryForDate:date andUnit:StatsPeriodUnitDay withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -146,10 +144,9 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (void)fetchVisitsStatsForDate:(NSDate *)date
                         andUnit:(StatsPeriodUnit)unit
           withCompletionHandler:(StatsRemoteVisitsCompletion)completionHandler
-                 failureHandler:(void (^)(NSError *error))failureHandler
 {
     
-    AFHTTPRequestOperation *operation = [self operationForVisitsForDate:date andUnit:unit withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForVisitsForDate:date andUnit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -157,11 +154,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (void)fetchEventsForDate:(NSDate *)date
                    andUnit:(StatsPeriodUnit)unit
      withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-            failureHandler:(void (^)(NSError *error))failureHandler
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForEventsForDate:date andUnit:unit withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForEventsForDate:date andUnit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -169,11 +165,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (void)fetchPostsStatsForDate:(NSDate *)date
                        andUnit:(StatsPeriodUnit)unit
          withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                failureHandler:(void (^)(NSError *error))failureHandler
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForPostsForDate:date andUnit:unit withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForPostsForDate:date andUnit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -181,11 +176,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (void)fetchReferrersStatsForDate:(NSDate *)date
                            andUnit:(StatsPeriodUnit)unit
              withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                    failureHandler:(void (^)(NSError *error))failureHandler
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForReferrersForDate:date andUnit:unit withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForReferrersForDate:date andUnit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -193,11 +187,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (void)fetchClicksStatsForDate:(NSDate *)date
                         andUnit:(StatsPeriodUnit)unit
           withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                 failureHandler:(void (^)(NSError *error))failureHandler
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForClicksForDate:date andUnit:unit withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForClicksForDate:date andUnit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -205,11 +198,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (void)fetchCountryStatsForDate:(NSDate *)date
                          andUnit:(StatsPeriodUnit)unit
            withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                  failureHandler:(void (^)(NSError *error))failureHandler
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForCountryForDate:date andUnit:unit withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForCountryForDate:date andUnit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -217,11 +209,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (void)fetchVideosStatsForDate:(NSDate *)date
                         andUnit:(StatsPeriodUnit)unit
           withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                 failureHandler:(void (^)(NSError *error))failureHandler
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForVideosForDate:date andUnit:unit withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForVideosForDate:date andUnit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -229,11 +220,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (void)fetchCommentsStatsForDate:(NSDate *)date
                           andUnit:(StatsPeriodUnit)unit
             withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                   failureHandler:(void (^)(NSError *error))failureHandler
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForCommentsForDate:date andUnit:unit withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForCommentsForDate:date andUnit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -241,11 +231,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (void)fetchTagsCategoriesStatsForDate:(NSDate *)date
                                 andUnit:(StatsPeriodUnit)unit
                   withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                         failureHandler:(void (^)(NSError *error))failureHandler
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForTagsCategoriesForDate:date andUnit:unit withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForTagsCategoriesForDate:date andUnit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -254,11 +243,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
                                       date:(NSDate *)date
                                    andUnit:(StatsPeriodUnit)unit
                      withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                            failureHandler:(void (^)(NSError *error))failureHandler
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForFollowersOfType:followerType forDate:date andUnit:unit withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForFollowersOfType:followerType forDate:date andUnit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -266,11 +254,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (void)fetchPublicizeStatsForDate:(NSDate *)date
                            andUnit:(StatsPeriodUnit)unit
              withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                    failureHandler:(void (^)(NSError *error))failureHandler
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForPublicizeForDate:date andUnit:unit withCompletionHandler:completionHandler failureHandler:failureHandler];
+    AFHTTPRequestOperation *operation = [self operationForPublicizeForDate:date andUnit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -281,7 +268,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForSummaryForDate:(NSDate *)date
                                                andUnit:(StatsPeriodUnit)unit
                                  withCompletionHandler:(StatsRemoteSummaryCompletion)completionHandler
-                                        failureHandler:(void (^)(NSError *error))failureHandler
 {
     
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
@@ -297,14 +283,18 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         statsSummary.comments = [self localizedStringForNumber:[statsSummaryDict numberForKey:@"comments"]];
         
         if (completionHandler) {
-            completionHandler(statsSummary);
+            completionHandler(statsSummary, nil);
         }
     };
     
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForSummary]
                                                                  parameters:nil
                                                                     success:handler
-                                                                    failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                    failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                                                                        if (completionHandler) {
+                                                                            completionHandler(nil, error);
+                                                                        }
+                                                                    }];
     return operation;
 }
 
@@ -312,7 +302,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForVisitsForDate:(NSDate *)date
                                               andUnit:(StatsPeriodUnit)unit
                                 withCompletionHandler:(StatsRemoteVisitsCompletion)completionHandler
-                                       failureHandler:(void (^)(NSError *error))failureHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -348,7 +337,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         statsVisits.statsDataByDate = dictionary;
         
         if (completionHandler) {
-            completionHandler(statsVisits);
+            completionHandler(statsVisits, nil);
         }
     };
     
@@ -361,7 +350,11 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForVisits]
                                                                  parameters:parameters
                                                                     success:handler
-                                                                    failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                    failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+                                                                        if (completionHandler) {
+                                                                            completionHandler(nil, error);
+                                                                        }
+                                                                    }];
     return operation;
 }
 
@@ -369,7 +362,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForEventsForDate:(NSDate *)date
                                               andUnit:(StatsPeriodUnit)unit
                                 withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                                       failureHandler:(void (^)(NSError *error))failureHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -390,7 +382,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         }
         
         if (completionHandler) {
-            completionHandler(items, nil, NO);
+            completionHandler(items, nil, NO, nil);
         }
     };
     
@@ -401,7 +393,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForPosts]
                                                                  parameters:parameters
                                                                     success:handler
-                                                                    failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                    failure:[self failureForCompletionHandler:handler]];
     return operation;
 }
 
@@ -409,7 +401,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForPostsForDate:(NSDate *)date
                                              andUnit:(StatsPeriodUnit)unit
                                withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                                      failureHandler:(void (^)(NSError *error))failureHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -439,7 +430,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         
         
         if (completionHandler) {
-            completionHandler(items, totalViews, moreViewsAvailable);
+            completionHandler(items, totalViews, moreViewsAvailable, nil);
         }
     };
     
@@ -448,7 +439,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForTopPosts]
                                                                  parameters:parameters
                                                                     success:handler
-                                                                    failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                    failure:[self failureForCompletionHandler:handler]];
     return operation;
 }
 
@@ -456,7 +447,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForReferrersForDate:(NSDate *)date
                                                  andUnit:(StatsPeriodUnit)unit
                                    withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                                          failureHandler:(void (^)(NSError *error))failureHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -526,7 +516,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         
         
         if (completionHandler) {
-            completionHandler(items, totalViews, moreViewsAvailable);
+            completionHandler(items, totalViews, moreViewsAvailable, nil);
         }
     };
     
@@ -536,7 +526,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForReferrers]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                   failure:[self failureForCompletionHandler:handler]];
     
     return operation;
 }
@@ -545,7 +535,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForClicksForDate:(NSDate *)date
                                               andUnit:(StatsPeriodUnit)unit
                                 withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                                       failureHandler:(void (^)(NSError *error))failureHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -595,7 +584,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         
         
         if (completionHandler) {
-            completionHandler(items, totalClicks, moreClicksAvailable);
+            completionHandler(items, totalClicks, moreClicksAvailable, nil);
         }
     };
     
@@ -605,7 +594,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForClicks]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                   failure:[self failureForCompletionHandler:handler]];
     return operation;
 }
 
@@ -613,7 +602,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForCountryForDate:(NSDate *)date
                                                andUnit:(StatsPeriodUnit)unit
                                  withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                                        failureHandler:(void (^)(NSError *error))failureHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -638,7 +626,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         }
         
         if (completionHandler) {
-            completionHandler(items, totalViews, moreViewsAvailable);
+            completionHandler(items, totalViews, moreViewsAvailable, nil);
         }
     };
     
@@ -648,7 +636,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForCountryViews]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                   failure:[self failureForCompletionHandler:handler]];
 
     return operation;
 }
@@ -657,7 +645,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForVideosForDate:(NSDate *)date
                                               andUnit:(StatsPeriodUnit)unit
                                 withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                                       failureHandler:(void (^)(NSError *error))failureHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -688,7 +675,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         }
         
         if (completionHandler) {
-            completionHandler(items, totalPlays, morePlaysAvailable);
+            completionHandler(items, totalPlays, morePlaysAvailable, nil);
         }
     };
     
@@ -698,7 +685,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForVideos]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                   failure:[self failureForCompletionHandler:handler]];
     
     return operation;
 }
@@ -707,7 +694,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForCommentsForDate:(NSDate *)date
                                                 andUnit:(StatsPeriodUnit)unit
                                   withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                                         failureHandler:(void (^)(NSError *error))failureHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -746,7 +732,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         
         if (completionHandler) {
             // More not available with comments
-            completionHandler(@[authorItems, postsItems], nil, false);
+            completionHandler(@[authorItems, postsItems], nil, false, nil);
         }
     };
     
@@ -756,7 +742,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForComments]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                   failure:[self failureForCompletionHandler:handler]];
     
     return operation;
 }
@@ -765,7 +751,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForTagsCategoriesForDate:(NSDate *)date
                                                       andUnit:(StatsPeriodUnit)unit
                                         withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                                               failureHandler:(void (^)(NSError *error))failureHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -806,7 +791,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         
         if (completionHandler) {
             // More not available with tags
-            completionHandler(items, nil, false);
+            completionHandler(items, nil, false, nil);
         }
     };
     
@@ -816,7 +801,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForTagsCategories]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                   failure:[self failureForCompletionHandler:handler]];
     return operation;}
 
 
@@ -824,7 +809,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
                                                 forDate:(NSDate *)date
                                                 andUnit:(StatsPeriodUnit)unit
                                   withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                                         failureHandler:(void (^)(NSError *error))failureHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -850,7 +834,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         }
         
         if (completionHandler) {
-            completionHandler(items, totalFollowers, moreFollowersAvailable);
+            completionHandler(items, totalFollowers, moreFollowersAvailable, nil);
         }
     };
     
@@ -862,7 +846,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForFollowers]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                   failure:[self failureForCompletionHandler:handler]];
     
     return operation;
 }
@@ -871,7 +855,6 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForPublicizeForDate:(NSDate *)date
                                                  andUnit:(StatsPeriodUnit)unit
                                    withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
-                                          failureHandler:(void (^)(NSError *error))failureHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -914,7 +897,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         
         if (completionHandler) {
             // More not available with publicize
-            completionHandler(items, nil, false);
+            completionHandler(items, nil, false, nil);
         }
     };
     
@@ -924,7 +907,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForPublicize]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForFailureCompletionHandler:failureHandler]];
+                                                                   failure:[self failureForCompletionHandler:handler]];
     
     return operation;
 }
@@ -949,14 +932,12 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 }
 
 
-- (void(^)(AFHTTPRequestOperation *operation, NSError *error))failureForFailureCompletionHandler:(void (^)(NSError *error))failureHandler
+- (void(^)(AFHTTPRequestOperation *operation, NSError *error))failureForCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
 {
     return ^(AFHTTPRequestOperation *operation, NSError *error)
     {
-        DDLogError(@"Error with today summary stats: %@", error);
-        
-        if (failureHandler) {
-            failureHandler(error);
+        if (completionHandler) {
+            completionHandler(nil, nil, false, error);
         }
     };
 }

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -7,7 +7,7 @@
 #import <NSObject+SafeExpectations.h>
 #import <NSString+XMLExtensions.h>
 
-static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.wordpress.com/rest/v1.2";
+static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.wordpress.com/rest/v1.1";
 
 @interface WPStatsServiceRemote ()
 
@@ -352,7 +352,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
                                                                     success:handler
                                                                     failure:^(AFHTTPRequestOperation *operation, NSError *error) {
                                                                         if (completionHandler) {
-                                                                            completionHandler(nil, error);
+                                                                            StatsVisits *visits = [StatsVisits new];
+                                                                            visits.errorWhileRetrieving = YES;
+                                                                            
+                                                                            completionHandler(visits, error);
                                                                         }
                                                                     }];
     return operation;
@@ -393,7 +396,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForPosts]
                                                                  parameters:parameters
                                                                     success:handler
-                                                                    failure:[self failureForCompletionHandler:handler]];
+                                                                    failure:[self failureForCompletionHandler:completionHandler]];
     return operation;
 }
 
@@ -439,7 +442,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForTopPosts]
                                                                  parameters:parameters
                                                                     success:handler
-                                                                    failure:[self failureForCompletionHandler:handler]];
+                                                                    failure:[self failureForCompletionHandler:completionHandler]];
     return operation;
 }
 
@@ -526,7 +529,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForReferrers]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForCompletionHandler:handler]];
+                                                                   failure:[self failureForCompletionHandler:completionHandler]];
     
     return operation;
 }
@@ -594,7 +597,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForClicks]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForCompletionHandler:handler]];
+                                                                   failure:[self failureForCompletionHandler:completionHandler]];
     return operation;
 }
 
@@ -636,7 +639,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForCountryViews]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForCompletionHandler:handler]];
+                                                                   failure:[self failureForCompletionHandler:completionHandler]];
 
     return operation;
 }
@@ -685,7 +688,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForVideos]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForCompletionHandler:handler]];
+                                                                   failure:[self failureForCompletionHandler:completionHandler]];
     
     return operation;
 }
@@ -742,7 +745,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForComments]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForCompletionHandler:handler]];
+                                                                   failure:[self failureForCompletionHandler:completionHandler]];
     
     return operation;
 }
@@ -801,7 +804,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForTagsCategories]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForCompletionHandler:handler]];
+                                                                   failure:[self failureForCompletionHandler:completionHandler]];
     return operation;}
 
 
@@ -846,7 +849,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForFollowers]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForCompletionHandler:handler]];
+                                                                   failure:[self failureForCompletionHandler:completionHandler]];
     
     return operation;
 }
@@ -907,7 +910,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForPublicize]
                                                                 parameters:parameters
                                                                    success:handler
-                                                                   failure:[self failureForCompletionHandler:handler]];
+                                                                   failure:[self failureForCompletionHandler:completionHandler]];
     
     return operation;
 }

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
@@ -36,18 +36,16 @@
         return [OHHTTPStubsResponse responseWithFileAtPath:OHPathForFileInBundle(@"stats-v1.1-summary.json", nil) statusCode:200 headers:@{@"Content-Type" : @"application/json"}];
     }];
     
-    [self.subject fetchSummaryStatsForDate:[NSDate date] withCompletionHandler:^(StatsSummary *summary) {
+    [self.subject fetchSummaryStatsForDate:[NSDate date] withCompletionHandler:^(StatsSummary *summary, NSError *error) {
         XCTAssertNotNil(summary, @"summary should not be nil.");
         XCTAssertNotNil(summary.date);
+        XCTAssertNil(error);
         XCTAssertTrue(summary.periodUnit == StatsPeriodUnitDay);
         XCTAssertTrue([summary.views isEqualToString:@"56"]);
         XCTAssertTrue([summary.visitors isEqualToString:@"44"]);
         XCTAssertTrue([summary.likes isEqualToString:@"1"]);
         XCTAssertTrue([summary.comments isEqualToString:@"3"]);
         
-        [expectation fulfill];
-    } failureHandler:^(NSError *error) {
-        XCTFail(@"Failure handler should not be called here.");
         [expectation fulfill];
     }];
     
@@ -66,12 +64,14 @@
     
     [self.subject fetchVisitsStatsForDate:[NSDate date]
                                   andUnit:StatsPeriodUnitDay
-                    withCompletionHandler:^(StatsVisits *visits)
+                    withCompletionHandler:^(StatsVisits *visits, NSError *error)
      {
          XCTAssertNotNil(visits, @"visits should not be nil.");
          XCTAssertNotNil(visits.date);
          XCTAssertEqual(30, visits.statsData.count);
          XCTAssertEqual(StatsPeriodUnitDay, visits.unit);
+         XCTAssertFalse(visits.errorWhileRetrieving);
+         XCTAssertNil(error);
          
          StatsSummary *firstSummary = visits.statsData[0];
          XCTAssertNotNil(firstSummary.date);
@@ -80,9 +80,6 @@
          XCTAssertTrue([firstSummary.likes isEqualToString:@"1"]);
          XCTAssertTrue([firstSummary.comments isEqualToString:@"3"]);
          
-         [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
          [expectation fulfill];
      }];
     
@@ -102,13 +99,15 @@
     
     [self.subject fetchVisitsStatsForDate:[NSDate date]
                                   andUnit:StatsPeriodUnitDay
-                    withCompletionHandler:^(StatsVisits *visits)
+                    withCompletionHandler:^(StatsVisits *visits, NSError *error)
      {
          XCTAssertNotNil(visits, @"visits should not be nil.");
          XCTAssertNotNil(visits.date);
          XCTAssertEqual(30, visits.statsData.count);
          XCTAssertEqual(StatsPeriodUnitDay, visits.unit);
-         
+         XCTAssertFalse(visits.errorWhileRetrieving);
+         XCTAssertNil(error);
+
          StatsSummary *firstSummary = visits.statsData[0];
          XCTAssertNotNil(firstSummary.date);
          XCTAssertTrue([firstSummary.views isEqualToString:@"7,808"]);
@@ -116,9 +115,6 @@
          XCTAssertTrue([firstSummary.likes isEqualToString:@"0"]);
          XCTAssertTrue([firstSummary.comments isEqualToString:@"0"]);
          
-         [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
          [expectation fulfill];
      }];
     
@@ -137,10 +133,11 @@
     
     [self.subject fetchPostsStatsForDate:[NSDate date]
                                  andUnit:StatsPeriodUnitDay
-                   withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                   withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
          XCTAssertNotNil(totalViews, @"There should be a number provided.");
+         XCTAssertNil(error);
          
          XCTAssertEqual(10, items.count);
          
@@ -154,9 +151,6 @@
          XCTAssertTrue(action.defaultAction);
          XCTAssertTrue([action.url.absoluteString isEqualToString:@"http://astralbodi.es/2014/08/06/asynchronous-unit-testing-core-data-with-xcode-6/"]);
          
-         [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
          [expectation fulfill];
      }];
     
@@ -175,11 +169,12 @@
     
     [self.subject fetchPostsStatsForDate:[NSDate date]
                                  andUnit:StatsPeriodUnitDay
-                   withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                   withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
          XCTAssertNotNil(totalViews, @"There should be a number provided.");
-         
+         XCTAssertNil(error);
+
          XCTAssertEqual(10, items.count);
          
          StatsItem *item = items[0];
@@ -192,9 +187,6 @@
          XCTAssertTrue(action.defaultAction);
          XCTAssertTrue([action.url.absoluteString isEqualToString:@"http://automattic.com/home/"]);
          
-         [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
          [expectation fulfill];
      }];
     
@@ -213,11 +205,12 @@
     
     [self.subject fetchReferrersStatsForDate:[NSDate date]
                                      andUnit:StatsPeriodUnitDay
-                       withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                       withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
          XCTAssertNotNil(totalViews, @"There should be a number provided.");
          XCTAssertFalse(moreViewsAvailable);
+         XCTAssertNil(error);
          
          XCTAssertEqual(4, items.count);
          
@@ -272,9 +265,6 @@
          XCTAssertTrue(flipBoardItemAction.defaultAction);
          
          [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
-         [expectation fulfill];
      }];
     
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
@@ -293,11 +283,12 @@
     
     [self.subject fetchReferrersStatsForDate:[NSDate date]
                                      andUnit:StatsPeriodUnitDay
-                       withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                       withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
          XCTAssertTrue([@"2,161" isEqualToString:totalViews]);
          XCTAssertTrue(moreViewsAvailable);
+         XCTAssertNil(error);
          
          XCTAssertEqual(10, items.count);
          
@@ -359,9 +350,6 @@
          XCTAssertTrue(mattRootItemAction.defaultAction);
          
          [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
-         [expectation fulfill];
      }];
     
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
@@ -380,12 +368,13 @@
     
     [self.subject fetchClicksStatsForDate:[NSDate date]
                                   andUnit:StatsPeriodUnitDay
-                    withCompletionHandler:^(NSArray *items, NSString *totalClicks, BOOL moreViewsAvailable)
+                    withCompletionHandler:^(NSArray *items, NSString *totalClicks, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
          XCTAssertNotNil(totalClicks, @"There should be a number provided.");
          XCTAssertFalse(moreViewsAvailable);
-         
+         XCTAssertNil(error);
+        
          XCTAssertEqual(2, items.count);
          
          StatsItem *statsItem1 = items[0];
@@ -413,9 +402,6 @@
          XCTAssertNil(statsItemAction2.iconURL);
          
          [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
-         [expectation fulfill];
      }];
     
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
@@ -433,11 +419,12 @@
     
     [self.subject fetchClicksStatsForDate:[NSDate date]
                                   andUnit:StatsPeriodUnitMonth
-                    withCompletionHandler:^(NSArray *items, NSString *totalClicks, BOOL moreViewsAvailable)
+                    withCompletionHandler:^(NSArray *items, NSString *totalClicks, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items);
          XCTAssertTrue([@"9" isEqualToString:totalClicks]);
          XCTAssertFalse(moreViewsAvailable);
+         XCTAssertNil(error);
          
          XCTAssertEqual(6, items.count);
          
@@ -474,9 +461,6 @@
          XCTAssertNil(statsItemAction2.iconURL);
          
          [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
-         [expectation fulfill];
      }];
     
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
@@ -494,11 +478,12 @@
     
     [self.subject fetchCountryStatsForDate:[NSDate date]
                                    andUnit:StatsPeriodUnitDay
-                     withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                     withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items, @"Posts should not be nil.");
          XCTAssertNotNil(totalViews, @"There should be a number provided.");
          XCTAssertTrue(moreViewsAvailable);
+         XCTAssertNil(error);
          
          XCTAssertEqual(12, items.count);
          
@@ -510,9 +495,6 @@
          XCTAssertEqual(0, item.actions.count);
          XCTAssertEqual(0, item.children.count);
          
-         [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
          [expectation fulfill];
      }];
     
@@ -531,12 +513,13 @@
     
     [self.subject fetchVideosStatsForDate:[NSDate date]
                                   andUnit:StatsPeriodUnitDay
-                    withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                    withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items);
          XCTAssertTrue([totalViews isEqualToString:@"2"]);
          XCTAssertFalse(moreViewsAvailable);
-         
+         XCTAssertNil(error);
+
          XCTAssertEqual(1, items.count);
          
          StatsItem *item = items.firstObject;
@@ -547,9 +530,6 @@
          StatsItemAction *itemAction = item.actions.firstObject;
          XCTAssertTrue([itemAction.url.absoluteString isEqualToString:@"http://maplebaconyummies.wordpress.com/wp-admin/media.php?action=edit&attachment_id=144"]);
          
-         [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
          [expectation fulfill];
      }];
     
@@ -568,17 +548,15 @@
     
     [self.subject fetchVideosStatsForDate:[NSDate date]
                                   andUnit:StatsPeriodUnitDay
-                    withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                    withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items);
          XCTAssertTrue([totalViews isEqualToString:@"0"]);
          XCTAssertFalse(moreViewsAvailable);
-         
+         XCTAssertNil(error);
+
          XCTAssertEqual(0, items.count);
 
-         [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
          [expectation fulfill];
      }];
     
@@ -597,12 +575,13 @@
     
     [self.subject fetchCommentsStatsForDate:[NSDate date]
                                     andUnit:StatsPeriodUnitDay
-                      withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                      withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items);
          XCTAssertNil(totalViews);
          XCTAssertFalse(moreViewsAvailable);
-         
+         XCTAssertNil(error);
+
          XCTAssertEqual(2, items.count);
          NSArray *authorItems = items.firstObject;
          NSArray *postItems = items.lastObject;
@@ -625,9 +604,6 @@
          XCTAssertTrue(post1Action.defaultAction);
          
          [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
-         [expectation fulfill];
      }];
     
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
@@ -645,12 +621,13 @@
     
     [self.subject fetchTagsCategoriesStatsForDate:[NSDate date]
                                           andUnit:StatsPeriodUnitDay
-                            withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                            withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items);
          XCTAssertNil(totalViews);
          XCTAssertFalse(moreViewsAvailable);
-         
+         XCTAssertNil(error);
+
          XCTAssertEqual(10, items.count);
          
          StatsItem *item1 = items.firstObject;
@@ -665,9 +642,6 @@
          XCTAssertEqual(0, item9.actions.count);
          XCTAssertEqual(4, item9.children.count);
          
-         [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
          [expectation fulfill];
      }];
     
@@ -687,12 +661,13 @@
     [self.subject fetchFollowersStatsForFollowerType:StatsFollowerTypeDotCom
                                                 date:[NSDate date]
                                              andUnit:StatsPeriodUnitDay
-                               withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                               withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items);
          XCTAssertTrue([@"7,925,800" isEqualToString:totalViews]);
          XCTAssertTrue(moreViewsAvailable);
-         
+         XCTAssertNil(error);
+
          XCTAssertEqual(7, items.count);
          
          StatsItem *item1 = items.firstObject;
@@ -703,9 +678,6 @@
          XCTAssertEqual(0, item1.actions.count);
          XCTAssertEqual(0, item1.children.count);
          
-         [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
          [expectation fulfill];
      }];
     
@@ -725,12 +697,13 @@
     [self.subject fetchFollowersStatsForFollowerType:StatsFollowerTypeEmail
                                                 date:[NSDate date]
                                              andUnit:StatsPeriodUnitDay
-                               withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                               withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
      {
          XCTAssertNotNil(items);
          XCTAssertTrue([@"2,931" isEqualToString:totalViews]);
          XCTAssertTrue(moreViewsAvailable);
-         
+         XCTAssertNil(error);
+
          XCTAssertEqual(7, items.count);
          
          StatsItem *item1 = items.firstObject;
@@ -742,9 +715,6 @@
          XCTAssertEqual(0, item1.children.count);
          
          [expectation fulfill];
-     } failureHandler:^(NSError *error) {
-         XCTFail(@"Failure handler should not be called here.");
-         [expectation fulfill];
      }];
     
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
@@ -753,7 +723,7 @@
 
 - (void)testPublicizeDay
 {
-    
+    // TODO
 }
 
 @end

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
@@ -50,51 +50,48 @@
     
     [self.subject retrieveAllStatsForDates:@[[NSDate date]]
                                    andUnit:StatsPeriodUnitDay
-               withVisitsCompletionHandler:^(StatsVisits *visits) {
+               withVisitsCompletionHandler:^(StatsVisits *visits, NSError *error) {
                    [visitsExpectation fulfill];
                }
-                   eventsCompletionHandler:^(StatsGroup *group) {
+                   eventsCompletionHandler:^(StatsGroup *group, NSError *error) {
                         [eventsExpectation fulfill];
                     }
-                    postsCompletionHandler:^(StatsGroup *group) {
+                    postsCompletionHandler:^(StatsGroup *group, NSError *error) {
                         [postsExpectation fulfill];
                     }
-                referrersCompletionHandler:^(StatsGroup *group) {
+                referrersCompletionHandler:^(StatsGroup *group, NSError *error) {
                     [referrersExpectation fulfill];
                 }
-                   clicksCompletionHandler:^(StatsGroup *group) {
+                   clicksCompletionHandler:^(StatsGroup *group, NSError *error) {
                        [clicksExpectation fulfill];
                 }
-                  countryCompletionHandler:^(StatsGroup *group) {
+                  countryCompletionHandler:^(StatsGroup *group, NSError *error) {
                       [countryExpectation fulfill];
                 }
-                   videosCompletionHandler:^(StatsGroup *group) {
+                   videosCompletionHandler:^(StatsGroup *group, NSError *error) {
                        [videosExpectation fulfill];
                 }
-           commentsAuthorCompletionHandler:^(StatsGroup *group) {
+           commentsAuthorCompletionHandler:^(StatsGroup *group, NSError *error) {
                [commentsAuthorExpectation fulfill];
            }
-            commentsPostsCompletionHandler:^(StatsGroup *group) {
+            commentsPostsCompletionHandler:^(StatsGroup *group, NSError *error) {
                 [commentsPostsExpectation fulfill];
             }
-           tagsCategoriesCompletionHandler:^(StatsGroup *group) {
+           tagsCategoriesCompletionHandler:^(StatsGroup *group, NSError *error) {
                [tagsExpectation fulfill];
            }
-          followersDotComCompletionHandler:^(StatsGroup *group) {
+          followersDotComCompletionHandler:^(StatsGroup *group, NSError *error) {
               [followersDotComExpectation fulfill];
           }
-           followersEmailCompletionHandler:^(StatsGroup *group) {
+           followersEmailCompletionHandler:^(StatsGroup *group, NSError *error) {
                [followersEmailExpectation fulfill];
            }
-                publicizeCompletionHandler:^(StatsGroup *group) {
+                publicizeCompletionHandler:^(StatsGroup *group, NSError *error) {
                     [publicizeExpectation fulfill];
                 }
                andOverallCompletionHandler:^{
                    [overallExpectation fulfill];
-               }
-                     overallFailureHandler:^(NSError *error) {
-                         XCTFail(@"Failure is not an option.");
-                     }];
+               }];
     
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
@@ -308,8 +305,7 @@
              followersDotComCompletionHandler:[OCMArg any]
               followersEmailCompletionHandler:[OCMArg any]
                    publicizeCompletionHandler:[OCMArg any]
-                  andOverallCompletionHandler:[OCMArg any]
-                        overallFailureHandler:[OCMArg any]]);
+                  andOverallCompletionHandler:[OCMArg any]]);
     
     self.subject.remote = remote;
     
@@ -330,8 +326,7 @@
                 publicizeCompletionHandler:nil
                andOverallCompletionHandler:^{
                    // Don't do anything
-               }
-                     overallFailureHandler:nil];
+               }];
     
     OCMVerifyAll((id)remote);
 }
@@ -356,45 +351,44 @@ followersDotComCompletionHandler:(StatsRemoteItemsCompletion)followersDotComComp
 followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailCompletion
      publicizeCompletionHandler:(StatsRemoteItemsCompletion)publicizeCompletion
     andOverallCompletionHandler:(void (^)())completionHandler
-          overallFailureHandler:(void (^)(NSError *))failureHandler
 {
     NSInteger count = dates.count;
     for (NSInteger x = 0; x < count; ++x) {
         if (visitsCompletion) {
-            visitsCompletion([StatsVisits new]);
+            visitsCompletion([StatsVisits new], nil);
         }
         if (eventsCompletion) {
-            eventsCompletion(@[[StatsItem new]], nil, false);
+            eventsCompletion(@[[StatsItem new]], nil, false, nil);
         }
         if (postsCompletion) {
-            postsCompletion(@[[StatsItem new]], nil, false);
+            postsCompletion(@[[StatsItem new]], nil, false, nil);
         }
         if (referrersCompletion) {
-            referrersCompletion(@[[StatsItem new]], nil, false);
+            referrersCompletion(@[[StatsItem new]], nil, false, nil);
         }
         if (clicksCompletion) {
-            clicksCompletion(@[[StatsItem new]], nil, false);
+            clicksCompletion(@[[StatsItem new]], nil, false, nil);
         }
         if (countryCompletion) {
-            countryCompletion(@[[StatsItem new]], nil, false);
+            countryCompletion(@[[StatsItem new]], nil, false, nil);
         }
         if (videosCompletion) {
-            videosCompletion(@[[StatsItem new]], nil, false);
+            videosCompletion(@[[StatsItem new]], nil, false, nil);
         }
         if (commentsCompletion) {
-            commentsCompletion(@[[StatsItem new]], nil, false);
+            commentsCompletion(@[[StatsItem new]], nil, false, nil);
         }
         if (tagsCategoriesCompletion) {
-            tagsCategoriesCompletion(@[[StatsItem new]], nil, false);
+            tagsCategoriesCompletion(@[[StatsItem new]], nil, false, nil);
         }
         if (followersDotComCompletion) {
-            followersDotComCompletion(@[[StatsItem new]], nil, false);
+            followersDotComCompletion(@[[StatsItem new]], nil, false, nil);
         }
         if (followersEmailCompletion) {
-            followersEmailCompletion(@[[StatsItem new]], nil, false);
+            followersEmailCompletion(@[[StatsItem new]], nil, false, nil);
         }
         if (publicizeCompletion) {
-            publicizeCompletion(@[[StatsItem new]], nil, false);
+            publicizeCompletion(@[[StatsItem new]], nil, false, nil);
         }
     }
     


### PR DESCRIPTION
Closes #72 

Implements basic error handling on a per-section basis. If an error occurs fetching a particular section, show that there was an error. The original issue indicated having some sort of automatic retry mechanism but I think that's out of scope for this first release. Users can pull to refresh to retry.