### PR TITLE
Styling below graph

### DIFF
--- a/StatsDemo/StatsDemo/StatsDemo Internal-Info.plist
+++ b/StatsDemo/StatsDemo/StatsDemo Internal-Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -34,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>7</string>
+	<string>8</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIAppFonts</key>
@@ -64,5 +62,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>

--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		936B2251195C48700058C828 /* WPStatsGraphBarCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B2250195C48700058C828 /* WPStatsGraphBarCell.m */; };
 		936B2254195CB2FE0058C828 /* WPStyleGuide+Stats.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B2253195CB2FE0058C828 /* WPStyleGuide+Stats.m */; };
 		936E74A41A688E6F0048F552 /* StatsSelectableTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */; };
+		936E74A71A69A8990048F552 /* StatsTableSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 936E74A61A69A8990048F552 /* StatsTableSectionHeaderView.m */; };
 		9389C94E197EBBAF0036D437 /* WPStatsGraphToastView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9389C94D197EBBAF0036D437 /* WPStatsGraphToastView.m */; };
 		9396CFB31921096A006A66D7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9396CFB21921096A006A66D7 /* Foundation.framework */; };
 		9396CFC11921096B006A66D7 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9396CFC01921096B006A66D7 /* XCTest.framework */; };
@@ -132,6 +133,8 @@
 		936B2253195CB2FE0058C828 /* WPStyleGuide+Stats.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WPStyleGuide+Stats.m"; sourceTree = "<group>"; };
 		936E74A21A688E6F0048F552 /* StatsSelectableTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsSelectableTableViewCell.h; sourceTree = "<group>"; };
 		936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsSelectableTableViewCell.m; sourceTree = "<group>"; };
+		936E74A51A69A8990048F552 /* StatsTableSectionHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsTableSectionHeaderView.h; sourceTree = "<group>"; };
+		936E74A61A69A8990048F552 /* StatsTableSectionHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsTableSectionHeaderView.m; sourceTree = "<group>"; };
 		9383180E1994F701003B953A /* WordPressCom-Stats-iOSTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WordPressCom-Stats-iOSTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		9389C94C197EBBAF0036D437 /* WPStatsGraphToastView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPStatsGraphToastView.h; sourceTree = "<group>"; };
 		9389C94D197EBBAF0036D437 /* WPStatsGraphToastView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPStatsGraphToastView.m; sourceTree = "<group>"; };
@@ -332,6 +335,8 @@
 				939A83091A6703E00041B68A /* WPStatsContainerViewController.m */,
 				936E74A21A688E6F0048F552 /* StatsSelectableTableViewCell.h */,
 				936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */,
+				936E74A51A69A8990048F552 /* StatsTableSectionHeaderView.h */,
+				936E74A61A69A8990048F552 /* StatsTableSectionHeaderView.m */,
 			);
 			name = UI;
 			sourceTree = "<group>";
@@ -547,6 +552,7 @@
 				9340980D1A5C83A00005DF06 /* StatsEphemory.m in Sources */,
 				9326EC011A60765B00FA4DAB /* WPStatsViewController.m in Sources */,
 				936B2251195C48700058C828 /* WPStatsGraphBarCell.m in Sources */,
+				936E74A71A69A8990048F552 /* StatsTableSectionHeaderView.m in Sources */,
 				936E74A41A688E6F0048F552 /* StatsSelectableTableViewCell.m in Sources */,
 				93302C521A1BD78300B49CFC /* WPStatsService.m in Sources */,
 				936B22481958C3840058C828 /* WPStatsGraphViewController.m in Sources */,

--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		936B224E195AFD380058C828 /* WPStatsGraphLegendView.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B224D195AFD380058C828 /* WPStatsGraphLegendView.m */; };
 		936B2251195C48700058C828 /* WPStatsGraphBarCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B2250195C48700058C828 /* WPStatsGraphBarCell.m */; };
 		936B2254195CB2FE0058C828 /* WPStyleGuide+Stats.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B2253195CB2FE0058C828 /* WPStyleGuide+Stats.m */; };
+		936E74A41A688E6F0048F552 /* StatsSelectableTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */; };
 		9389C94E197EBBAF0036D437 /* WPStatsGraphToastView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9389C94D197EBBAF0036D437 /* WPStatsGraphToastView.m */; };
 		9396CFB31921096A006A66D7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9396CFB21921096A006A66D7 /* Foundation.framework */; };
 		9396CFC11921096B006A66D7 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9396CFC01921096B006A66D7 /* XCTest.framework */; };
@@ -129,6 +130,8 @@
 		936B2250195C48700058C828 /* WPStatsGraphBarCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPStatsGraphBarCell.m; sourceTree = "<group>"; };
 		936B2252195CB2FE0058C828 /* WPStyleGuide+Stats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPStyleGuide+Stats.h"; sourceTree = "<group>"; };
 		936B2253195CB2FE0058C828 /* WPStyleGuide+Stats.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WPStyleGuide+Stats.m"; sourceTree = "<group>"; };
+		936E74A21A688E6F0048F552 /* StatsSelectableTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsSelectableTableViewCell.h; sourceTree = "<group>"; };
+		936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsSelectableTableViewCell.m; sourceTree = "<group>"; };
 		9383180E1994F701003B953A /* WordPressCom-Stats-iOSTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WordPressCom-Stats-iOSTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		9389C94C197EBBAF0036D437 /* WPStatsGraphToastView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPStatsGraphToastView.h; sourceTree = "<group>"; };
 		9389C94D197EBBAF0036D437 /* WPStatsGraphToastView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPStatsGraphToastView.m; sourceTree = "<group>"; };
@@ -327,6 +330,8 @@
 				936B2253195CB2FE0058C828 /* WPStyleGuide+Stats.m */,
 				939A83081A6703E00041B68A /* WPStatsContainerViewController.h */,
 				939A83091A6703E00041B68A /* WPStatsContainerViewController.m */,
+				936E74A21A688E6F0048F552 /* StatsSelectableTableViewCell.h */,
+				936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */,
 			);
 			name = UI;
 			sourceTree = "<group>";
