### PR TITLE
Fixes for iOS 7 in layout, etc

### DIFF
--- a/StatsDemo/StatsDemo.xcodeproj/project.pbxproj
+++ b/StatsDemo/StatsDemo.xcodeproj/project.pbxproj
@@ -375,7 +375,7 @@
 				GCC_PREFIX_HEADER = "StatsDemo/StatsDemo-Prefix.pch";
 				INFOPLIST_FILE = "StatsDemo/StatsDemo-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "8dfe8c6d-c08d-4a6a-9ab3-3c6231b2dc37";
+				PROVISIONING_PROFILE = "8ca65172-dee4-4364-b45d-021d477411de";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -38,7 +38,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <segmentedControl opaque="NO" tag="100" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Wxx-2G-3HH">
-                                            <rect key="frame" x="15" y="8" width="570" height="29"/>
+                                            <rect key="frame" x="16" y="8" width="569" height="29"/>
                                             <segments>
                                                 <segment title="Days"/>
                                                 <segment title="Weeks"/>
@@ -51,9 +51,9 @@
                                         </segmentedControl>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="Wxx-2G-3HH" firstAttribute="leading" secondItem="xOE-3o-GEM" secondAttribute="leadingMargin" constant="7" id="GbI-5r-G8O"/>
+                                        <constraint firstItem="Wxx-2G-3HH" firstAttribute="leading" secondItem="xOE-3o-GEM" secondAttribute="leadingMargin" priority="750" constant="7" id="8V0-Xe-lc4"/>
                                         <constraint firstAttribute="centerX" secondItem="Wxx-2G-3HH" secondAttribute="centerX" id="SLE-lT-8WB"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="Wxx-2G-3HH" secondAttribute="trailing" constant="7" id="YEJ-mp-7Cl"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="Wxx-2G-3HH" secondAttribute="trailing" priority="750" constant="7" id="Y13-84-qHL"/>
                                         <constraint firstAttribute="centerY" secondItem="Wxx-2G-3HH" secondAttribute="centerY" id="hnS-Rv-3Ln"/>
                                     </constraints>
                                 </tableViewCellContentView>
@@ -64,7 +64,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Group Header Text" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UHc-xu-haN">
-                                            <rect key="frame" x="15" y="11" width="159" height="24"/>
+                                            <rect key="frame" x="15" y="11" width="570" height="24"/>
                                             <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="17"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>
@@ -116,8 +116,8 @@
                                         <constraint firstItem="Gf0-YI-zAr" firstAttribute="baseline" secondItem="G4l-GA-6pv" secondAttribute="baseline" id="1zj-ku-Urv"/>
                                         <constraint firstItem="G4l-GA-6pv" firstAttribute="leading" secondItem="Gf0-YI-zAr" secondAttribute="trailing" constant="10" id="4uN-KB-8Tj"/>
                                         <constraint firstAttribute="centerY" secondItem="Gf0-YI-zAr" secondAttribute="centerY" id="BBV-dU-zgj"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="G4l-GA-6pv" secondAttribute="trailing" constant="8" id="EhP-Gt-kch"/>
-                                        <constraint firstItem="Gf0-YI-zAr" firstAttribute="leading" secondItem="OP0-Uc-wLW" secondAttribute="leadingMargin" constant="7" id="jKx-ja-3XV"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="G4l-GA-6pv" secondAttribute="trailing" priority="750" constant="8" id="EhP-Gt-kch"/>
+                                        <constraint firstItem="Gf0-YI-zAr" firstAttribute="leading" secondItem="OP0-Uc-wLW" secondAttribute="leadingMargin" priority="750" constant="7" id="jKx-ja-3XV"/>
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -148,21 +148,11 @@
                                     <constraints>
                                         <constraint firstAttribute="trailingMargin" secondItem="xSH-fQ-AtQ" secondAttribute="trailing" constant="8" id="0bK-zh-FLZ"/>
                                         <constraint firstAttribute="centerY" secondItem="xSH-fQ-AtQ" secondAttribute="centerY" id="VuV-oq-yHv"/>
