### PR TITLE
Basic caching with time-based expiration

### DIFF
--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		933FF2261A40C7FD00336167 /* stats-v1.1-comments-day.json in Resources */ = {isa = PBXBuildFile; fileRef = 933FF2251A40C7FD00336167 /* stats-v1.1-comments-day.json */; };
 		933FF2281A41C64300336167 /* WPStatsServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 933FF2271A41C64300336167 /* WPStatsServiceTests.m */; };
 		9340980D1A5C83A00005DF06 /* StatsEphemory.m in Sources */ = {isa = PBXBuildFile; fileRef = 9340980C1A5C83A00005DF06 /* StatsEphemory.m */; };
+		9340980F1A5D75AC0005DF06 /* StatsEphemoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9340980E1A5D75AC0005DF06 /* StatsEphemoryTests.m */; };
 		9358D15B19FFFB740094BBF5 /* WPStatsServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9358D15A19FFFB740094BBF5 /* WPStatsServiceRemoteTests.m */; };
 		93652B7F19FFFC60006A4C47 /* stats-v1.1-summary.json in Resources */ = {isa = PBXBuildFile; fileRef = 93652B7E19FFFC60006A4C47 /* stats-v1.1-summary.json */; };
 		936B22481958C3840058C828 /* WPStatsGraphViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B22471958C3840058C828 /* WPStatsGraphViewController.m */; };
@@ -113,6 +114,7 @@
 		933FF2271A41C64300336167 /* WPStatsServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPStatsServiceTests.m; sourceTree = "<group>"; };
 		9340980B1A5C83A00005DF06 /* StatsEphemory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsEphemory.h; sourceTree = "<group>"; };
 		9340980C1A5C83A00005DF06 /* StatsEphemory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsEphemory.m; sourceTree = "<group>"; };
+		9340980E1A5D75AC0005DF06 /* StatsEphemoryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsEphemoryTests.m; sourceTree = "<group>"; };
 		9358D15A19FFFB740094BBF5 /* WPStatsServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPStatsServiceRemoteTests.m; sourceTree = "<group>"; };
 		93652B7E19FFFC60006A4C47 /* stats-v1.1-summary.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-v1.1-summary.json"; sourceTree = "<group>"; };
 		936B22461958C3840058C828 /* WPStatsGraphViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPStatsGraphViewController.h; sourceTree = "<group>"; };
@@ -262,6 +264,7 @@
 				9383180E1994F701003B953A /* WordPressCom-Stats-iOSTests-Bridging-Header.h */,
 				9358D15A19FFFB740094BBF5 /* WPStatsServiceRemoteTests.m */,
 				933FF2271A41C64300336167 /* WPStatsServiceTests.m */,
+				9340980E1A5D75AC0005DF06 /* StatsEphemoryTests.m */,
 			);
 			path = "WordPressCom-Stats-iOSTests";
 			sourceTree = "<group>";
@@ -295,12 +298,12 @@
 		9396CFD91921534E006A66D7 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				9340980B1A5C83A00005DF06 /* StatsEphemory.h */,
+				9340980C1A5C83A00005DF06 /* StatsEphemory.m */,
 				93302C501A1BD77900B49CFC /* WPStatsService.h */,
 				93302C511A1BD78300B49CFC /* WPStatsService.m */,
 				93A379E819FEDEE100415023 /* WPStatsServiceRemote.h */,
 				93A379E919FEDEE100415023 /* WPStatsServiceRemote.m */,
-				9340980B1A5C83A00005DF06 /* StatsEphemory.h */,
-				9340980C1A5C83A00005DF06 /* StatsEphemory.m */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -543,6 +546,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				933FF2281A41C64300336167 /* WPStatsServiceTests.m in Sources */,
+				9340980F1A5D75AC0005DF06 /* StatsEphemoryTests.m in Sources */,
 				9358D15B19FFFB740094BBF5 /* WPStatsServiceRemoteTests.m in Sources */,
 				9327FD2E1A4A058600FF3A2E /* StatsGroupTests.m in Sources */,
 				9327FD2C1A4A001100FF3A2E /* StatsItemTests.m in Sources */,

--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		933FF2241A4085C300336167 /* stats-v1.1-followers-email-day.json in Resources */ = {isa = PBXBuildFile; fileRef = 933FF2231A4085C300336167 /* stats-v1.1-followers-email-day.json */; };
 		933FF2261A40C7FD00336167 /* stats-v1.1-comments-day.json in Resources */ = {isa = PBXBuildFile; fileRef = 933FF2251A40C7FD00336167 /* stats-v1.1-comments-day.json */; };
 		933FF2281A41C64300336167 /* WPStatsServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 933FF2271A41C64300336167 /* WPStatsServiceTests.m */; };
+		9340980D1A5C83A00005DF06 /* StatsEphemory.m in Sources */ = {isa = PBXBuildFile; fileRef = 9340980C1A5C83A00005DF06 /* StatsEphemory.m */; };
 		9358D15B19FFFB740094BBF5 /* WPStatsServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9358D15A19FFFB740094BBF5 /* WPStatsServiceRemoteTests.m */; };
 		93652B7F19FFFC60006A4C47 /* stats-v1.1-summary.json in Resources */ = {isa = PBXBuildFile; fileRef = 93652B7E19FFFC60006A4C47 /* stats-v1.1-summary.json */; };
 		936B22481958C3840058C828 /* WPStatsGraphViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B22471958C3840058C828 /* WPStatsGraphViewController.m */; };
@@ -110,6 +111,8 @@
 		933FF2231A4085C300336167 /* stats-v1.1-followers-email-day.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-v1.1-followers-email-day.json"; sourceTree = "<group>"; };
 		933FF2251A40C7FD00336167 /* stats-v1.1-comments-day.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-v1.1-comments-day.json"; sourceTree = "<group>"; };
 		933FF2271A41C64300336167 /* WPStatsServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPStatsServiceTests.m; sourceTree = "<group>"; };
+		9340980B1A5C83A00005DF06 /* StatsEphemory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsEphemory.h; sourceTree = "<group>"; };
+		9340980C1A5C83A00005DF06 /* StatsEphemory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsEphemory.m; sourceTree = "<group>"; };
 		9358D15A19FFFB740094BBF5 /* WPStatsServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPStatsServiceRemoteTests.m; sourceTree = "<group>"; };
 		93652B7E19FFFC60006A4C47 /* stats-v1.1-summary.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-v1.1-summary.json"; sourceTree = "<group>"; };
 		936B22461958C3840058C828 /* WPStatsGraphViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPStatsGraphViewController.h; sourceTree = "<group>"; };
@@ -296,6 +299,8 @@
 				93302C511A1BD78300B49CFC /* WPStatsService.m */,
 				93A379E819FEDEE100415023 /* WPStatsServiceRemote.h */,
 				93A379E919FEDEE100415023 /* WPStatsServiceRemote.m */,