@@ -542,6 +547,7 @@
 				9340980D1A5C83A00005DF06 /* StatsEphemory.m in Sources */,
 				9326EC011A60765B00FA4DAB /* WPStatsViewController.m in Sources */,
 				936B2251195C48700058C828 /* WPStatsGraphBarCell.m in Sources */,
+				936E74A41A688E6F0048F552 /* StatsSelectableTableViewCell.m in Sources */,
 				93302C521A1BD78300B49CFC /* WPStatsService.m in Sources */,
 				936B22481958C3840058C828 /* WPStatsGraphViewController.m in Sources */,
 				93FABB831A126DC5000C15ED /* StatsTableViewController.m in Sources */,

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -27,39 +27,14 @@
         <scene sceneID="1Ph-TU-kpl">
             <objects>
                 <tableViewController storyboardIdentifier="StatsTableViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Tay-X0-ceG" userLabel="Stats TableView Controller" customClass="StatsTableViewController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" allowsMultipleSelection="YES" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="UJ3-1G-p8v">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" allowsMultipleSelection="YES" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="UJ3-1G-p8v">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="492"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.90980392156862744" green="0.94117647058823528" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="separatorColor" red="0.90980392156862744" green="0.94117647058823528" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="PeriodSelector" id="y6t-fT-X57" userLabel="PeriodSelector">
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="y6t-fT-X57" id="xOE-3o-GEM">
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <segmentedControl opaque="NO" tag="100" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Wxx-2G-3HH">
-                                            <rect key="frame" x="15" y="8" width="570" height="29"/>
-                                            <segments>
-                                                <segment title="Days"/>
-                                                <segment title="Weeks"/>
-                                                <segment title="Months"/>
-                                                <segment title="Years"/>
-                                            </segments>
-                                            <connections>
-                                                <action selector="periodUnitControlDidChange:" destination="Tay-X0-ceG" eventType="valueChanged" id="o13-S3-E1c"/>
-                                            </connections>
-                                        </segmentedControl>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstItem="Wxx-2G-3HH" firstAttribute="leading" secondItem="xOE-3o-GEM" secondAttribute="leadingMargin" constant="7" id="GbI-5r-G8O"/>
-                                        <constraint firstAttribute="centerX" secondItem="Wxx-2G-3HH" secondAttribute="centerX" id="SLE-lT-8WB"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="Wxx-2G-3HH" secondAttribute="trailing" constant="7" id="YEJ-mp-7Cl"/>
-                                        <constraint firstAttribute="centerY" secondItem="Wxx-2G-3HH" secondAttribute="centerY" id="hnS-Rv-3Ln"/>
-                                    </constraints>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupHeader" id="Ex4-nH-VUK">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupHeader" id="Ex4-nH-VUK" customClass="WPTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ex4-nH-VUK" id="aL3-p0-bNa">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -73,7 +48,7 @@
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupSelector" id="vr8-L0-G3G" userLabel="GroupSelector">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupSelector" id="vr8-L0-G3G" userLabel="GroupSelector" customClass="WPTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="vr8-L0-G3G" id="0qW-oh-xTV">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -95,7 +70,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TwoColumnHeader" id="zkK-fE-70Y">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TwoColumnHeader" id="zkK-fE-70Y" customClass="WPTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zkK-fE-70Y" id="OP0-Uc-wLW">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -169,7 +144,7 @@
                                     <outlet property="valueLabel" destination="xSH-fQ-AtQ" id="VCq-qK-HKI"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TwoColumnRow" id="fhY-TT-0EH" userLabel="TwoColumnRow">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TwoColumnRow" id="fhY-TT-0EH" userLabel="TwoColumnRow" customClass="WPTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fhY-TT-0EH" id="Dnr-8L-jIZ">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -211,7 +186,7 @@
                                     </variation>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MoreRow" id="xct-fr-svw" userLabel="MoreRow">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MoreRow" id="xct-fr-svw" userLabel="MoreRow" customClass="WPTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="xct-fr-svw" id="9ex-YE-WVE">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -230,7 +205,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="GroupTotalsRow" id="NuU-bX-mTY" userLabel="GroupTotalsRow">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="GroupTotalsRow" id="NuU-bX-mTY" userLabel="GroupTotalsRow" customClass="WPTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NuU-bX-mTY" id="vYe-7i-oUA">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -249,19 +224,19 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GraphRow" rowHeight="185" id="SNT-we-G8r" userLabel="GraphRow" customClass="StatsSelectableTableViewCell">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GraphRow" rowHeight="185" id="SNT-we-G8r" userLabel="GraphRow" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SNT-we-G8r" id="8Ri-ji-AJb">
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="NoResultsRow" rowHeight="100" id="DDa-Lh-zDs" userLabel="NoResultsRow">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="NoResultsRow" rowHeight="100" id="DDa-Lh-zDs" userLabel="NoResultsRow" customClass="WPTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="DDa-Lh-zDs" id="0Bj-bw-PZy">
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This means no data is present." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kg0-Ed-1Km">
-                                            <rect key="frame" x="15" y="15" width="570" height="69"/>
+                                            <rect key="frame" x="15" y="15" width="570" height="70"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -31,7 +31,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="492"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
-                        <inset key="separatorInset" minX="15" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="PeriodSelector" id="y6t-fT-X57" userLabel="PeriodSelector">
                                 <autoresizingMask key="autoresizingMask"/>