-                                        <constraint firstItem="9u9-zI-9kF" firstAttribute="baseline" secondItem="xSH-fQ-AtQ" secondAttribute="baseline" id="Xhi-m2-aeL"/>
                                         <constraint firstAttribute="centerY" secondItem="Mzc-DL-teM" secondAttribute="centerY" id="bb3-1l-H26"/>
-                                        <constraint firstItem="9u9-zI-9kF" firstAttribute="top" secondItem="eBL-g2-naI" secondAttribute="topMargin" constant="-10" id="bo8-0j-rkK"/>
                                         <constraint firstAttribute="centerY" secondItem="9u9-zI-9kF" secondAttribute="centerY" constant="-3" id="fmG-7n-obz"/>
                                         <constraint firstItem="9u9-zI-9kF" firstAttribute="leading" secondItem="eBL-g2-naI" secondAttribute="leadingMargin" constant="7" id="hQO-YO-eDt"/>
-                                        <constraint firstItem="9u9-zI-9kF" firstAttribute="baseline" secondItem="Mzc-DL-teM" secondAttribute="baseline" id="qPy-LI-p68"/>
                                         <constraint firstItem="Mzc-DL-teM" firstAttribute="leading" secondItem="9u9-zI-9kF" secondAttribute="trailing" constant="8" id="sOz-9D-iHH"/>
                                     </constraints>
-                                    <variation key="default">
-                                        <mask key="constraints">
-                                            <exclude reference="Xhi-m2-aeL"/>
-                                            <exclude reference="bo8-0j-rkK"/>
-                                            <exclude reference="qPy-LI-p68"/>
-                                        </mask>
-                                    </variation>
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TwoColumnRow" id="fhY-TT-0EH" userLabel="TwoColumnRow">
@@ -192,19 +182,13 @@
                                     </subviews>
                                     <constraints>
                                         <constraint firstAttribute="centerY" secondItem="GAp-0f-HXa" secondAttribute="centerY" id="ERR-TL-htO"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="Rwp-nF-8c1" secondAttribute="trailing" constant="8" id="Gsf-dz-QkE"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="Rwp-nF-8c1" secondAttribute="trailing" priority="750" constant="8" id="Gsf-dz-QkE"/>
                                         <constraint firstItem="Rwp-nF-8c1" firstAttribute="leading" secondItem="GAp-0f-HXa" secondAttribute="trailing" constant="10" id="RaW-kA-vQK"/>
                                         <constraint firstAttribute="centerY" secondItem="p4X-m5-Nld" secondAttribute="centerY" id="XTA-mJ-ta4"/>
-                                        <constraint firstItem="p4X-m5-Nld" firstAttribute="leading" secondItem="Dnr-8L-jIZ" secondAttribute="leadingMargin" constant="7" id="XsQ-gt-qaQ"/>
+                                        <constraint firstItem="p4X-m5-Nld" firstAttribute="leading" secondItem="Dnr-8L-jIZ" secondAttribute="leadingMargin" priority="750" constant="7" id="XsQ-gt-qaQ"/>
                                         <constraint firstItem="GAp-0f-HXa" firstAttribute="leading" secondItem="p4X-m5-Nld" secondAttribute="trailing" constant="8" id="jMx-Mh-VzX"/>
                                         <constraint firstItem="Rwp-nF-8c1" firstAttribute="baseline" secondItem="GAp-0f-HXa" secondAttribute="baseline" id="mna-l6-qeG"/>
-                                        <constraint firstItem="p4X-m5-Nld" firstAttribute="top" secondItem="Dnr-8L-jIZ" secondAttribute="topMargin" constant="-8" id="oGv-TS-QBX"/>
                                     </constraints>