+				9340980B1A5C83A00005DF06 /* StatsEphemory.h */,
+				9340980C1A5C83A00005DF06 /* StatsEphemory.m */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -521,6 +526,7 @@
 				93A379E119FEAB1C00415023 /* StatsItemAction.m in Sources */,
 				930C2EEB195DB4D300C6964D /* WPStatsGraphBackgroundView.m in Sources */,
 				93A379EA19FEDEE100415023 /* WPStatsServiceRemote.m in Sources */,
+				9340980D1A5C83A00005DF06 /* StatsEphemory.m in Sources */,
 				936B2251195C48700058C828 /* WPStatsGraphBarCell.m in Sources */,
 				93302C521A1BD78300B49CFC /* WPStatsService.m in Sources */,
 				936B22481958C3840058C828 /* WPStatsGraphViewController.m in Sources */,

--- a/WordPressCom-Stats-iOS/StatsEphemory.h
+++ b/WordPressCom-Stats-iOS/StatsEphemory.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+@interface StatsEphemory : NSObject
+
+@property (nonatomic, assign, readonly) NSTimeInterval expiryInterval;
+
+- (instancetype)initWithExpiryInterval:(NSTimeInterval)expiryInterval;
+
+- (id)objectForKey:(id)key;
+- (void)setObject:(id)obj forKey:(id)key;
+- (void)removeObjectForKey:(id)key;
+
+- (void)removeAllObjects;
+
+@end

--- a/WordPressCom-Stats-iOS/StatsEphemory.h
+++ b/WordPressCom-Stats-iOS/StatsEphemory.h
@@ -1,5 +1,12 @@
 #import <Foundation/Foundation.h>
 
+/*!
+    @class      StatsEphemory
+    @brief      A lightweight container for NSCache.
+    @discussion Encapsulates an NSCache instance with an additional parameter for expiration time interval.
+ 
+                This class' name is a portmanteua of Ephemeral and Memory.
+*/
 @interface StatsEphemory : NSObject
 
 @property (nonatomic, assign, readonly) NSTimeInterval expiryInterval;
@@ -9,7 +16,6 @@
 - (id)objectForKey:(id)key;
 - (void)setObject:(id)obj forKey:(id)key;
 - (void)removeObjectForKey:(id)key;
-
 - (void)removeAllObjects;
 
 @end

--- a/WordPressCom-Stats-iOS/StatsEphemory.m
+++ b/WordPressCom-Stats-iOS/StatsEphemory.m
@@ -43,9 +43,16 @@
 
 - (id)objectForKey:(id)key
 {
+    NSParameterAssert(key != nil);
+
     EphemoryContainer *container = [self.cache objectForKey:key];
     
-    return container.data;
+    // Only return data when the expiration hasn't passed
+    if (fabs([container.date timeIntervalSinceNow]) <= self.expiryInterval) {
+        return container.data;
+    }
+
+    return nil;
 }
 
 

--- a/WordPressCom-Stats-iOS/StatsEphemory.m
+++ b/WordPressCom-Stats-iOS/StatsEphemory.m
@@ -1,0 +1,77 @@
+#import "StatsEphemory.h"
+
+@interface EphemoryContainer : NSObject
+
+@property (nonatomic, strong) NSDate *date;
+@property (nonatomic, strong) id data;
+
+@end
+
+@implementation EphemoryContainer
+
+@end
+
+@interface StatsEphemory ()
+
+@property (nonatomic, strong) NSCache *cache;
+@property (nonatomic, assign, readwrite) NSTimeInterval expiryInterval;
+
+@end
+
+@implementation StatsEphemory
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _cache = [NSCache new];
+        _expiryInterval = NSTimeIntervalSince1970;
+    }
+    return self;
+}
+
+
+- (instancetype)initWithExpiryInterval:(NSTimeInterval)expiryInterval
+{
+    self = [self init];
+    if (self) {
+        _expiryInterval = expiryInterval;
+    }
+    return self;
+}
+
+
+- (id)objectForKey:(id)key
+{
+    EphemoryContainer *container = [self.cache objectForKey:key];
+    
+    return container.data;
+}
+
+
+- (void)setObject:(id)obj forKey:(id)key
+{
+    NSParameterAssert(obj != nil);
+    NSParameterAssert(key != nil);
+    
+    EphemoryContainer *container = [EphemoryContainer new];
+    container.date = [NSDate date];
+    container.data = obj;
+    
+    [self.cache setObject:container forKey:key];
+}
+
+
+- (void)removeObjectForKey:(id)key
+{
+    NSParameterAssert(key != nil);
+    
+    [self.cache removeObjectForKey:key];
+}
+
+- (void)removeAllObjects
+{
+    [self.cache removeAllObjects];
+}
+
+@end

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -105,7 +105,8 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     self.graphViewController.allowDeselection = NO;
     self.graphViewController.graphDelegate = self;
     
-    self.statsService = [[WPStatsService alloc] initWithSiteId:self.siteID siteTimeZone:self.siteTimeZone andOAuth2Token:self.oauth2Token];
+    NSTimeInterval fiveMinutes = 60 * 5;
+    self.statsService = [[WPStatsService alloc] initWithSiteId:self.siteID siteTimeZone:self.siteTimeZone oauth2Token:self.oauth2Token andCacheExpirationInterval:fiveMinutes];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -330,8 +331,10 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
 
 #pragma mark - Stats retrieval methods
 