@@ -122,24 +122,24 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="SelectableRow" rowHeight="35" id="MK8-E3-Aa9" customClass="StatsSelectableTableViewCell">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="SelectableRow" id="MK8-E3-Aa9" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="MK8-E3-Aa9" id="eBL-g2-naI">
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9u9-zI-9kF">
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9u9-zI-9kF">
                                             <rect key="frame" x="15" y="-2" width="25" height="44"/>
                                             <fontDescription key="fontDescription" name="Noticons-Regular" family="Noticons" pointSize="25"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" tag="200" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mzc-DL-teM">
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="200" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mzc-DL-teM">
                                             <rect key="frame" x="48" y="5" width="50" height="24"/>
                                             <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="17"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" tag="300" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1000" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xSH-fQ-AtQ">
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="300" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="1000" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xSH-fQ-AtQ">
                                             <rect key="frame" x="545" y="5" width="39" height="24"/>
                                             <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="17"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -34,7 +34,7 @@
                         <color key="separatorColor" red="0.90980392156862744" green="0.94117647058823528" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupHeader" id="Ex4-nH-VUK" customClass="WPTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupHeader" id="Ex4-nH-VUK" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ex4-nH-VUK" id="aL3-p0-bNa">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -48,7 +48,7 @@
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupSelector" id="vr8-L0-G3G" userLabel="GroupSelector" customClass="WPTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupSelector" id="vr8-L0-G3G" userLabel="GroupSelector" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="vr8-L0-G3G" id="0qW-oh-xTV">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -70,7 +70,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TwoColumnHeader" id="zkK-fE-70Y" customClass="WPTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TwoColumnHeader" id="zkK-fE-70Y" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zkK-fE-70Y" id="OP0-Uc-wLW">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -144,7 +144,7 @@
                                     <outlet property="valueLabel" destination="xSH-fQ-AtQ" id="VCq-qK-HKI"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TwoColumnRow" id="fhY-TT-0EH" userLabel="TwoColumnRow" customClass="WPTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TwoColumnRow" id="fhY-TT-0EH" userLabel="TwoColumnRow" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fhY-TT-0EH" id="Dnr-8L-jIZ">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -186,7 +186,7 @@
                                     </variation>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MoreRow" id="xct-fr-svw" userLabel="MoreRow" customClass="WPTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MoreRow" id="xct-fr-svw" userLabel="MoreRow" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="xct-fr-svw" id="9ex-YE-WVE">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -205,7 +205,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="GroupTotalsRow" id="NuU-bX-mTY" userLabel="GroupTotalsRow" customClass="WPTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="GroupTotalsRow" id="NuU-bX-mTY" userLabel="GroupTotalsRow" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NuU-bX-mTY" id="vYe-7i-oUA">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -230,7 +230,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="NoResultsRow" rowHeight="100" id="DDa-Lh-zDs" userLabel="NoResultsRow" customClass="WPTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="NoResultsRow" rowHeight="100" id="DDa-Lh-zDs" userLabel="NoResultsRow" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="DDa-Lh-zDs" id="0Bj-bw-PZy">
                                     <autoresizingMask key="autoresizingMask"/>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -127,20 +127,20 @@
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="MK8-E3-Aa9" id="eBL-g2-naI">
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9u9-zI-9kF">
-                                            <rect key="frame" x="15" y="-2" width="25" height="44"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9u9-zI-9kF">
+                                            <rect key="frame" x="15" y="3" width="25" height="44"/>
                                             <fontDescription key="fontDescription" name="Noticons-Regular" family="Noticons" pointSize="25"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" tag="200" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mzc-DL-teM">
-                                            <rect key="frame" x="48" y="5" width="50" height="24"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="200" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mzc-DL-teM">
+                                            <rect key="frame" x="48" y="10" width="50" height="24"/>
                                             <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="17"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" tag="300" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="1000" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xSH-fQ-AtQ">
-                                            <rect key="frame" x="545" y="5" width="39" height="24"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="300" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1000" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xSH-fQ-AtQ">
+                                            <rect key="frame" x="545" y="10" width="39" height="24"/>
                                             <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="17"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -31,6 +31,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="492"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <inset key="separatorInset" minX="15" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="PeriodSelector" id="y6t-fT-X57" userLabel="PeriodSelector">
                                 <autoresizingMask key="autoresizingMask"/>
@@ -121,7 +122,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="SelectableRow" rowHeight="35" id="MK8-E3-Aa9">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="SelectableRow" rowHeight="35" id="MK8-E3-Aa9" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="MK8-E3-Aa9" id="eBL-g2-naI">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -164,6 +165,9 @@
                                         </mask>
                                     </variation>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="valueLabel" destination="xSH-fQ-AtQ" id="VCq-qK-HKI"/>
+                                </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TwoColumnRow" id="fhY-TT-0EH" userLabel="TwoColumnRow">
                                 <autoresizingMask key="autoresizingMask"/>
@@ -245,7 +249,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GraphRow" rowHeight="185" id="SNT-we-G8r" userLabel="GraphRow">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GraphRow" rowHeight="185" id="SNT-we-G8r" userLabel="GraphRow" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SNT-we-G8r" id="8Ri-ji-AJb">
                                     <autoresizingMask key="autoresizingMask"/>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -30,7 +30,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" allowsMultipleSelection="YES" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="UJ3-1G-p8v">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="492"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" red="0.90980392156862744" green="0.94117647058823528" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="PeriodSelector" id="y6t-fT-X57" userLabel="PeriodSelector">
@@ -130,19 +130,19 @@
                                         <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9u9-zI-9kF">
                                             <rect key="frame" x="15" y="3" width="25" height="44"/>
                                             <fontDescription key="fontDescription" name="Noticons-Regular" family="Noticons" pointSize="25"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="200" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mzc-DL-teM">
                                             <rect key="frame" x="48" y="10" width="50" height="24"/>
                                             <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="17"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.19607843137254902" green="0.25490196078431371" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="300" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1000" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xSH-fQ-AtQ">
                                             <rect key="frame" x="545" y="10" width="39" height="24"/>
                                             <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="17"/>
-                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -327,7 +327,6 @@
                                 </connections>
                             </segmentedControl>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="ENG-tq-nCx" firstAttribute="leading" secondItem="yO0-Lr-iKb" secondAttribute="leading" id="9Zh-6H-jIN"/>
                             <constraint firstItem="ysq-ij-dbS" firstAttribute="top" secondItem="IUN-av-KWH" secondAttribute="bottom" constant="8" id="Baf-6r-wmp"/>