-                                    <variation key="default">
-                                        <mask key="constraints">
-                                            <exclude reference="oGv-TS-QBX"/>
-                                        </mask>
-                                    </variation>
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MoreRow" id="xct-fr-svw" userLabel="MoreRow">
@@ -239,9 +223,9 @@
                                         </label>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="HmG-gY-rM9" firstAttribute="leading" secondItem="vYe-7i-oUA" secondAttribute="leadingMargin" constant="7" id="KjH-vZ-SLf"/>
+                                        <constraint firstItem="HmG-gY-rM9" firstAttribute="leading" secondItem="vYe-7i-oUA" secondAttribute="leadingMargin" priority="750" constant="7" id="KjH-vZ-SLf"/>
                                         <constraint firstAttribute="centerY" secondItem="HmG-gY-rM9" secondAttribute="centerY" id="Upi-Im-2C4"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="HmG-gY-rM9" secondAttribute="trailing" constant="7" id="fAp-db-GbW"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="HmG-gY-rM9" secondAttribute="trailing" priority="750" constant="7" id="fAp-db-GbW"/>
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -264,17 +248,11 @@
                                         </label>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="bottomMargin" secondItem="Kg0-Ed-1Km" secondAttribute="bottom" constant="7" id="6uY-Ac-ucE"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="Kg0-Ed-1Km" secondAttribute="trailing" constant="7" id="CTF-PN-wBx"/>
-                                        <constraint firstItem="Kg0-Ed-1Km" firstAttribute="top" secondItem="0Bj-bw-PZy" secondAttribute="topMargin" constant="7" id="cHY-4n-7mg"/>
-                                        <constraint firstAttribute="bottomMargin" secondItem="Kg0-Ed-1Km" secondAttribute="bottom" constant="31" id="iH9-GS-iSc"/>
-                                        <constraint firstItem="Kg0-Ed-1Km" firstAttribute="leading" secondItem="0Bj-bw-PZy" secondAttribute="leadingMargin" constant="7" id="vxP-2u-x6G"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="Kg0-Ed-1Km" secondAttribute="bottom" priority="750" constant="7" id="6uY-Ac-ucE"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="Kg0-Ed-1Km" secondAttribute="trailing" priority="750" constant="7" id="CTF-PN-wBx"/>
+                                        <constraint firstItem="Kg0-Ed-1Km" firstAttribute="top" secondItem="0Bj-bw-PZy" secondAttribute="topMargin" priority="750" constant="7" id="cHY-4n-7mg"/>
+                                        <constraint firstItem="Kg0-Ed-1Km" firstAttribute="leading" secondItem="0Bj-bw-PZy" secondAttribute="leadingMargin" priority="750" constant="7" id="vxP-2u-x6G"/>
                                     </constraints>
-                                    <variation key="default">
-                                        <mask key="constraints">
-                                            <exclude reference="iH9-GS-iSc"/>
-                                        </mask>
-                                    </variation>
                                 </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>
@@ -288,7 +266,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Q7L-pU-m4M" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1920" y="102"/>
+            <point key="canvasLocation" x="1920" y="98"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="2Kt-k2-d36">

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -168,7 +168,7 @@
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" verticalHuggingPriority="251" text="Example Label Goes Here" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GAp-0f-HXa">
-                                            <rect key="frame" x="43" y="11" width="488" height="21"/>
+                                            <rect key="frame" x="43" y="11" width="179" height="21"/>
                                             <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="15"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>
@@ -183,7 +183,7 @@
                                     <constraints>
                                         <constraint firstAttribute="centerY" secondItem="GAp-0f-HXa" secondAttribute="centerY" id="ERR-TL-htO"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="Rwp-nF-8c1" secondAttribute="trailing" constant="8" id="Gsf-dz-QkE"/>
