### PR TITLE
Graph bars didn't always load properly

### DIFF
--- a/WordPressCom-Stats-iOS/StatsSummary.h
+++ b/WordPressCom-Stats-iOS/StatsSummary.h
@@ -24,4 +24,9 @@ typedef NS_ENUM(NSInteger, StatsSummaryType) {
 @property (nonatomic, strong) NSString *likes;
 @property (nonatomic, strong) NSString *comments;
 
+@property (nonatomic, strong) NSNumber *viewsValue;
+@property (nonatomic, strong) NSNumber *visitorsValue;
+@property (nonatomic, strong) NSNumber *likesValue;
+@property (nonatomic, strong) NSNumber *commentsValue;
+
 @end

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -805,6 +805,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     
     self.graphViewController.currentSummaryType = self.selectedSummaryType;
     self.graphViewController.visits = visits;
+    [self.graphViewController doneSettingProperties];
     [self.graphViewController.collectionView reloadData];
     [self.graphViewController selectGraphBarWithDate:self.selectedDate];
 }

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -805,7 +805,6 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     
     self.graphViewController.currentSummaryType = self.selectedSummaryType;
     self.graphViewController.visits = visits;
-    self.graphViewController.currentUnit = self.selectedPeriodUnit;
     [self.graphViewController.collectionView reloadData];
     [self.graphViewController selectGraphBarWithDate:self.selectedDate];
 }

--- a/WordPressCom-Stats-iOS/WPStatsGraphViewController.h
+++ b/WordPressCom-Stats-iOS/WPStatsGraphViewController.h
@@ -8,7 +8,6 @@
 
 @property (nonatomic, weak) id<WPStatsGraphViewControllerDelegate> graphDelegate;
 @property (nonatomic, strong) StatsVisits *visits;
-@property (nonatomic, assign) StatsPeriodUnit currentUnit;
 @property (nonatomic, assign) StatsSummaryType currentSummaryType;
 @property (nonatomic, assign) BOOL allowDeselection; // defaults to YES
 

--- a/WordPressCom-Stats-iOS/WPStatsGraphViewController.h
+++ b/WordPressCom-Stats-iOS/WPStatsGraphViewController.h
@@ -12,6 +12,7 @@
 @property (nonatomic, assign) BOOL allowDeselection; // defaults to YES
 
 - (void)selectGraphBarWithDate:(NSDate *)selectedDate;
+- (void)doneSettingProperties;
 
 @end
 

--- a/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
@@ -244,16 +244,16 @@ static NSInteger const RecommendedYAxisTicks = 7;
     NSNumber *value = nil;
     switch (self.currentSummaryType) {
         case StatsSummaryTypeViews:
-            value = @([summary.views integerValue]);
+            value = @([summary.viewsValue integerValue]);
             break;
         case StatsSummaryTypeVisitors:
-            value = @([summary.visitors integerValue]);
+            value = @([summary.visitorsValue integerValue]);
             break;
         case StatsSummaryTypeComments:
-            value = @([summary.comments integerValue]);
+            value = @([summary.commentsValue integerValue]);
             break;
         case StatsSummaryTypeLikes:
-            value = @([summary.likes integerValue]);
+            value = @([summary.likesValue integerValue]);
             break;
     }
 

--- a/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
@@ -35,7 +35,6 @@ static NSInteger const RecommendedYAxisTicks = 7;
         _numberOfYValues = 7;
         _maximumY = 0;
         _allowDeselection = YES;
-        _currentUnit = StatsPeriodUnitDay;
         _currentSummaryType = StatsSummaryTypeViews;
     }
     return self;

--- a/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
@@ -183,17 +183,8 @@ static NSInteger const RecommendedYAxisTicks = 7;
     }
 }
 
-#pragma mark - Property methods
-
-- (void)setVisits:(StatsVisits *)visits
+- (void)doneSettingProperties
 {
-    _visits = visits;
-    [self calculateMaximumYValue];
-}
-
-- (void)setCurrentUnit:(StatsPeriodUnit)currentUnit
-{
-    _currentUnit = currentUnit;
     [self calculateMaximumYValue];
 }
 

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -276,9 +276,13 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         statsSummary.date = [self deviceLocalDateForString:statsSummaryDict[@"date"] withPeriodUnit:unit];
         statsSummary.label = [self nicePointNameForDate:statsSummary.date forStatsPeriodUnit:statsSummary.periodUnit];
         statsSummary.views = [self localizedStringForNumber:[statsSummaryDict numberForKey:@"views"]];
+        statsSummary.viewsValue = [statsSummaryDict numberForKey:@"views"];
         statsSummary.visitors = [self localizedStringForNumber:[statsSummaryDict numberForKey:@"visitors"]];
+        statsSummary.visitorsValue = [statsSummaryDict numberForKey:@"visitors"];
         statsSummary.likes = [self localizedStringForNumber:[statsSummaryDict numberForKey:@"likes"]];
+        statsSummary.likesValue = [statsSummaryDict numberForKey:@"likes"];
         statsSummary.comments = [self localizedStringForNumber:[statsSummaryDict numberForKey:@"comments"]];
+        statsSummary.commentsValue = [statsSummaryDict numberForKey:@"comments"];
         
         if (completionHandler) {
             completionHandler(statsSummary, nil);
@@ -324,9 +328,13 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
             periodSummary.date = [self deviceLocalDateForString:period[periodIndex] withPeriodUnit:unit];
             periodSummary.label = [self nicePointNameForDate:periodSummary.date forStatsPeriodUnit:periodSummary.periodUnit];
             periodSummary.views = [self localizedStringForNumber:period[viewsIndex]];
+            periodSummary.viewsValue = period[viewsIndex];
             periodSummary.visitors = [self localizedStringForNumber:period[visitorsIndex]];
+            periodSummary.visitorsValue = period[visitorsIndex];
             periodSummary.likes = [self localizedStringForNumber:period[likesIndex]];
+            periodSummary.likesValue = period[likesIndex];
             periodSummary.comments = [self localizedStringForNumber:period[commentsIndex]];
+            periodSummary.commentsValue = period[commentsIndex];
             [array addObject:periodSummary];
             dictionary[periodSummary.date] = periodSummary;
         }

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -348,7 +348,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     // TODO :: Abstract this out to the local service
-    NSNumber *quantity = IS_IPAD ? @12 : @7;
+    NSNumber *quantity = IS_IPAD ? @12 : @5;
     NSDictionary *parameters = @{@"quantity" : quantity,
                                  @"unit"     : [self stringForPeriodUnit:unit],
                                  @"date"     : [self siteLocalStringForDate:date]};


### PR DESCRIPTION
Resolves #122 

When the values for a particular period had a comma (or period depending on locale) the graph bars wouldn't always render properly. The numeric value is needed for bar calculation so `StatsSummary` was updated to include the original non-localized value.  This should resolve a lot of the weirdness seen in the graph rendering.