--- a/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface StatsSelectableTableViewCell : UITableViewCell
+
+@property (nonatomic, weak) IBOutlet UILabel *valueLabel;
+
+@end

--- a/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
+#import <WPTableViewCell.h>
 
-@interface StatsSelectableTableViewCell : UITableViewCell
+@interface StatsSelectableTableViewCell : WPTableViewCell
 
 @property (nonatomic, weak) IBOutlet UILabel *valueLabel;
 

--- a/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
@@ -1,6 +1,7 @@
 #import "StatsSelectableTableViewCell.h"
 #import <UIImage+Util.h>
 #import <WPStyleGuide.h>
+#import "WPStyleGuide+Stats.h"
 
 @implementation StatsSelectableTableViewCell
 
@@ -11,7 +12,7 @@
     self.selectedBackgroundView = selectedBackgroundView;
     
     UIView *backgroundView = [[UIView alloc] initWithFrame:self.bounds];
-    backgroundView.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+    backgroundView.backgroundColor = [WPStyleGuide statsUltraLightGray];
     self.backgroundView = backgroundView;
     
     // Remove seperator inset

--- a/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
@@ -45,9 +45,13 @@
 {
     [super layoutSubviews];
     
-    self.theBoxView.frame = CGRectMake(7.0, 0.0, CGRectGetWidth(self.frame) - 14.0, CGRectGetHeight(self.frame));
-    self.contentBackgroundView.frame = CGRectMake(8.0, 0.0, CGRectGetWidth(self.frame) - 16.0, CGRectGetHeight(self.frame));
-    self.dividerView.frame = CGRectMake(CGRectGetMinX(self.contentBackgroundView.frame), CGRectGetHeight(self.frame) - 1.0f, CGRectGetWidth(self.contentBackgroundView.frame), 1.0f);
+    CGFloat borderSidePadding = IS_IPHONE ? RPTVCHorizontalOuterPadding - 1.0f : 0.0f;
+    CGFloat bottomPadding = 1.0f;
+    CGFloat sidePadding = IS_IPHONE ? RPTVCHorizontalOuterPadding : 0.0f;
+
+    self.theBoxView.frame = CGRectMake(borderSidePadding, 0.0, CGRectGetWidth(self.frame) - 2 * borderSidePadding, CGRectGetHeight(self.frame));
+    self.contentBackgroundView.frame = CGRectMake(sidePadding, 0.0, CGRectGetWidth(self.frame) - 2 * sidePadding, CGRectGetHeight(self.frame));
+    self.dividerView.frame = CGRectMake(CGRectGetMinX(self.contentBackgroundView.frame), CGRectGetHeight(self.frame) - bottomPadding, CGRectGetWidth(self.contentBackgroundView.frame), bottomPadding);
 }
 
 @end

--- a/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
@@ -3,33 +3,82 @@
 #import <WPStyleGuide.h>
 #import "WPStyleGuide+Stats.h"
 