-                                        <constraint firstItem="Rwp-nF-8c1" firstAttribute="leading" secondItem="GAp-0f-HXa" secondAttribute="trailing" constant="10" id="RaW-kA-vQK"/>
+                                        <constraint firstItem="Rwp-nF-8c1" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="GAp-0f-HXa" secondAttribute="trailing" constant="10" id="RaW-kA-vQK"/>
                                         <constraint firstAttribute="centerY" secondItem="p4X-m5-Nld" secondAttribute="centerY" id="XTA-mJ-ta4"/>
                                         <constraint firstItem="p4X-m5-Nld" firstAttribute="leading" secondItem="Dnr-8L-jIZ" secondAttribute="leadingMargin" constant="7" id="XsQ-gt-qaQ"/>
                                         <constraint firstItem="GAp-0f-HXa" firstAttribute="leading" secondItem="p4X-m5-Nld" secondAttribute="trailing" constant="8" id="jMx-Mh-VzX"/>
@@ -248,10 +248,10 @@
                                         </label>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="bottomMargin" secondItem="Kg0-Ed-1Km" secondAttribute="bottom" priority="750" constant="7" id="6uY-Ac-ucE"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="Kg0-Ed-1Km" secondAttribute="trailing" priority="750" constant="7" id="CTF-PN-wBx"/>
-                                        <constraint firstItem="Kg0-Ed-1Km" firstAttribute="top" secondItem="0Bj-bw-PZy" secondAttribute="topMargin" priority="750" constant="7" id="cHY-4n-7mg"/>
-                                        <constraint firstItem="Kg0-Ed-1Km" firstAttribute="leading" secondItem="0Bj-bw-PZy" secondAttribute="leadingMargin" priority="750" constant="7" id="vxP-2u-x6G"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="Kg0-Ed-1Km" secondAttribute="bottom" constant="7" id="6uY-Ac-ucE"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="Kg0-Ed-1Km" secondAttribute="trailing" constant="7" id="CTF-PN-wBx"/>
+                                        <constraint firstItem="Kg0-Ed-1Km" firstAttribute="top" secondItem="0Bj-bw-PZy" secondAttribute="topMargin" constant="7" id="cHY-4n-7mg"/>
+                                        <constraint firstItem="Kg0-Ed-1Km" firstAttribute="leading" secondItem="0Bj-bw-PZy" secondAttribute="leadingMargin" constant="7" id="vxP-2u-x6G"/>
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -182,10 +182,10 @@
                                     </subviews>
                                     <constraints>
                                         <constraint firstAttribute="centerY" secondItem="GAp-0f-HXa" secondAttribute="centerY" id="ERR-TL-htO"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="Rwp-nF-8c1" secondAttribute="trailing" priority="750" constant="8" id="Gsf-dz-QkE"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="Rwp-nF-8c1" secondAttribute="trailing" constant="8" id="Gsf-dz-QkE"/>
                                         <constraint firstItem="Rwp-nF-8c1" firstAttribute="leading" secondItem="GAp-0f-HXa" secondAttribute="trailing" constant="10" id="RaW-kA-vQK"/>
                                         <constraint firstAttribute="centerY" secondItem="p4X-m5-Nld" secondAttribute="centerY" id="XTA-mJ-ta4"/>
-                                        <constraint firstItem="p4X-m5-Nld" firstAttribute="leading" secondItem="Dnr-8L-jIZ" secondAttribute="leadingMargin" priority="750" constant="7" id="XsQ-gt-qaQ"/>
+                                        <constraint firstItem="p4X-m5-Nld" firstAttribute="leading" secondItem="Dnr-8L-jIZ" secondAttribute="leadingMargin" constant="7" id="XsQ-gt-qaQ"/>
                                         <constraint firstItem="GAp-0f-HXa" firstAttribute="leading" secondItem="p4X-m5-Nld" secondAttribute="trailing" constant="8" id="jMx-Mh-VzX"/>
                                         <constraint firstItem="Rwp-nF-8c1" firstAttribute="baseline" secondItem="GAp-0f-HXa" secondAttribute="baseline" id="mna-l6-qeG"/>
                                     </constraints>

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -190,6 +190,13 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     NSString *cellIdentifier = [self cellIdentifierForIndexPath:indexPath];
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:cellIdentifier forIndexPath:indexPath];
     