-- (IBAction)refreshCurrentStats:(id)sender
+- (IBAction)refreshCurrentStats:(UIRefreshControl *)sender
 {
+    self.selectedDate = [NSDate date];
+    [self.statsService expireAllItemsInCache];
     [self retrieveStatsSkipGraph:NO];
 }
 

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -955,7 +955,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
 - (void)configureSectionGroupSelectorCell:(UITableViewCell *)cell withStatsSection:(StatsSection)statsSection
 {
     NSArray *titles;
-    NSInteger selectedIndex;
+    NSInteger selectedIndex = 0;
     StatsSubSection selectedSubsection = [self statsSubSectionForStatsSection:statsSection];
     
     switch (statsSection) {

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -393,8 +393,8 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
 {
     self.syncing = YES;
     
-    [self.statsService retrieveAllStatsForDates:@[self.selectedDate]
-                                        andUnit:self.selectedPeriodUnit
+    [self.statsService retrieveAllStatsForDate:self.selectedDate
+                                       andUnit:self.selectedPeriodUnit
                     withVisitsCompletionHandler:^(StatsVisits *visits)
      {
          if (skipGraph) {

--- a/WordPressCom-Stats-iOS/WPStatsService.h
+++ b/WordPressCom-Stats-iOS/WPStatsService.h
@@ -3,7 +3,7 @@
 #import "StatsVisits.h"
 #import "StatsGroup.h"
 
-typedef void (^StatsSummaryCompletion)(StatsSummary *summary, NSError *error);
+typedef void (^StatsSummaryCompletion)(StatsSummary *summary);
 typedef void (^StatsVisitsCompletion)(StatsVisits *visits, NSError *error);
 typedef void (^StatsItemsCompletion)(StatsGroup *group, NSError *error);
 
@@ -32,7 +32,7 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
       publicizeCompletionHandler:(StatsItemsCompletion)publicizeCompletion
      andOverallCompletionHandler:(void (^)())completionHandler;
 
-- (void)retrieveTodayStatsWithCompletionHandler:(void (^)(StatsSummaryCompletion *))completion failureHandler:(void (^)(NSError *))failureHandler;
+- (void)retrieveTodayStatsWithCompletionHandler:(StatsSummaryCompletion)completion failureHandler:(void (^)(NSError *))failureHandler;
 
 - (void)expireAllItemsInCache;
 

--- a/WordPressCom-Stats-iOS/WPStatsService.h
+++ b/WordPressCom-Stats-iOS/WPStatsService.h
@@ -13,7 +13,7 @@ typedef void (^StatsItemsCompletion)(StatsGroup *group, NSError *error);
 
 @property (nonatomic, strong) WPStatsServiceRemote *remote;
 
-- (instancetype)initWithSiteId:(NSNumber *)siteId siteTimeZone:(NSTimeZone *)timeZone andOAuth2Token:(NSString *)oauth2Token;
+- (instancetype)initWithSiteId:(NSNumber *)siteId siteTimeZone:(NSTimeZone *)timeZone oauth2Token:(NSString *)oauth2Token andCacheExpirationInterval:(NSTimeInterval)cacheExpirationInterval;
 
 - (void)retrieveAllStatsForDate:(NSDate *)date
                         andUnit:(StatsPeriodUnit)unit
@@ -33,5 +33,7 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
      andOverallCompletionHandler:(void (^)())completionHandler;
 
 - (void)retrieveTodayStatsWithCompletionHandler:(void (^)(StatsSummaryCompletion *))completion failureHandler:(void (^)(NSError *))failureHandler;
+
+- (void)expireAllItemsInCache;
 
 @end

--- a/WordPressCom-Stats-iOS/WPStatsService.h
+++ b/WordPressCom-Stats-iOS/WPStatsService.h
@@ -15,23 +15,23 @@ typedef void (^StatsItemsCompletion)(StatsGroup *group);
 
 - (instancetype)initWithSiteId:(NSNumber *)siteId siteTimeZone:(NSTimeZone *)timeZone andOAuth2Token:(NSString *)oauth2Token;
 
-- (void)retrieveAllStatsForDates:(NSArray *)dates
-                         andUnit:(StatsPeriodUnit)unit
-     withVisitsCompletionHandler:(StatsVisitsCompletion)visitsCompletion
-         eventsCompletionHandler:(StatsItemsCompletion)eventsCompletion
-          postsCompletionHandler:(StatsItemsCompletion)postsCompletion
-      referrersCompletionHandler:(StatsItemsCompletion)referrersCompletion
-         clicksCompletionHandler:(StatsItemsCompletion)clicksCompletion
-        countryCompletionHandler:(StatsItemsCompletion)countryCompletion
-         videosCompletionHandler:(StatsItemsCompletion)videosCompletion
- commentsAuthorCompletionHandler:(StatsItemsCompletion)commentsAuthorsCompletion
-  commentsPostsCompletionHandler:(StatsItemsCompletion)commentsPostsCompletion
- tagsCategoriesCompletionHandler:(StatsItemsCompletion)tagsCategoriesCompletion
+- (void)retrieveAllStatsForDate:(NSDate *)date
+                        andUnit:(StatsPeriodUnit)unit
+    withVisitsCompletionHandler:(StatsVisitsCompletion)visitsCompletion
+        eventsCompletionHandler:(StatsItemsCompletion)eventsCompletion
+         postsCompletionHandler:(StatsItemsCompletion)postsCompletion
+     referrersCompletionHandler:(StatsItemsCompletion)referrersCompletion
+        clicksCompletionHandler:(StatsItemsCompletion)clicksCompletion
+       countryCompletionHandler:(StatsItemsCompletion)countryCompletion
+        videosCompletionHandler:(StatsItemsCompletion)videosCompletion
+commentsAuthorCompletionHandler:(StatsItemsCompletion)commentsAuthorsCompletion
+ commentsPostsCompletionHandler:(StatsItemsCompletion)commentsPostsCompletion
+tagsCategoriesCompletionHandler:(StatsItemsCompletion)tagsCategoriesCompletion
 followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
- followersEmailCompletionHandler:(StatsItemsCompletion)followersEmailCompletion
-      publicizeCompletionHandler:(StatsItemsCompletion)publicizeCompletion
-     andOverallCompletionHandler:(void (^)())completionHandler
-           overallFailureHandler:(void (^)(NSError *error))failureHandler;
+followersEmailCompletionHandler:(StatsItemsCompletion)followersEmailCompletion
+     publicizeCompletionHandler:(StatsItemsCompletion)publicizeCompletion
+    andOverallCompletionHandler:(void (^)())completionHandler
+          overallFailureHandler:(void (^)(NSError *error))failureHandler;
 
 - (void)retrieveTodayStatsWithCompletionHandler:(void (^)(StatsSummaryCompletion *))completion failureHandler:(void (^)(NSError *))failureHandler;
 

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -153,6 +153,7 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
             withVisitsCompletionHandler:^(StatsVisits *visits, NSError *error)
      {
          cacheDictionary[@(StatsCacheVisits)] = visits;
+         visits.errorWhileRetrieving = error != nil;
          
          if (visitsCompletion) {
              visitsCompletion(visits, error);

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -6,11 +6,28 @@
 #import "StatsVisits.h"
 #import "StatsSummary.h"
 
+typedef NS_ENUM(NSInteger, StatsCache) {
+    StatsCacheVisits,
+    StatsCacheEvents,
+    StatsCachePosts,
+    StatsCacheReferrers,
+    StatsCacheClicks,
+    StatsCacheCountry,
+    StatsCacheVideos,
+    StatsCacheCommentsAuthors,
+    StatsCacheCommentsPosts,
+    StatsCacheTagsCategories,
+    StatsCacheFollowersDotCom,
+    StatsCacheFollowersEmail,
+    StatsCachePublicize
+};
+
 @interface WPStatsService ()
 
 @property (nonatomic, strong) NSNumber *siteId;
 @property (nonatomic, strong) NSString *oauth2Token;
 @property (nonatomic, strong) NSTimeZone *siteTimeZone;
+@property (nonatomic, strong) NSCache *cache;
 
 @end
 
@@ -30,28 +47,29 @@
         _siteId = siteId;
         _oauth2Token = oauth2Token;
         _siteTimeZone = timeZone ?: [NSTimeZone systemTimeZone];
+        _cache = [NSCache new];
     }
 
     return self;
 }
 
-- (void)retrieveAllStatsForDates:(NSArray *)dates
-                         andUnit:(StatsPeriodUnit)unit
-     withVisitsCompletionHandler:(StatsVisitsCompletion)visitsCompletion
-         eventsCompletionHandler:(StatsItemsCompletion)eventsCompletion
-          postsCompletionHandler:(StatsItemsCompletion)postsCompletion
-      referrersCompletionHandler:(StatsItemsCompletion)referrersCompletion
-         clicksCompletionHandler:(StatsItemsCompletion)clicksCompletion
-        countryCompletionHandler:(StatsItemsCompletion)countryCompletion
-         videosCompletionHandler:(StatsItemsCompletion)videosCompletion
- commentsAuthorCompletionHandler:(StatsItemsCompletion)commentsAuthorsCompletion
-  commentsPostsCompletionHandler:(StatsItemsCompletion)commentsPostsCompletion
- tagsCategoriesCompletionHandler:(StatsItemsCompletion)tagsCategoriesCompletion
+- (void)retrieveAllStatsForDate:(NSDate *)date
+                        andUnit:(StatsPeriodUnit)unit
+    withVisitsCompletionHandler:(StatsVisitsCompletion)visitsCompletion
+        eventsCompletionHandler:(StatsItemsCompletion)eventsCompletion
+         postsCompletionHandler:(StatsItemsCompletion)postsCompletion
+     referrersCompletionHandler:(StatsItemsCompletion)referrersCompletion
+        clicksCompletionHandler:(StatsItemsCompletion)clicksCompletion
+       countryCompletionHandler:(StatsItemsCompletion)countryCompletion
+        videosCompletionHandler:(StatsItemsCompletion)videosCompletion
+commentsAuthorCompletionHandler:(StatsItemsCompletion)commentsAuthorsCompletion
+ commentsPostsCompletionHandler:(StatsItemsCompletion)commentsPostsCompletion
+tagsCategoriesCompletionHandler:(StatsItemsCompletion)tagsCategoriesCompletion
 followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
- followersEmailCompletionHandler:(StatsItemsCompletion)followersEmailCompletion
-      publicizeCompletionHandler:(StatsItemsCompletion)publicizeCompletion
-     andOverallCompletionHandler:(void (^)())completionHandler
-           overallFailureHandler:(void (^)(NSError *error))failureHandler
+followersEmailCompletionHandler:(StatsItemsCompletion)followersEmailCompletion
+     publicizeCompletionHandler:(StatsItemsCompletion)publicizeCompletion
+    andOverallCompletionHandler:(void (^)())completionHandler
+          overallFailureHandler:(void (^)(NSError *error))failureHandler
 {
     if (!completionHandler) {
         return;
@@ -65,116 +83,182 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
         }
     };
     
-    NSMutableArray *endDates = [NSMutableArray new];
-    for (NSDate *date in dates) {
-        NSDate *endDate = [self calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
-        [endDates addObject:endDate];
+    NSDate *endDate = [self calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
+    NSMutableDictionary *cacheDictionary = [self.cache objectForKey:@[@(unit), endDate]];
+    if (cacheDictionary) {
+        if (visitsCompletion) {
+            visitsCompletion(cacheDictionary[@(StatsCacheVisits)]);
+        }
+
+        if (eventsCompletion) {
+            eventsCompletion(cacheDictionary[@(StatsCacheEvents)]);
+        }
+
+        if (postsCompletion) {
+            postsCompletion(cacheDictionary[@(StatsCachePosts)]);
+        }
+    
+        if (referrersCompletion) {
+            referrersCompletion(cacheDictionary[@(StatsCacheReferrers)]);
+        }
+    
+        if (clicksCompletion) {
+            clicksCompletion(cacheDictionary[@(StatsCacheClicks)]);
+        }
+    
+        if (countryCompletion) {
+            countryCompletion(cacheDictionary[@(StatsCacheCountry)]);
+        }
+    
+        if (videosCompletion) {
+            videosCompletion(cacheDictionary[@(StatsCacheVideos)]);
+        }
+    
+        if (commentsAuthorsCompletion) {
+            commentsAuthorsCompletion(cacheDictionary[@(StatsCacheCommentsAuthors)]);
+        }
+        
+        if (commentsPostsCompletion) {
+            commentsPostsCompletion(cacheDictionary[@(StatsCacheCommentsPosts)]);
+        }
+    
+        if (tagsCategoriesCompletion) {
+            tagsCategoriesCompletion(cacheDictionary[@(StatsCacheTagsCategories)]);
+        }
+    
+        if (followersDotComCompletion) {
+            followersDotComCompletion(cacheDictionary[@(StatsCacheFollowersDotCom)]);
+        }
+    
+        if (followersEmailCompletion) {
+            followersEmailCompletion(cacheDictionary[@(StatsCacheFollowersEmail)]);
+        }
+    
+        if (publicizeCompletion) {
+            publicizeCompletion(cacheDictionary[@(StatsCachePublicize)]);
+        }
+        
+        completionHandler();
+        
+        return;
+    } else {
+        cacheDictionary = [NSMutableDictionary new];
+        [self.cache setObject:cacheDictionary forKey:@[@(unit), endDate]];
     }
 
-    __block StatsVisits *visitsResult = nil;
-    [self.remote batchFetchStatsForDates:endDates
-                                 andUnit:unit
-             withVisitsCompletionHandler:^(StatsVisits *visits)
-    {
-        visitsResult = visits;
-        
-        if (visitsCompletion) {
-            visitsCompletion(visits);
-        }
-    }
-                 eventsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+    [self.remote batchFetchStatsForDate:endDate
+                                andUnit:unit
+            withVisitsCompletionHandler:^(StatsVisits *visits)
+     {
+         cacheDictionary[@(StatsCacheVisits)] = visits;
+         
+         if (visitsCompletion) {
+             visitsCompletion(visits);
+         }
+     }
+                eventsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
      {
          StatsGroup *eventsResult = [StatsGroup new];
          eventsResult.items = items;
          eventsResult.moreItemsExist = moreViewsAvailable;
-         
+         cacheDictionary[@(StatsCacheEvents)] = eventsResult;
+
          if (eventsCompletion) {
              eventsCompletion(eventsResult);
          }
      }
-                  postsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+                 postsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
      {
          StatsGroup *postsResult = [StatsGroup new];
          postsResult.items = items;
          postsResult.titlePrimary = NSLocalizedString(@"Posts & Pages", @"Title for stats section for Posts & Pages");
          postsResult.moreItemsExist = moreViewsAvailable;
-         
+         cacheDictionary[@(StatsCachePosts)] = postsResult;
+
          if (postsCompletion) {
              postsCompletion(postsResult);
          }
      }
-              referrersCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
-    {
-        StatsGroup *referrersResult = [StatsGroup new];
-        referrersResult.items = items;
-        referrersResult.moreItemsExist = moreViewsAvailable;
-        
-        if (referrersCompletion) {
-            referrersCompletion(referrersResult);
-        }
-    }
-                 clicksCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
-    {
-        StatsGroup *clicksResult = [StatsGroup new];
-        clicksResult.items = items;
-        clicksResult.moreItemsExist = moreViewsAvailable;
-        
-        if (clicksCompletion) {
-            clicksCompletion(clicksResult);
-        }
-    }
-                countryCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
-    {
-        StatsGroup *countriesResult = [StatsGroup new];
-        countriesResult.items = items;
-        countriesResult.moreItemsExist = moreViewsAvailable;
-        
-        if (countryCompletion) {
-            countryCompletion(countriesResult);
-        }
-    }
-                 videosCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
-    {
-        StatsGroup *videosResult = [StatsGroup new];
-        videosResult.items = items;
-        videosResult.moreItemsExist = moreViewsAvailable;
-        
-        if (videosCompletion) {
-            videosCompletion(videosResult);
-        }
-    }
-               commentsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
-    {
-        StatsGroup *commentsAuthorsResult = [StatsGroup new];
-        commentsAuthorsResult.items = items.firstObject;
-        StatsGroup *commentsPostsResult = [StatsGroup new];
-        commentsPostsResult.items = items.lastObject;
-        
-        if (commentsAuthorsCompletion) {
-            commentsAuthorsCompletion(commentsAuthorsResult);
-        }
-        
-        if (commentsPostsResult) {
-            commentsPostsCompletion(commentsPostsResult);
-        }
-    }
-         tagsCategoriesCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
-    {
-        StatsGroup *tagsCategoriesResult = [StatsGroup new];
-        tagsCategoriesResult.items = items;
-        tagsCategoriesResult.moreItemsExist = moreViewsAvailable;
-        
-        if (tagsCategoriesCompletion) {
-            tagsCategoriesCompletion(tagsCategoriesResult);
-        }
-    }
-        followersDotComCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+             referrersCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+     {
+         StatsGroup *referrersResult = [StatsGroup new];
+         referrersResult.items = items;
+         referrersResult.moreItemsExist = moreViewsAvailable;
+         cacheDictionary[@(StatsCacheReferrers)] = referrersResult;
+
+         if (referrersCompletion) {
+             referrersCompletion(referrersResult);
+         }
+     }
+                clicksCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+     {
+         StatsGroup *clicksResult = [StatsGroup new];
+         clicksResult.items = items;
+         clicksResult.moreItemsExist = moreViewsAvailable;
+         cacheDictionary[@(StatsCacheClicks)] = clicksResult;
+         
+         if (clicksCompletion) {
+             clicksCompletion(clicksResult);
+         }
+     }
+               countryCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+     {
+         StatsGroup *countriesResult = [StatsGroup new];
+         countriesResult.items = items;
+         countriesResult.moreItemsExist = moreViewsAvailable;
+         cacheDictionary[@(StatsCacheCountry)] = countriesResult;
+         
+         if (countryCompletion) {
+             countryCompletion(countriesResult);
+         }
+     }
+                videosCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+     {
+         StatsGroup *videosResult = [StatsGroup new];
+         videosResult.items = items;
+         videosResult.moreItemsExist = moreViewsAvailable;
+         cacheDictionary[@(StatsCacheVideos)] = videosResult;
+
+         if (videosCompletion) {
+             videosCompletion(videosResult);
+         }
+     }
+              commentsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+     {
+         StatsGroup *commentsAuthorsResult = [StatsGroup new];
+         commentsAuthorsResult.items = items.firstObject;
+         cacheDictionary[@(StatsCacheCommentsAuthors)] = commentsAuthorsResult;
+         StatsGroup *commentsPostsResult = [StatsGroup new];
+         commentsPostsResult.items = items.lastObject;
+         cacheDictionary[@(StatsCacheCommentsPosts)] = commentsPostsResult;
+         
+         if (commentsAuthorsCompletion) {
+             commentsAuthorsCompletion(commentsAuthorsResult);
+         }
+         
+         if (commentsPostsCompletion) {
+             commentsPostsCompletion(commentsPostsResult);
+         }
+     }
+        tagsCategoriesCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+     {
+         StatsGroup *tagsCategoriesResult = [StatsGroup new];
+         tagsCategoriesResult.items = items;
+         tagsCategoriesResult.moreItemsExist = moreViewsAvailable;
+         cacheDictionary[@(StatsCacheTagsCategories)] = tagsCategoriesResult;
+
+         if (tagsCategoriesCompletion) {
+             tagsCategoriesCompletion(tagsCategoriesResult);
+         }
+     }
+       followersDotComCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
      {
          StatsGroup *followersDotComResult = [StatsGroup new];
          followersDotComResult.items = items;
          followersDotComResult.moreItemsExist = moreViewsAvailable;
          followersDotComResult.totalCount = totalViews;
-         
+         cacheDictionary[@(StatsCacheFollowersDotCom)] = followersDotComResult;
+
          for (StatsItem *item in items) {
              NSString *age = [self dateAgeForDate:item.date];
              item.value = age;
@@ -184,13 +268,14 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
              followersDotComCompletion(followersDotComResult);
          }
      }
-         followersEmailCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+        followersEmailCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
      {
          StatsGroup *followersEmailResult = [StatsGroup new];
          followersEmailResult.items = items;
          followersEmailResult.moreItemsExist = moreViewsAvailable;
          followersEmailResult.totalCount = totalViews;
-
+         cacheDictionary[@(StatsCacheFollowersEmail)] = followersEmailResult;
+         
          for (StatsItem *item in items) {
              NSString *age = [self dateAgeForDate:item.date];
              item.value = age;
@@ -200,21 +285,22 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
              followersEmailCompletion(followersEmailResult);
          }
      }
-              publicizeCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
-    {
-        StatsGroup *publicizeResult = [StatsGroup new];
-        publicizeResult.items = items;
-        publicizeResult.moreItemsExist = moreViewsAvailable;
-        
-        if (publicizeCompletion) {
-            publicizeCompletion(publicizeResult);
-        }
-    }
-             andOverallCompletionHandler:^
-    {
-        completionHandler();
-    }
-                   overallFailureHandler:failure];
+             publicizeCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable)
+     {
+         StatsGroup *publicizeResult = [StatsGroup new];
+         publicizeResult.items = items;
+         publicizeResult.moreItemsExist = moreViewsAvailable;
+         cacheDictionary[@(StatsCachePublicize)] = publicizeResult;
+
+         if (publicizeCompletion) {
+             publicizeCompletion(publicizeResult);
+         }
+     }
+            andOverallCompletionHandler:^
+     {
+         completionHandler();
+     }
+                  overallFailureHandler:failure];
 }
 
 
@@ -276,13 +362,14 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
 
 - (NSDate *)calculateEndDateForPeriodUnit:(StatsPeriodUnit)unit withDateWithinPeriod:(NSDate *)date
 {
-    if (unit == StatsPeriodUnitDay) {
-        return date;
-    }
-    
     NSCalendar *calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
 
-    if (unit == StatsPeriodUnitMonth) {
+    if (unit == StatsPeriodUnitDay) {
+        NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
+        date = [calendar dateFromComponents:dateComponents];
+        
+        return date;
+    } else if (unit == StatsPeriodUnitMonth) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth fromDate:date];
         date = [calendar dateFromComponents:dateComponents];
         
@@ -303,6 +390,10 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
             date = [calendar dateByAddingComponents:dateComponents toDate:date options:0];
         }
         
+        // Strip time
+        dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
+        date = [calendar dateFromComponents:dateComponents];
+
         return date;
     } else if (unit == StatsPeriodUnitYear) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear fromDate:date];

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -5,6 +5,7 @@
 #import "StatsGroup.h"
 #import "StatsVisits.h"
 #import "StatsSummary.h"
+#import "StatsEphemory.h"
 
 typedef NS_ENUM(NSInteger, StatsCache) {
     StatsCacheVisits,
@@ -27,7 +28,7 @@ typedef NS_ENUM(NSInteger, StatsCache) {
 @property (nonatomic, strong) NSNumber *siteId;
 @property (nonatomic, strong) NSString *oauth2Token;
 @property (nonatomic, strong) NSTimeZone *siteTimeZone;
-@property (nonatomic, strong) NSCache *cache;
+@property (nonatomic, strong) StatsEphemory *ephemory;
 
 @end
 
@@ -47,7 +48,7 @@ typedef NS_ENUM(NSInteger, StatsCache) {
         _siteId = siteId;
         _oauth2Token = oauth2Token;
         _siteTimeZone = timeZone ?: [NSTimeZone systemTimeZone];
-        _cache = [NSCache new];
+        _ephemory = [StatsEphemory new];
     }
 
     return self;
@@ -84,7 +85,7 @@ followersEmailCompletionHandler:(StatsItemsCompletion)followersEmailCompletion
     };
     
     NSDate *endDate = [self calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
-    NSMutableDictionary *cacheDictionary = [self.cache objectForKey:@[@(unit), endDate]];
+    NSMutableDictionary *cacheDictionary = [self.ephemory objectForKey:@[@(unit), endDate]];
     if (cacheDictionary) {
         if (visitsCompletion) {
             visitsCompletion(cacheDictionary[@(StatsCacheVisits)]);
@@ -143,7 +144,7 @@ followersEmailCompletionHandler:(StatsItemsCompletion)followersEmailCompletion
         return;
     } else {
         cacheDictionary = [NSMutableDictionary new];
-        [self.cache setObject:cacheDictionary forKey:@[@(unit), endDate]];
+        [self.ephemory setObject:cacheDictionary forKey:@[@(unit), endDate]];
     }
 
     [self.remote batchFetchStatsForDate:endDate

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -329,7 +329,7 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
 }
 
 
-- (void)retrieveTodayStatsWithCompletionHandler:(void (^)(StatsSummaryCompletion *))completion failureHandler:(void (^)(NSError *))failureHandler
+- (void)retrieveTodayStatsWithCompletionHandler:(StatsSummaryCompletion)completion failureHandler:(void (^)(NSError *))failureHandler
 {
     void (^failure)(NSError *error) = ^void (NSError *error) {
         DDLogError(@"Error while retrieving stats: %@", error);
@@ -339,6 +339,26 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
         }
     };
     
+    if (!completion) {
+        return;
+    }
+    
+    StatsSummary *summary = [self.ephemory objectForKey:@"TodayStats"];
+    if (summary) {
+        completion(summary);
+    }
+    
+    [self.remote fetchSummaryStatsForDate:[NSDate date]
+                    withCompletionHandler:^(StatsSummary *summary, NSError *error) {
+                        if (error) {
+                            failure(error);
+                            return;
+                        }
+
+                        [self.ephemory setObject:summary forKey:@"TodayStats"];
+
+                        completion(summary);
+                    }];
 }
 
 

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -47,17 +47,18 @@ typedef NS_ENUM(NSInteger, StatsCache) {
     return self;
 }
 
-- (instancetype)initWithSiteId:(NSNumber *)siteId siteTimeZone:(NSTimeZone *)timeZone andOAuth2Token:(NSString *)oauth2Token
+- (instancetype)initWithSiteId:(NSNumber *)siteId siteTimeZone:(NSTimeZone *)timeZone oauth2Token:(NSString *)oauth2Token andCacheExpirationInterval:(NSTimeInterval)cacheExpirationInterval
 {
     NSAssert(oauth2Token.length > 0, @"OAuth2 token must not be empty.");
     NSAssert(siteId != nil, @"Site ID must not be nil.");
     NSAssert(timeZone != nil, @"Timezone must not be nil.");
 
-    self = [self init];
+    self = [super init];
     if (self) {
         _siteId = siteId;
         _oauth2Token = oauth2Token;
         _siteTimeZone = timeZone ?: [NSTimeZone systemTimeZone];
+        _ephemory = [[StatsEphemory alloc] initWithExpiryInterval:cacheExpirationInterval];
     }
 
     return self;
@@ -340,6 +341,7 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
     
 }
 
+
 - (WPStatsServiceRemote *)remote
 {
     if (!_remote) {
@@ -348,6 +350,13 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
 
     return _remote;
 }
+
+
+- (void)expireAllItemsInCache
+{
+    [self.ephemory removeAllObjects];
+}
+
 
 // TODO - Extract this into a separate class that's unit testable
 - (NSString *)dateAgeForDate:(NSDate *)date

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -37,18 +37,27 @@ typedef NS_ENUM(NSInteger, StatsCache) {
 
 }
 
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        NSTimeInterval fiveMinutes = 60.0 * 5.0;
+        _ephemory = [[StatsEphemory alloc] initWithExpiryInterval:fiveMinutes];
+    }
+    return self;
+}
+
 - (instancetype)initWithSiteId:(NSNumber *)siteId siteTimeZone:(NSTimeZone *)timeZone andOAuth2Token:(NSString *)oauth2Token
 {
     NSAssert(oauth2Token.length > 0, @"OAuth2 token must not be empty.");
     NSAssert(siteId != nil, @"Site ID must not be nil.");
     NSAssert(timeZone != nil, @"Timezone must not be nil.");
 
-    self = [super init];
+    self = [self init];
     if (self) {
         _siteId = siteId;
         _oauth2Token = oauth2Token;
         _siteTimeZone = timeZone ?: [NSTimeZone systemTimeZone];
-        _ephemory = [StatsEphemory new];
     }
 
     return self;

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
@@ -19,7 +19,7 @@ typedef NS_ENUM(NSUInteger, StatsFollowerType) {
 /**
  Batches all remote calls locally to retrieve stats for a particular set of dates and period.  Completion handlers are called
  
- @param dates An array with at least one date.  Completion handlers may be called more than once if multiple dates are given.
+ @param date End date of period to fetch stats for
  @param unit Period unit to run stats for
  @param summaryCompletion
  @param visitsCompletion
@@ -36,22 +36,22 @@ typedef NS_ENUM(NSUInteger, StatsFollowerType) {
  @param failureHandler
  
  */
-- (void)batchFetchStatsForDates:(NSArray *)dates
-                        andUnit:(StatsPeriodUnit)unit
-    withVisitsCompletionHandler:(StatsRemoteVisitsCompletion)visitsCompletion
-        eventsCompletionHandler:(StatsRemoteItemsCompletion)eventsCompletion
-         postsCompletionHandler:(StatsRemoteItemsCompletion)postsCompletion
-     referrersCompletionHandler:(StatsRemoteItemsCompletion)referrersCompletion
-        clicksCompletionHandler:(StatsRemoteItemsCompletion)clicksCompletion
-       countryCompletionHandler:(StatsRemoteItemsCompletion)countryCompletion
-        videosCompletionHandler:(StatsRemoteItemsCompletion)videosCompletion
-      commentsCompletionHandler:(StatsRemoteItemsCompletion)commentsCompletion
+- (void)batchFetchStatsForDate:(NSDate *)date
+                       andUnit:(StatsPeriodUnit)unit
+   withVisitsCompletionHandler:(StatsRemoteVisitsCompletion)visitsCompletion
+       eventsCompletionHandler:(StatsRemoteItemsCompletion)eventsCompletion
+        postsCompletionHandler:(StatsRemoteItemsCompletion)postsCompletion
+    referrersCompletionHandler:(StatsRemoteItemsCompletion)referrersCompletion
+       clicksCompletionHandler:(StatsRemoteItemsCompletion)clicksCompletion
+      countryCompletionHandler:(StatsRemoteItemsCompletion)countryCompletion
+       videosCompletionHandler:(StatsRemoteItemsCompletion)videosCompletion
+     commentsCompletionHandler:(StatsRemoteItemsCompletion)commentsCompletion
 tagsCategoriesCompletionHandler:(StatsRemoteItemsCompletion)tagsCategoriesCompletion
 followersDotComCompletionHandler:(StatsRemoteItemsCompletion)followersDotComCompletion
 followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailCompletion
-     publicizeCompletionHandler:(StatsRemoteItemsCompletion)publicizeCompletion
-    andOverallCompletionHandler:(void (^)())completionHandler
-          overallFailureHandler:(void (^)(NSError *error))failureHandler;
+    publicizeCompletionHandler:(StatsRemoteItemsCompletion)publicizeCompletion
+   andOverallCompletionHandler:(void (^)())completionHandler
+         overallFailureHandler:(void (^)(NSError *error))failureHandler;
 
 - (void)fetchSummaryStatsForDate:(NSDate *)date
            withCompletionHandler:(StatsRemoteSummaryCompletion)completionHandler

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -65,62 +65,60 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
 #pragma mark - Public methods
 
 
-- (void)batchFetchStatsForDates:(NSArray *)dates
-                        andUnit:(StatsPeriodUnit)unit
-    withVisitsCompletionHandler:(StatsRemoteVisitsCompletion)visitsCompletion
-        eventsCompletionHandler:(StatsRemoteItemsCompletion)eventsCompletion
-         postsCompletionHandler:(StatsRemoteItemsCompletion)postsCompletion
-     referrersCompletionHandler:(StatsRemoteItemsCompletion)referrersCompletion
-        clicksCompletionHandler:(StatsRemoteItemsCompletion)clicksCompletion
-       countryCompletionHandler:(StatsRemoteItemsCompletion)countryCompletion
-        videosCompletionHandler:(StatsRemoteItemsCompletion)videosCompletion
-      commentsCompletionHandler:(StatsRemoteItemsCompletion)commentsCompletion
+- (void)batchFetchStatsForDate:(NSDate *)date
+                       andUnit:(StatsPeriodUnit)unit
+   withVisitsCompletionHandler:(StatsRemoteVisitsCompletion)visitsCompletion
+       eventsCompletionHandler:(StatsRemoteItemsCompletion)eventsCompletion
+        postsCompletionHandler:(StatsRemoteItemsCompletion)postsCompletion
+    referrersCompletionHandler:(StatsRemoteItemsCompletion)referrersCompletion
+       clicksCompletionHandler:(StatsRemoteItemsCompletion)clicksCompletion
+      countryCompletionHandler:(StatsRemoteItemsCompletion)countryCompletion
+       videosCompletionHandler:(StatsRemoteItemsCompletion)videosCompletion
+     commentsCompletionHandler:(StatsRemoteItemsCompletion)commentsCompletion
 tagsCategoriesCompletionHandler:(StatsRemoteItemsCompletion)tagsCategoriesCompletion
 followersDotComCompletionHandler:(StatsRemoteItemsCompletion)followersDotComCompletion
 followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailCompletion
-     publicizeCompletionHandler:(StatsRemoteItemsCompletion)publicizeCompletion
-    andOverallCompletionHandler:(void (^)())completionHandler
-          overallFailureHandler:(void (^)(NSError *error))failureHandler
+    publicizeCompletionHandler:(StatsRemoteItemsCompletion)publicizeCompletion
+   andOverallCompletionHandler:(void (^)())completionHandler
+         overallFailureHandler:(void (^)(NSError *error))failureHandler
 {
     NSMutableArray *mutableOperations = [NSMutableArray new];
     
-    for (NSDate *date in dates) {
-        if (visitsCompletion) {
-            [mutableOperations addObject:[self operationForVisitsForDate:date andUnit:unit withCompletionHandler:visitsCompletion failureHandler:nil]];
-        }
-        if (eventsCompletion) {
-            [mutableOperations addObject:[self operationForEventsForDate:date andUnit:unit withCompletionHandler:eventsCompletion failureHandler:nil]];
-        }
-        if (postsCompletion) {
-            [mutableOperations addObject:[self operationForPostsForDate:date andUnit:unit withCompletionHandler:postsCompletion failureHandler:nil]];
-        }
-        if (referrersCompletion) {
-            [mutableOperations addObject:[self operationForReferrersForDate:date andUnit:unit withCompletionHandler:referrersCompletion failureHandler:nil]];
-        }
-        if (clicksCompletion) {
-            [mutableOperations addObject:[self operationForClicksForDate:date andUnit:unit withCompletionHandler:clicksCompletion failureHandler:nil]];
-        }
-        if (countryCompletion) {
-            [mutableOperations addObject:[self operationForCountryForDate:date andUnit:unit withCompletionHandler:countryCompletion failureHandler:nil]];
-        }
-        if (videosCompletion) {
-            [mutableOperations addObject:[self operationForVideosForDate:date andUnit:unit withCompletionHandler:videosCompletion failureHandler:nil]];
-        }
-        if (commentsCompletion) {
-            [mutableOperations addObject:[self operationForCommentsForDate:date andUnit:unit withCompletionHandler:commentsCompletion failureHandler:nil]];
-        }
-        if (tagsCategoriesCompletion) {
-            [mutableOperations addObject:[self operationForTagsCategoriesForDate:date andUnit:unit withCompletionHandler:tagsCategoriesCompletion failureHandler:nil]];
-        }
-        if (followersDotComCompletion) {
-            [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeDotCom forDate:date andUnit:unit withCompletionHandler:followersDotComCompletion failureHandler:nil]];
-        }
-        if (followersEmailCompletion) {
-            [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeEmail forDate:date andUnit:unit withCompletionHandler:followersEmailCompletion failureHandler:nil]];
-        }
-        if (publicizeCompletion) {
-            [mutableOperations addObject:[self operationForPublicizeForDate:date andUnit:unit withCompletionHandler:publicizeCompletion failureHandler:nil]];
-        }
+    if (visitsCompletion) {
+        [mutableOperations addObject:[self operationForVisitsForDate:date andUnit:unit withCompletionHandler:visitsCompletion failureHandler:nil]];
+    }
+    if (eventsCompletion) {
+        [mutableOperations addObject:[self operationForEventsForDate:date andUnit:unit withCompletionHandler:eventsCompletion failureHandler:nil]];
+    }
+    if (postsCompletion) {
+        [mutableOperations addObject:[self operationForPostsForDate:date andUnit:unit withCompletionHandler:postsCompletion failureHandler:nil]];
+    }
+    if (referrersCompletion) {
+        [mutableOperations addObject:[self operationForReferrersForDate:date andUnit:unit withCompletionHandler:referrersCompletion failureHandler:nil]];
+    }
+    if (clicksCompletion) {
+        [mutableOperations addObject:[self operationForClicksForDate:date andUnit:unit withCompletionHandler:clicksCompletion failureHandler:nil]];
+    }
+    if (countryCompletion) {
+        [mutableOperations addObject:[self operationForCountryForDate:date andUnit:unit withCompletionHandler:countryCompletion failureHandler:nil]];
+    }
+    if (videosCompletion) {
+        [mutableOperations addObject:[self operationForVideosForDate:date andUnit:unit withCompletionHandler:videosCompletion failureHandler:nil]];
+    }
+    if (commentsCompletion) {
+        [mutableOperations addObject:[self operationForCommentsForDate:date andUnit:unit withCompletionHandler:commentsCompletion failureHandler:nil]];
+    }
+    if (tagsCategoriesCompletion) {
+        [mutableOperations addObject:[self operationForTagsCategoriesForDate:date andUnit:unit withCompletionHandler:tagsCategoriesCompletion failureHandler:nil]];
+    }
+    if (followersDotComCompletion) {
+        [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeDotCom forDate:date andUnit:unit withCompletionHandler:followersDotComCompletion failureHandler:nil]];
+    }
+    if (followersEmailCompletion) {
+        [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeEmail forDate:date andUnit:unit withCompletionHandler:followersEmailCompletion failureHandler:nil]];
+    }
+    if (publicizeCompletion) {
+        [mutableOperations addObject:[self operationForPublicizeForDate:date andUnit:unit withCompletionHandler:publicizeCompletion failureHandler:nil]];
     }
     
     NSArray *operations = [AFURLConnectionOperation batchOfRequestOperations:mutableOperations progressBlock:^(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations) {

--- a/WordPressCom-Stats-iOSTests/StatsEphemoryTests.m
+++ b/WordPressCom-Stats-iOSTests/StatsEphemoryTests.m
@@ -1,0 +1,83 @@
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+#import "StatsEphemory.h"
+
+@interface StatsEphemoryTests : XCTestCase
+
+@property (nonatomic, strong) StatsEphemory *subject;
+
+@end
+
+@implementation StatsEphemoryTests
+
+- (void)setUp
+{
+    [super setUp];
+
+    self.subject = [[StatsEphemory alloc] init];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    
+    self.subject = nil;
+}
+
+- (void)testObjectForKeyNoMatch
+{
+    XCTAssertNil([self.subject objectForKey:@"nosuchmatch"]);
+}
+
+- (void)testObjectForKeyNil
+{
+    XCTAssertThrows([self.subject objectForKey:nil]);
+}
+
+- (void)testSetObjectValid
+{
+    [self.subject setObject:@"Test" forKey:@"TestKey"];
+    
+    XCTAssertEqual(@"Test", [self.subject objectForKey:@"TestKey"]);
+}
+
+- (void)testSetObjectNilObject
+{
+    XCTAssertThrows([self.subject setObject:nil forKey:@"TestKey"]);
+}
+
+- (void)testRemoveAllObjectsNoObjects
+{
+    XCTAssertNoThrow([self.subject removeAllObjects]);
+}
+
+- (void)testRemoveAllObjectsOneObject
+{
+    [self.subject setObject:@"Test" forKey:@"TestKey"];
+    
+    XCTAssertNoThrow([self.subject removeAllObjects]);
+    XCTAssertNil([self.subject objectForKey:@"TestKey"]);
+}
+
+- (void)testRemoveObjectNonExistent
+{
+    XCTAssertNoThrow([self.subject removeObjectForKey:@"TestKey"]);
+}
+
+- (void)testRemoveObjectExists
+{
+    [self.subject setObject:@"Test" forKey:@"TestKey"];
+    
+    XCTAssertNoThrow([self.subject removeObjectForKey:@"TestKey"]);
+    XCTAssertNil([self.subject objectForKey:@"TestKey"]);
+}
+
+- (void)testObjectForKeySuperShortExpiry
+{
+    self.subject = [[StatsEphemory alloc] initWithExpiryInterval:-1];
+    
+    [self.subject setObject:@"Test" forKey:@"TestKey"];
+    XCTAssertNil([self.subject objectForKey:@"TestKey"]);
+}
+
+@end

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
@@ -20,7 +20,7 @@
 - (void)setUp {
     [super setUp];
     
-    self.subject = [[WPStatsService alloc] initWithSiteId:@123456 siteTimeZone:[NSTimeZone systemTimeZone] andOAuth2Token:@"token"];
+    self.subject = [[WPStatsService alloc] initWithSiteId:@123456 siteTimeZone:[NSTimeZone systemTimeZone] oauth2Token:@"token" andCacheExpirationInterval:50 * 6];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
Closes #15 

Adds a basic caching mechanism to the WPStatsService. I chose to include the cache `StatsEphemory` at the service layer because it's a form of a persistence mechanism. The implementation detail should not be part of the view controller. I feel like there is room for improvement over the way I've implemented it but it's a simple solution to start with.

At some point having a layer in front of the service makes sense because it can cache stats for multiple sites and persist beyond the somewhat disposable instance of `WPStatsService`.

Pull to refresh forces the cache to evict all items as it's a user-requested force refresh. Tapping between periods and dates will not force a refresh.

cc: @jleandroperez 