+@interface StatsBorderedCellBackgroundView : UIView
+
+- (instancetype)initWithFrame:(CGRect)frame andSelected:(BOOL)selected;
+
+@end
+
+@implementation StatsBorderedCellBackgroundView
+
+- (instancetype)initWithFrame:(CGRect)frame andSelected:(BOOL)selected
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+        self.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin |UIViewAutoresizingFlexibleTopMargin |UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleBottomMargin;
+        
+        UIView *theBoxView = [[UIView alloc] initWithFrame:CGRectZero];
+        theBoxView.translatesAutoresizingMaskIntoConstraints = NO;
+        theBoxView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        theBoxView.backgroundColor = [UIColor colorWithRed:210.0/255.0 green:222.0/255.0 blue:238.0/255.0 alpha:1.0];
+        [self addSubview:theBoxView];
+        
+        UIView *contentBackgroundView = [[UIView alloc] initWithFrame:CGRectZero];
+        contentBackgroundView.translatesAutoresizingMaskIntoConstraints = NO;
+        contentBackgroundView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        contentBackgroundView.backgroundColor = selected ? [UIColor whiteColor] : [WPStyleGuide statsUltraLightGray];
+        [self addSubview:contentBackgroundView];
+        
+        NSNumber *borderSidePadding = IS_IPHONE ? @(RPTVCHorizontalOuterPadding - 1.0f) : @0; // Just to the left of the container
+        NSNumber *borderBottomPadding = @(0);
+        NSNumber *bottomPadding = @(1.0f);
+        NSNumber *sidePadding = IS_IPHONE ? @(RPTVCHorizontalOuterPadding) : @0.0f;
+
+        NSDictionary *metrics =  @{@"borderSidePadding":borderSidePadding,
+                                   @"borderBottomPadding":borderBottomPadding,
+                                   @"sidePadding":sidePadding,
+                                   @"bottomPadding":bottomPadding};
+        
+        NSDictionary *views = NSDictionaryOfVariableBindings(theBoxView, contentBackgroundView);
+        // Border View
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-(borderSidePadding)-[theBoxView]-(borderSidePadding)-|"
+                                                                     options:0
+                                                                     metrics:metrics
+                                                                       views:views]];
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(borderBottomPadding)-[theBoxView]-(borderBottomPadding)-|"
+                                                                     options:0
+                                                                     metrics:metrics
+                                                                       views:views]];
+        
+        // Post View
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-(sidePadding)-[contentBackgroundView]-(sidePadding)-|"
+                                                                     options:0
+                                                                     metrics:metrics
+                                                                       views:views]];
+        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[contentBackgroundView]-(bottomPadding)-|"
+                                                                     options:0
+                                                                     metrics:metrics
+                                                                       views:views]];
+
+    }
+    
+    return self;
+}
+
+@end
+
+@interface StatsSelectableTableViewCell ()
+
+@property (nonatomic, strong) UIView *sideBorderView;
+
+@end
+
 @implementation StatsSelectableTableViewCell
 
 - (void)awakeFromNib {
-    // Initialization code
-    UIView *selectedBackgroundView = [[UIView alloc] initWithFrame:self.bounds];
-    selectedBackgroundView.backgroundColor = [UIColor whiteColor];
-    self.selectedBackgroundView = selectedBackgroundView;
-    
-    UIView *backgroundView = [[UIView alloc] initWithFrame:self.bounds];
-    backgroundView.backgroundColor = [WPStyleGuide statsUltraLightGray];
-    self.backgroundView = backgroundView;
-    
-    // Remove seperator inset
-    if ([self respondsToSelector:@selector(setSeparatorInset:)]) {
-        [self setSeparatorInset:UIEdgeInsetsZero];
-    }
-    
-    // Prevent the cell from inheriting the Table View's margin settings
-    if ([self respondsToSelector:@selector(setPreservesSuperviewLayoutMargins:)]) {
-        [self setPreservesSuperviewLayoutMargins:NO];
-    }
-    
-    // Explictly set your cell's layout margins
-    if ([self respondsToSelector:@selector(setLayoutMargins:)]) {
-        [self setLayoutMargins:UIEdgeInsetsZero];
-    }
-    
+    self.backgroundView = [[StatsBorderedCellBackgroundView alloc] initWithFrame:self.bounds andSelected:NO];
+    self.selectedBackgroundView = [[StatsBorderedCellBackgroundView alloc] initWithFrame:self.bounds andSelected:YES];
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {

--- a/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
@@ -1,0 +1,40 @@
+#import "StatsSelectableTableViewCell.h"
+#import <UIImage+Util.h>
+#import <WPStyleGuide.h>
+
+@implementation StatsSelectableTableViewCell
+
+- (void)awakeFromNib {
+    // Initialization code
+    UIView *selectedBackgroundView = [[UIView alloc] initWithFrame:self.bounds];
+    selectedBackgroundView.backgroundColor = [UIColor whiteColor];
+    self.selectedBackgroundView = selectedBackgroundView;
+    
+    UIView *backgroundView = [[UIView alloc] initWithFrame:self.bounds];
+    backgroundView.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+    self.backgroundView = backgroundView;
+    
+    // Remove seperator inset
+    if ([self respondsToSelector:@selector(setSeparatorInset:)]) {
+        [self setSeparatorInset:UIEdgeInsetsZero];
+    }
+    
+    // Prevent the cell from inheriting the Table View's margin settings
+    if ([self respondsToSelector:@selector(setPreservesSuperviewLayoutMargins:)]) {
+        [self setPreservesSuperviewLayoutMargins:NO];
+    }
+    
+    // Explictly set your cell's layout margins
+    if ([self respondsToSelector:@selector(setLayoutMargins:)]) {
+        [self setLayoutMargins:UIEdgeInsetsZero];
+    }
+    
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+
+@end

--- a/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
@@ -7,6 +7,10 @@
 
 - (instancetype)initWithFrame:(CGRect)frame andSelected:(BOOL)selected;
 
+@property (nonatomic, strong) UIView *theBoxView;
+@property (nonatomic, strong) UIView *contentBackgroundView;
+@property (nonatomic, strong) UIView *dividerView;
+
 @end
 
 @implementation StatsBorderedCellBackgroundView
@@ -16,54 +20,34 @@
     self = [super initWithFrame:frame];
     if (self) {
         self.backgroundColor = [WPStyleGuide itsEverywhereGrey];
-        self.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin |UIViewAutoresizingFlexibleTopMargin |UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleBottomMargin;
         
-        UIView *theBoxView = [[UIView alloc] initWithFrame:CGRectZero];
-        theBoxView.translatesAutoresizingMaskIntoConstraints = NO;
-        theBoxView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        theBoxView.backgroundColor = [UIColor colorWithRed:210.0/255.0 green:222.0/255.0 blue:238.0/255.0 alpha:1.0];
-        [self addSubview:theBoxView];
+        _theBoxView = [[UIView alloc] initWithFrame:CGRectZero];
+        _theBoxView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        _theBoxView.backgroundColor = [UIColor colorWithRed:210.0/255.0 green:222.0/255.0 blue:238.0/255.0 alpha:1.0];
+        [self addSubview:_theBoxView];
         
-        UIView *contentBackgroundView = [[UIView alloc] initWithFrame:CGRectZero];
-        contentBackgroundView.translatesAutoresizingMaskIntoConstraints = NO;
-        contentBackgroundView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        contentBackgroundView.backgroundColor = selected ? [UIColor whiteColor] : [WPStyleGuide statsUltraLightGray];
-        [self addSubview:contentBackgroundView];
+        _contentBackgroundView = [[UIView alloc] initWithFrame:CGRectZero];
+        _contentBackgroundView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        _contentBackgroundView.backgroundColor = selected ? [UIColor whiteColor] : [WPStyleGuide statsUltraLightGray];
+        [self addSubview:_contentBackgroundView];
         
-        NSNumber *borderSidePadding = IS_IPHONE ? @(RPTVCHorizontalOuterPadding - 1.0f) : @0; // Just to the left of the container
-        NSNumber *borderBottomPadding = @(0);
-        NSNumber *bottomPadding = @(1.0f);
-        NSNumber *sidePadding = IS_IPHONE ? @(RPTVCHorizontalOuterPadding) : @0.0f;
-
-        NSDictionary *metrics =  @{@"borderSidePadding":borderSidePadding,
-                                   @"borderBottomPadding":borderBottomPadding,
-                                   @"sidePadding":sidePadding,
-                                   @"bottomPadding":bottomPadding};
-        
-        NSDictionary *views = NSDictionaryOfVariableBindings(theBoxView, contentBackgroundView);
-        // Border View
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-(borderSidePadding)-[theBoxView]-(borderSidePadding)-|"
-                                                                     options:0
-                                                                     metrics:metrics
-                                                                       views:views]];
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(borderBottomPadding)-[theBoxView]-(borderBottomPadding)-|"
-                                                                     options:0
-                                                                     metrics:metrics
-                                                                       views:views]];
-        
-        // Post View
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-(sidePadding)-[contentBackgroundView]-(sidePadding)-|"
-                                                                     options:0
-                                                                     metrics:metrics
-                                                                       views:views]];
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[contentBackgroundView]-(bottomPadding)-|"
-                                                                     options:0
-                                                                     metrics:metrics
-                                                                       views:views]];
-
+        _dividerView = [[UIView alloc] initWithFrame:CGRectZero];
+        _dividerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        _dividerView.backgroundColor = [WPStyleGuide statsLightGray];
+        [self addSubview:_dividerView];
     }
     
     return self;