+    // Tweak for Storyboards in iOS 8 SDK breaking constraints in iOS 7
+    // Taken from: http://stackoverflow.com/questions/19132908/auto-layout-constraints-issue-on-ios7-in-uitableviewcell
+    if (NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1) {
+        cell.contentView.frame = cell.bounds;
+        cell.contentView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin |UIViewAutoresizingFlexibleTopMargin |UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleBottomMargin;
+    }
+    
     [self configureCell:cell forIndexPath:indexPath];
     
     return cell;

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -192,7 +192,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     
     // Tweak for Storyboards in iOS 8 SDK breaking constraints in iOS 7
     // Taken from: http://stackoverflow.com/questions/19132908/auto-layout-constraints-issue-on-ios7-in-uitableviewcell
-    if (NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1) {
+    if (NSFoundationVersionNumber <= NSFoundationVersionNumber_iOS_7_1 && !CGRectEqualToRect(cell.bounds, cell.contentView.frame)) {
         cell.contentView.frame = cell.bounds;
         cell.contentView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin |UIViewAutoresizingFlexibleTopMargin |UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleBottomMargin;
     }

--- a/WordPressCom-Stats-iOS/WPStatsGraphViewController.h
+++ b/WordPressCom-Stats-iOS/WPStatsGraphViewController.h
@@ -20,6 +20,7 @@
 
 @optional
 
+- (BOOL)statsGraphViewController:(WPStatsGraphViewController *)controller shouldSelectDate:(NSDate *)date;
 - (void)statsGraphViewController:(WPStatsGraphViewController *)controller didSelectDate:(NSDate *)date;
 - (void)statsGraphViewControllerDidDeselectAllBars:(WPStatsGraphViewController *)controller;
 

--- a/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
@@ -79,6 +79,16 @@ static NSInteger const RecommendedYAxisTicks = 7;
     return self.allowDeselection;
 }
 
+- (BOOL)collectionView:(UICollectionView *)collectionView shouldSelectItemAtIndexPath:(NSIndexPath *)indexPath
+{
+    if ([self.graphDelegate respondsToSelector:@selector(statsGraphViewController:shouldSelectDate:)]) {
+        StatsSummary *summary = (StatsSummary *)self.visits.statsData[indexPath.row];
+        return [self.graphDelegate statsGraphViewController:self shouldSelectDate:summary.date];
+    }
+    
+    return YES;
+}
+
 - (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath
 {
     NSArray *selectedIndexPaths = [collectionView indexPathsForSelectedItems];

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -386,7 +386,7 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
         return @"";
     }
     
-    NSCalendar *calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     NSDate *now = [NSDate date];
     
     NSDateComponents *dateComponents = [calendar components:NSCalendarUnitHour | NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear
@@ -416,7 +416,7 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
 
 - (NSDate *)calculateEndDateForPeriodUnit:(StatsPeriodUnit)unit withDateWithinPeriod:(NSDate *)date
 {
-    NSCalendar *calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
 
     if (unit == StatsPeriodUnitDay) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -1148,7 +1148,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         return date;
     }
     
-    NSCalendar *calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     
     if (unit == StatsPeriodUnitMonth) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth fromDate:date];


### PR DESCRIPTION
Closes #112 

Fixes some problems with the table refresh animation (in both iOS 7 and 8) and also alignment warnings with autolayout in iOS 7.  Also snuck in a change to prevent the graph from being tapped on while a download is occurring.  I added the network indicator to show there is something happening but there needs to be a better user experience for a downloading state.