### PR TITLE
Don't block the UI during fetch

### DIFF
--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -87,7 +87,9 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
     
     NSDate *endDate = [self calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
     NSMutableDictionary *cacheDictionary = [self.ephemory objectForKey:@[@(unit), endDate]];
-    if (cacheDictionary) {
+    DDLogVerbose(@"Cache count: %@", @(cacheDictionary.count));
+    
+    if (cacheDictionary && cacheDictionary.count == 13) {
         if (visitsCompletion) {
             visitsCompletion(cacheDictionary[@(StatsCacheVisits)], nil);
         }
@@ -148,6 +150,7 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
         [self.ephemory setObject:cacheDictionary forKey:@[@(unit), endDate]];
     }
 
+    [self.remote cancelAllRemoteOperations];
     [self.remote batchFetchStatsForDate:endDate
                                 andUnit:unit
             withVisitsCompletionHandler:^(StatsVisits *visits, NSError *error)

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
@@ -95,4 +95,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (void)fetchPublicizeStatsForDate:(NSDate *)date
                            andUnit:(StatsPeriodUnit)unit
              withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
+
+- (void)cancelAllRemoteOperations;
+
 @end

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -123,12 +123,17 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     NSArray *operations = [AFURLConnectionOperation batchOfRequestOperations:mutableOperations progressBlock:^(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations) {
         DDLogVerbose(@"Finished remote operations %@ of %@", @(numberOfFinishedOperations), @(totalNumberOfOperations));
     } completionBlock:^(NSArray *operations) {
-        if (completionHandler) {
+        BOOL zeroOperationsCancelled = [operations filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"isCancelled == YES"]].count == 0;
+        if (!zeroOperationsCancelled) {
+            DDLogWarn(@"At least one operation was cancelled - skipping the completion handler");
+        }
+        
+        if (completionHandler && zeroOperationsCancelled) {
             completionHandler();
         }
     }];
     
-    [[NSOperationQueue mainQueue] addOperations:operations waitUntilFinished:NO];
+    [self.manager.operationQueue addOperations:operations waitUntilFinished:NO];
 }
 
 - (void)fetchSummaryStatsForDate:(NSDate *)date
@@ -1183,6 +1188,17 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     }
     
     return nil;
+}
+
+
+- (void)cancelAllRemoteOperations
+{
+    if (self.manager.operationQueue.operationCount == 0) {
+        return;
+    }
+    
+    DDLogVerbose(@"Canceling %@ operations...", @(self.manager.operationQueue.operationCount));
+    [self.manager.operationQueue cancelAllOperations];
 }
 
 


### PR DESCRIPTION
Closes #124 

Don't block the UI during fetch - instead cancel pending remote operations. If the data is fully cached for a particular date/period then display the results. If there is an incomplete result set cached then refetch the entire result.