+}
+
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    self.theBoxView.frame = CGRectMake(7.0, 0.0, CGRectGetWidth(self.frame) - 14.0, CGRectGetHeight(self.frame));
+    self.contentBackgroundView.frame = CGRectMake(8.0, 0.0, CGRectGetWidth(self.frame) - 16.0, CGRectGetHeight(self.frame));
+    self.dividerView.frame = CGRectMake(CGRectGetMinX(self.contentBackgroundView.frame), CGRectGetHeight(self.frame) - 1.0f, CGRectGetWidth(self.contentBackgroundView.frame), 1.0f);
 }
 
 @end
@@ -77,8 +61,18 @@
 @implementation StatsSelectableTableViewCell
 
 - (void)awakeFromNib {
+    [super awakeFromNib];
+    
     self.backgroundView = [[StatsBorderedCellBackgroundView alloc] initWithFrame:self.bounds andSelected:NO];
     self.selectedBackgroundView = [[StatsBorderedCellBackgroundView alloc] initWithFrame:self.bounds andSelected:YES];
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    self.backgroundView.frame = self.bounds;
+    self.selectedBackgroundView.frame = self.bounds;
 }
 
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {

--- a/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
@@ -38,7 +38,7 @@
     if (selected) {
         self.valueLabel.textColor = [WPStyleGuide jazzyOrange];
     } else {
-        self.valueLabel.textColor = [UIColor blackColor];
+        self.valueLabel.textColor = [WPStyleGuide littleEddieGrey];
     }
 }
 

--- a/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
@@ -34,7 +34,11 @@
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     [super setSelected:selected animated:animated];
 
-    // Configure the view for the selected state
+    if (selected) {
+        self.valueLabel.textColor = [WPStyleGuide jazzyOrange];
+    } else {
+        self.valueLabel.textColor = [UIColor blackColor];
+    }
 }
 
 @end

--- a/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.h
+++ b/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface StatsTableSectionHeaderView : UITableViewHeaderFooterView
+
+@end

--- a/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.h
+++ b/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.h
@@ -2,4 +2,6 @@
 
 @interface StatsTableSectionHeaderView : UITableViewHeaderFooterView
 
+@property (nonatomic, assign, getter=isFooter) BOOL footer;
+
 @end

--- a/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
+++ b/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
@@ -1,0 +1,40 @@
+#import "StatsTableSectionHeaderView.h"
+#import "WPStyleGuide+Stats.h"
+
+@implementation StatsTableSectionHeaderView
+
+- (instancetype)initWithReuseIdentifier:(NSString *)reuseIdentifier
+{
+    self = [super initWithReuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.contentView.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+        self.contentView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin |UIViewAutoresizingFlexibleTopMargin |UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleBottomMargin;
+        
+        UIView *theBoxView = [[UIView alloc] initWithFrame:CGRectZero];
+        theBoxView.translatesAutoresizingMaskIntoConstraints = NO;
+        theBoxView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        theBoxView.backgroundColor = [UIColor colorWithRed:210.0/255.0 green:222.0/255.0 blue:238.0/255.0 alpha:1.0];
+        [self.contentView addSubview:theBoxView];
+        
+        NSNumber *borderSidePadding = IS_IPHONE ? @(RPTVCHorizontalOuterPadding - 1.0f) : @0; // Just to the left of the container
+        NSNumber *borderBottomPadding = @(0);
+        
+        NSDictionary *metrics =  @{@"borderSidePadding":borderSidePadding,
+                                   @"borderBottomPadding":borderBottomPadding};
+        
+        UIView *contentView = self.contentView;
+        NSDictionary *views = NSDictionaryOfVariableBindings(contentView, theBoxView);
+        // Border View
+        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-(borderSidePadding)-[theBoxView]-(borderSidePadding)-|"
+                                                                                 options:0
+                                                                                 metrics:metrics
+                                                                                   views:views]];
+        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(borderBottomPadding)-[theBoxView]-(borderBottomPadding)-|"
+                                                                                 options:0
+                                                                                 metrics:metrics
+                                                                                   views:views]];
+    }
+    return self;
+}
+
+@end

--- a/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
+++ b/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
@@ -1,40 +1,35 @@
 #import "StatsTableSectionHeaderView.h"
 #import "WPStyleGuide+Stats.h"
 
+@interface StatsTableSectionHeaderView ()
+
+@property (nonatomic, strong) UIView *theBoxView;
+
+@end
+
 @implementation StatsTableSectionHeaderView
 
 - (instancetype)initWithReuseIdentifier:(NSString *)reuseIdentifier
 {
     self = [super initWithReuseIdentifier:reuseIdentifier];
     if (self) {
-        self.contentView.backgroundColor = [WPStyleGuide itsEverywhereGrey];
-        self.contentView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin |UIViewAutoresizingFlexibleTopMargin |UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleBottomMargin;
+        self.contentView.backgroundColor = [WPStyleGuide statsLightGray];
         
-        UIView *theBoxView = [[UIView alloc] initWithFrame:CGRectZero];
-        theBoxView.translatesAutoresizingMaskIntoConstraints = NO;
-        theBoxView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        theBoxView.backgroundColor = [UIColor colorWithRed:210.0/255.0 green:222.0/255.0 blue:238.0/255.0 alpha:1.0];
-        [self.contentView addSubview:theBoxView];
+        _theBoxView = [[UIView alloc] initWithFrame:CGRectZero];
+        _theBoxView.backgroundColor = [UIColor colorWithRed:210.0/255.0 green:222.0/255.0 blue:238.0/255.0 alpha:1.0];
+        [self.contentView addSubview:_theBoxView];
         
-        NSNumber *borderSidePadding = IS_IPHONE ? @(RPTVCHorizontalOuterPadding - 1.0f) : @0; // Just to the left of the container
-        NSNumber *borderBottomPadding = @(0);
-        
-        NSDictionary *metrics =  @{@"borderSidePadding":borderSidePadding,
-                                   @"borderBottomPadding":borderBottomPadding};
-        
-        UIView *contentView = self.contentView;
-        NSDictionary *views = NSDictionaryOfVariableBindings(contentView, theBoxView);
-        // Border View
-        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|-(borderSidePadding)-[theBoxView]-(borderSidePadding)-|"
-                                                                                 options:0
-                                                                                 metrics:metrics
-                                                                                   views:views]];
-        [self.contentView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(borderBottomPadding)-[theBoxView]-(borderBottomPadding)-|"
-                                                                                 options:0
-                                                                                 metrics:metrics
-                                                                                   views:views]];
     }
     return self;
+}
+
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    CGFloat borderSidePadding = IS_IPHONE ? RPTVCHorizontalOuterPadding - 1.0f : 0.0f; // Just to the left of the container
+    self.theBoxView.frame = CGRectMake(borderSidePadding, self.isFooter ? -1.0f : 0.0f, CGRectGetWidth(self.frame) - 2 * borderSidePadding, 1.0f);
 }
 
 @end

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -212,12 +212,24 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
     return headerView;
 }
 
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+{
+    StatsTableSectionHeaderView *footerView = [tableView dequeueReusableHeaderFooterViewWithIdentifier:StatsTableSectionHeaderSimpleBorder];
+    footerView.footer = YES;
+    
+    return footerView;
+}
+
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
     return 1.0f;
 }
 
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+{
+    return 10.0f;
+}
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -802,7 +802,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
         case 1: // Views
         {
             iconLabel.text = @"";
-            textLabel.text = NSLocalizedString(@"Views", @"");
+            textLabel.text = [NSLocalizedString(@"Views", @"") uppercaseStringWithLocale:[NSLocale currentLocale]];
             valueLabel.text = summary.views;
             break;
         }
@@ -810,7 +810,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
         case 2: // Visitors
         {
             iconLabel.text = @"";
-            textLabel.text = NSLocalizedString(@"Visitors", @"");
+            textLabel.text = [NSLocalizedString(@"Visitors", @"") uppercaseStringWithLocale:[NSLocale currentLocale]];
             valueLabel.text = summary.visitors;
             break;
         }
@@ -818,7 +818,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
         case 3: // Likes
         {
             iconLabel.text = @"";
-            textLabel.text = NSLocalizedString(@"Likes", @"");
+            textLabel.text = [NSLocalizedString(@"Likes", @"") uppercaseStringWithLocale:[NSLocale currentLocale]];
             valueLabel.text = summary.likes;
             break;
         }
@@ -826,7 +826,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
         case 4: // Comments
         {
             iconLabel.text = @"";
-            textLabel.text = NSLocalizedString(@"Comments", @"");
+            textLabel.text = [NSLocalizedString(@"Comments", @"") uppercaseStringWithLocale:[NSLocale currentLocale]];
             valueLabel.text = summary.comments;
             break;
         }

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -7,9 +7,9 @@
 #import <WPFontManager.h>
 #import "WPStyleGuide+Stats.h"
 #import <WPImageSource.h>
+#import "StatsTableSectionHeaderView.h"
 
 typedef NS_ENUM(NSInteger, StatsSection) {
-    StatsSectionPeriodSelector,
     StatsSectionGraph,
     StatsSectionEvents,
     StatsSectionPosts,
@@ -36,7 +36,6 @@ static NSInteger const StatsTableRowDataOffsetStandard = 2;
 static NSInteger const StatsTableRowDataOffsetWithoutGroupHeader = 1;
 static NSInteger const StatsTableRowDataOffsetWithGroupSelector = 3;
 static NSInteger const StatsTableRowDataOffsetWithGroupSelectorAndTotal = 4;
-static NSString *const StatsTablePeriodSelectorCellIdentifier = @"PeriodSelector";
 static NSString *const StatsTableGroupHeaderCellIdentifier = @"GroupHeader";
 static NSString *const StatsTableGroupSelectorCellIdentifier = @"GroupSelector";
 static NSString *const StatsTableGroupTotalsCellIdentifier = @"GroupTotalsRow";
@@ -46,6 +45,7 @@ static NSString *const StatsTableGraphSelectableCellIdentifier = @"SelectableRow
 static NSString *const StatsTableViewAllCellIdentifier = @"MoreRow";
 static NSString *const StatsTableGraphCellIdentifier = @"GraphRow";
 static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
+static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSectionHeaderSimpleBorder";
 
 
 @interface StatsTableViewController () <WPStatsGraphViewControllerDelegate>
@@ -69,6 +69,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
 
     self.tableView.tableHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 20.0f)];
     self.tableView.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+    [self.tableView registerClass:[StatsTableSectionHeaderView class] forHeaderFooterViewReuseIdentifier:StatsTableSectionHeaderSimpleBorder];
     
     // Force load fonts from bundle
     [WPFontManager openSansBoldFontOfSize:1.0f];
@@ -144,8 +145,6 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     id data = [self statsDataForStatsSection:statsSection];
     
     switch (statsSection) {
-        case StatsSectionPeriodSelector:
-            return 1;
         case StatsSectionGraph: {
             return 5;
         }
@@ -204,6 +203,21 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
 
 
 #pragma mark - UITableViewDelegate methods
+
+
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+{
+    StatsTableSectionHeaderView *headerView = [tableView dequeueReusableHeaderFooterViewWithIdentifier:StatsTableSectionHeaderSimpleBorder];
+    
+    return headerView;
+}
+
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    return 1.0f;
+}
+
 
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
@@ -611,9 +625,6 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     StatsSection statsSection = [self statsSectionForTableViewSection:indexPath.section];
     
     switch (statsSection) {
-        case StatsSectionPeriodSelector:
-            identifier = StatsTablePeriodSelectorCellIdentifier;
-            break;
         case StatsSectionGraph: {
             switch (indexPath.row) {
                 case 0:
@@ -774,7 +785,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     if (![[cell.contentView subviews] containsObject:self.graphViewController.view]) {
         UIView *graphView = self.graphViewController.view;
         [graphView removeFromSuperview];
-        graphView.frame = CGRectMake(0.0f, 0.0f, CGRectGetWidth(cell.contentView.bounds), StatsTableGraphHeight);
+        graphView.frame = CGRectMake(8.0f, 0.0f, CGRectGetWidth(cell.contentView.bounds) - 16.0f, StatsTableGraphHeight - 1.0);
         graphView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
         [cell.contentView addSubview:graphView];
     }
@@ -1130,7 +1141,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     if ( statsSection == StatsSectionComments || statsSection == StatsSectionFollowers) {
         StatsSubSection selectedSubsection = [self statsSubSectionForStatsSection:statsSection];
         data = self.sectionData[@(statsSection)][@(selectedSubsection)];
-    } else if (statsSection != StatsSectionPeriodSelector) {
+    } else {
         data = self.sectionData[@(statsSection)];
     }
     

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -32,7 +32,6 @@ typedef NS_ENUM(NSInteger, StatsSubSection) {
 
 static CGFloat const StatsTableGraphHeight = 185.0f;
 static CGFloat const StatsTableNoResultsHeight = 100.0f;
-static CGFloat const StatsTableSelectableCellHeight = 35.0f;
 static NSInteger const StatsTableRowDataOffsetStandard = 2;
 static NSInteger const StatsTableRowDataOffsetWithoutGroupHeader = 1;
 static NSInteger const StatsTableRowDataOffsetWithGroupSelector = 3;
@@ -213,8 +212,6 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
         return StatsTableGraphHeight;
     } else if ([cellIdentifier isEqualToString:StatsTableNoResultsCellIdentifier]) {
         return StatsTableNoResultsHeight;
-    } else if ([cellIdentifier isEqualToString:StatsTableGraphSelectableCellIdentifier]) {
-        return StatsTableSelectableCellHeight;
     }
     
     return [super tableView:tableView heightForRowAtIndexPath:indexPath];

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -68,6 +68,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     [super viewDidLoad];
 
     self.tableView.tableHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 20.0f)];
+    self.tableView.backgroundColor = [WPStyleGuide itsEverywhereGrey];
     
     // Force load fonts from bundle
     [WPFontManager openSansBoldFontOfSize:1.0f];

--- a/WordPressCom-Stats-iOS/WPStatsGraphBarCell.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphBarCell.m
@@ -108,7 +108,13 @@
     UILabel *label = [[UILabel alloc] init];
     label.text = text;
     label.font = [WPStyleGuide axisLabelFont];
-    label.textColor = [WPStyleGuide wordPressBlue];
+    
+    if (self.selected) {
+        label.textColor = [WPStyleGuide jazzyOrange];
+    } else {
+        label.textColor = [WPStyleGuide wordPressBlue];
+    }
+
     label.backgroundColor = [UIColor clearColor];
     label.opaque = YES;
     [label sizeToFit];

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
@@ -7,6 +7,7 @@
 + (UIColor *)statsLighterOrangeTransparent;
 + (UIColor *)statsLighterOrange;
 + (UIColor *)statsDarkerOrange;
++ (UIColor *)statsUltraLightGray;
 
 + (UIFont *)subtitleFontBoldItalic;
 

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
@@ -1,5 +1,8 @@
 #import "WPStyleGuide.h"
 
+extern const CGFloat RPTVCHorizontalOuterPadding;
+extern const CGFloat RPTVCVerticalOuterPadding;
+
 @interface WPStyleGuide (Stats)
 
 + (UIFont *)axisLabelFont;

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
@@ -10,6 +10,8 @@ extern const CGFloat RPTVCVerticalOuterPadding;
 + (UIColor *)statsLighterOrangeTransparent;
 + (UIColor *)statsLighterOrange;
 + (UIColor *)statsDarkerOrange;
+
++ (UIColor *)statsLightGray;
 + (UIColor *)statsUltraLightGray;
 
 + (UIFont *)subtitleFontBoldItalic;

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
@@ -22,6 +22,11 @@
     return [self jazzyOrange];
 }
 
++ (UIColor *)statsUltraLightGray
+{
+    return [UIColor colorWithRed:0.957 green:0.973 blue:0.98 alpha:1]; /*#f4f8fa*/
+}
+
 + (UIFont *)subtitleFontBoldItalic
 {
     return [WPFontManager openSansBoldItalicFontOfSize:12.0];

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
@@ -1,6 +1,9 @@
 #import "WPStyleGuide+Stats.h"
 #import <WPFontManager.h>
 
+const CGFloat RPTVCHorizontalOuterPadding = 8.0f;
+const CGFloat RPTVCVerticalOuterPadding = 16.0f;
+
 @implementation WPStyleGuide (Stats)
 
 + (UIFont *)axisLabelFont {

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
@@ -25,6 +25,11 @@ const CGFloat RPTVCVerticalOuterPadding = 16.0f;
     return [self jazzyOrange];
 }
 
++ (UIColor *)statsLightGray
+{
+    return [UIColor colorWithRed:0.91 green:0.941 blue:0.961 alpha:1]; /*#e8f0f5*/
+}
+
 + (UIColor *)statsUltraLightGray
 {
     return [UIColor colorWithRed:0.957 green:0.973 blue:0.98 alpha:1]; /*#f4f8fa*/


### PR DESCRIPTION
Closes #139 & #143 

![2015-01-19_10-38-00](https://cloud.githubusercontent.com/assets/373903/5803881/41917060-9fc7-11e4-98bc-bc28f46aa7f7.png)

Adds a bunch of styling changes to the rows below the graph.