### PR TITLE
Implement View All

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -26,12 +26,12 @@ PODS:
   - CocoaLumberjack/Extensions (1.9.2):
     - CocoaLumberjack/Core
   - NSObject-SafeExpectations (0.0.2)
-  - OCMock (3.1.1)
+  - OCMock (3.1.2)
   - OHHTTPStubs (3.1.1)
   - WordPress-iOS-Shared/Core (0.1.5):
     - AFNetworking (~> 2.3.1)
     - CocoaLumberjack (~> 1.9)
-  - WordPressCom-Analytics-iOS (0.0.14)
+  - WordPressCom-Analytics-iOS (0.0.19)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.3.1)
@@ -46,9 +46,9 @@ SPEC CHECKSUMS:
   AFNetworking: 6d7b76aa5d04c8c37daad3eef4b7e3f2a7620da3
   CocoaLumberjack: 205769c032b5fef85b92472046bcc8b7e7c8a817
   NSObject-SafeExpectations: c31276ef7209016849fc4e5c8ed5ae5453e1e208
-  OCMock: f6cb8c162ab9d5620dddf411282c7b2c0ee78854
+  OCMock: ecdd510b73ef397f2f97274785c1e87fd147c49f
   OHHTTPStubs: 58b42d245ad2416bac170ce18e1383913d17e315
   WordPress-iOS-Shared: e73bf6f68cae64cf054daf246d00db53448e4f37
-  WordPressCom-Analytics-iOS: 93ca6c432c7015f26f1361482ba1e2b839a8b222
+  WordPressCom-Analytics-iOS: a5adb5720c43760f58305712033887947da04eb4
 
 COCOAPODS: 0.35.0

--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -30,7 +30,7 @@ PODS:
   - WordPress-iOS-Shared/Core (0.1.5):
     - AFNetworking (~> 2.3.1)
     - CocoaLumberjack (~> 1.9)
-  - WordPressCom-Analytics-iOS (0.0.14)
+  - WordPressCom-Analytics-iOS (0.0.19)
   - WordPressCom-Stats-iOS (0.1.6):
     - AFNetworking (~> 2.3.1)
     - CocoaLumberjack (~> 1.9)
@@ -52,7 +52,7 @@ SPEC CHECKSUMS:
   HockeySDK: bfd1f5ac75938b07499c4ac12932244b72a2e70b
   NSObject-SafeExpectations: c31276ef7209016849fc4e5c8ed5ae5453e1e208
   WordPress-iOS-Shared: e73bf6f68cae64cf054daf246d00db53448e4f37
-  WordPressCom-Analytics-iOS: 93ca6c432c7015f26f1361482ba1e2b839a8b222
+  WordPressCom-Analytics-iOS: a5adb5720c43760f58305712033887947da04eb4
   WordPressCom-Stats-iOS: fe40df5880d477f441e351bbbd8c29f056ea9bbf
 
 COCOAPODS: 0.35.0

--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		9367D9D11A6E99640033911A /* StatsDateUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9367D9D01A6E99640033911A /* StatsDateUtilitiesTests.m */; };
 		9367D9D41A6EAEBB0033911A /* StatsViewAllTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9367D9D31A6EAEBB0033911A /* StatsViewAllTableViewController.m */; };
 		9367D9D81A6EB5A90033911A /* StatsTwoColumnTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9367D9D71A6EB5A90033911A /* StatsTwoColumnTableViewCell.m */; };
+		9367D9DC1A7018350033911A /* StatsBorderedCellBackgroundView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9367D9DB1A7018350033911A /* StatsBorderedCellBackgroundView.m */; };
+		9367D9DF1A70194D0033911A /* StatsStandardBorderedTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9367D9DE1A70194D0033911A /* StatsStandardBorderedTableViewCell.m */; };
 		936B22481958C3840058C828 /* WPStatsGraphViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B22471958C3840058C828 /* WPStatsGraphViewController.m */; };
 		936B224E195AFD380058C828 /* WPStatsGraphLegendView.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B224D195AFD380058C828 /* WPStatsGraphLegendView.m */; };
 		936B2251195C48700058C828 /* WPStatsGraphBarCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B2250195C48700058C828 /* WPStatsGraphBarCell.m */; };
@@ -135,6 +137,10 @@
 		9367D9D61A6EB5A90033911A /* StatsTwoColumnTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsTwoColumnTableViewCell.h; sourceTree = "<group>"; };
 		9367D9D71A6EB5A90033911A /* StatsTwoColumnTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsTwoColumnTableViewCell.m; sourceTree = "<group>"; };
 		9367D9D91A6EF5690033911A /* StatsSection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StatsSection.h; sourceTree = "<group>"; };
+		9367D9DA1A7018350033911A /* StatsBorderedCellBackgroundView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsBorderedCellBackgroundView.h; sourceTree = "<group>"; };
+		9367D9DB1A7018350033911A /* StatsBorderedCellBackgroundView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsBorderedCellBackgroundView.m; sourceTree = "<group>"; };
+		9367D9DD1A70194D0033911A /* StatsStandardBorderedTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsStandardBorderedTableViewCell.h; sourceTree = "<group>"; };
+		9367D9DE1A70194D0033911A /* StatsStandardBorderedTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsStandardBorderedTableViewCell.m; sourceTree = "<group>"; };
 		936B22461958C3840058C828 /* WPStatsGraphViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPStatsGraphViewController.h; sourceTree = "<group>"; };
 		936B22471958C3840058C828 /* WPStatsGraphViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPStatsGraphViewController.m; sourceTree = "<group>"; };
 		936B224C195AFD380058C828 /* WPStatsGraphLegendView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPStatsGraphLegendView.h; sourceTree = "<group>"; };
@@ -211,6 +217,10 @@
 				936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */,
 				9367D9D61A6EB5A90033911A /* StatsTwoColumnTableViewCell.h */,
 				9367D9D71A6EB5A90033911A /* StatsTwoColumnTableViewCell.m */,
+				9367D9DA1A7018350033911A /* StatsBorderedCellBackgroundView.h */,
+				9367D9DB1A7018350033911A /* StatsBorderedCellBackgroundView.m */,
+				9367D9DD1A70194D0033911A /* StatsStandardBorderedTableViewCell.h */,
+				9367D9DE1A70194D0033911A /* StatsStandardBorderedTableViewCell.m */,
 			);
 			name = Cells;
 			sourceTree = "<group>";
@@ -572,6 +582,7 @@
 				93A379DE19FEA9E400415023 /* StatsItem.m in Sources */,
 				930C2EE8195DB00600C6964D /* WPStatsCollectionViewFlowLayout.m in Sources */,
 				9367D9D81A6EB5A90033911A /* StatsTwoColumnTableViewCell.m in Sources */,
+				9367D9DF1A70194D0033911A /* StatsStandardBorderedTableViewCell.m in Sources */,
 				93274AE41A07C7EA0017238F /* StatsVisits.m in Sources */,
 				93A379E419FEAB8100415023 /* StatsGroup.m in Sources */,
 				9389C94E197EBBAF0036D437 /* WPStatsGraphToastView.m in Sources */,
@@ -582,6 +593,7 @@
 				9367D9D41A6EAEBB0033911A /* StatsViewAllTableViewController.m in Sources */,
 				9326EC011A60765B00FA4DAB /* WPStatsViewController.m in Sources */,
 				936B2251195C48700058C828 /* WPStatsGraphBarCell.m in Sources */,
+				9367D9DC1A7018350033911A /* StatsBorderedCellBackgroundView.m in Sources */,
 				936E74A71A69A8990048F552 /* StatsTableSectionHeaderView.m in Sources */,
 				936E74A41A688E6F0048F552 /* StatsSelectableTableViewCell.m in Sources */,
 				93302C521A1BD78300B49CFC /* WPStatsService.m in Sources */,

--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		93652B7F19FFFC60006A4C47 /* stats-v1.1-summary.json in Resources */ = {isa = PBXBuildFile; fileRef = 93652B7E19FFFC60006A4C47 /* stats-v1.1-summary.json */; };
 		9367D9CF1A6D9D5A0033911A /* StatsDateUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 9367D9CE1A6D9D5A0033911A /* StatsDateUtilities.m */; };
 		9367D9D11A6E99640033911A /* StatsDateUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9367D9D01A6E99640033911A /* StatsDateUtilitiesTests.m */; };
+		9367D9D41A6EAEBB0033911A /* StatsViewAllTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9367D9D31A6EAEBB0033911A /* StatsViewAllTableViewController.m */; };
+		9367D9D81A6EB5A90033911A /* StatsTwoColumnTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9367D9D71A6EB5A90033911A /* StatsTwoColumnTableViewCell.m */; };
 		936B22481958C3840058C828 /* WPStatsGraphViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B22471958C3840058C828 /* WPStatsGraphViewController.m */; };
 		936B224E195AFD380058C828 /* WPStatsGraphLegendView.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B224D195AFD380058C828 /* WPStatsGraphLegendView.m */; };
 		936B2251195C48700058C828 /* WPStatsGraphBarCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B2250195C48700058C828 /* WPStatsGraphBarCell.m */; };
@@ -128,6 +130,11 @@
 		9367D9CD1A6D9D5A0033911A /* StatsDateUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsDateUtilities.h; sourceTree = "<group>"; };
 		9367D9CE1A6D9D5A0033911A /* StatsDateUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsDateUtilities.m; sourceTree = "<group>"; };
 		9367D9D01A6E99640033911A /* StatsDateUtilitiesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsDateUtilitiesTests.m; sourceTree = "<group>"; };
+		9367D9D21A6EAEBB0033911A /* StatsViewAllTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsViewAllTableViewController.h; sourceTree = "<group>"; };
+		9367D9D31A6EAEBB0033911A /* StatsViewAllTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsViewAllTableViewController.m; sourceTree = "<group>"; };
+		9367D9D61A6EB5A90033911A /* StatsTwoColumnTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsTwoColumnTableViewCell.h; sourceTree = "<group>"; };
+		9367D9D71A6EB5A90033911A /* StatsTwoColumnTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsTwoColumnTableViewCell.m; sourceTree = "<group>"; };
+		9367D9D91A6EF5690033911A /* StatsSection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StatsSection.h; sourceTree = "<group>"; };
 		936B22461958C3840058C828 /* WPStatsGraphViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPStatsGraphViewController.h; sourceTree = "<group>"; };
 		936B22471958C3840058C828 /* WPStatsGraphViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPStatsGraphViewController.m; sourceTree = "<group>"; };
 		936B224C195AFD380058C828 /* WPStatsGraphLegendView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPStatsGraphLegendView.h; sourceTree = "<group>"; };
@@ -197,6 +204,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9367D9D51A6EB5770033911A /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				936E74A21A688E6F0048F552 /* StatsSelectableTableViewCell.h */,
+				936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */,
+				9367D9D61A6EB5A90033911A /* StatsTwoColumnTableViewCell.h */,
+				9367D9D71A6EB5A90033911A /* StatsTwoColumnTableViewCell.m */,
+			);
+			name = Cells;
+			sourceTree = "<group>";
+		};
 		936B22491958C65A0058C828 /* Graph */ = {
 			isa = PBXGroup;
 			children = (
@@ -331,20 +349,22 @@
 		9396CFDA19215356006A66D7 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				9367D9D51A6EB5770033911A /* Cells */,
 				936B22491958C65A0058C828 /* Graph */,
 				93FABB7C1A115D90000C15ED /* SiteStats.storyboard */,
+				936E74A51A69A8990048F552 /* StatsTableSectionHeaderView.h */,
+				936E74A61A69A8990048F552 /* StatsTableSectionHeaderView.m */,
 				93FABB811A126DC5000C15ED /* StatsTableViewController.h */,
 				93FABB821A126DC5000C15ED /* StatsTableViewController.m */,
+				9367D9D21A6EAEBB0033911A /* StatsViewAllTableViewController.h */,
+				9367D9D31A6EAEBB0033911A /* StatsViewAllTableViewController.m */,
+				939A83081A6703E00041B68A /* WPStatsContainerViewController.h */,
+				939A83091A6703E00041B68A /* WPStatsContainerViewController.m */,
 				9326EBFF1A60765B00FA4DAB /* WPStatsViewController.h */,
 				9326EC001A60765B00FA4DAB /* WPStatsViewController.m */,
 				936B2252195CB2FE0058C828 /* WPStyleGuide+Stats.h */,
 				936B2253195CB2FE0058C828 /* WPStyleGuide+Stats.m */,
-				939A83081A6703E00041B68A /* WPStatsContainerViewController.h */,
-				939A83091A6703E00041B68A /* WPStatsContainerViewController.m */,
-				936E74A21A688E6F0048F552 /* StatsSelectableTableViewCell.h */,
-				936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */,
-				936E74A51A69A8990048F552 /* StatsTableSectionHeaderView.h */,
-				936E74A61A69A8990048F552 /* StatsTableSectionHeaderView.m */,
+				9367D9D91A6EF5690033911A /* StatsSection.h */,
 			);
 			name = UI;
 			sourceTree = "<group>";
@@ -551,6 +571,7 @@
 			files = (
 				93A379DE19FEA9E400415023 /* StatsItem.m in Sources */,
 				930C2EE8195DB00600C6964D /* WPStatsCollectionViewFlowLayout.m in Sources */,
+				9367D9D81A6EB5A90033911A /* StatsTwoColumnTableViewCell.m in Sources */,
 				93274AE41A07C7EA0017238F /* StatsVisits.m in Sources */,
 				93A379E419FEAB8100415023 /* StatsGroup.m in Sources */,
 				9389C94E197EBBAF0036D437 /* WPStatsGraphToastView.m in Sources */,
@@ -558,6 +579,7 @@
 				930C2EEB195DB4D300C6964D /* WPStatsGraphBackgroundView.m in Sources */,
 				93A379EA19FEDEE100415023 /* WPStatsServiceRemote.m in Sources */,
 				9340980D1A5C83A00005DF06 /* StatsEphemory.m in Sources */,
+				9367D9D41A6EAEBB0033911A /* StatsViewAllTableViewController.m in Sources */,
 				9326EC011A60765B00FA4DAB /* WPStatsViewController.m in Sources */,
 				936B2251195C48700058C828 /* WPStatsGraphBarCell.m in Sources */,
 				936E74A71A69A8990048F552 /* StatsTableSectionHeaderView.m in Sources */,

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -14,6 +14,7 @@
             <string>OpenSans-Bold</string>
             <string>OpenSans-Bold</string>
             <string>OpenSans-Bold</string>
+            <string>OpenSans-Bold</string>
         </mutableArray>
         <mutableArray key="OpenSans-Regular.ttf">
             <string>OpenSans</string>
@@ -316,33 +317,6 @@
                         <color key="backgroundColor" red="0.90980392160000001" green="0.94117647059999998" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TwoColumnHeader" id="3VH-u4-nO4" customClass="StatsSelectableTableViewCell">
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3VH-u4-nO4" id="cTT-cp-nYc">
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" verticalHuggingPriority="251" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ntT-Lp-D8q">
-                                            <rect key="frame" x="15" y="11" width="515" height="21"/>
-                                            <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="15"/>
-                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" tag="200" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MPE-sk-sci">
-                                            <rect key="frame" x="540" y="11" width="44" height="21"/>
-                                            <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="15"/>
-                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstItem="ntT-Lp-D8q" firstAttribute="baseline" secondItem="MPE-sk-sci" secondAttribute="baseline" id="FbP-gb-g6i"/>
-                                        <constraint firstItem="MPE-sk-sci" firstAttribute="leading" secondItem="ntT-Lp-D8q" secondAttribute="trailing" constant="10" id="IvB-au-8dK"/>
-                                        <constraint firstItem="ntT-Lp-D8q" firstAttribute="leading" secondItem="cTT-cp-nYc" secondAttribute="leadingMargin" constant="7" id="JWw-Gt-pSU"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="MPE-sk-sci" secondAttribute="trailing" constant="8" id="nu9-mQ-PAb"/>
-                                        <constraint firstAttribute="centerY" secondItem="ntT-Lp-D8q" secondAttribute="centerY" id="xep-WE-YjZ"/>
-                                    </constraints>
-                                </tableViewCellContentView>
-                            </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TwoColumnRow" id="VrZ-yR-B34" userLabel="TwoColumnRow" customClass="StatsTwoColumnTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="VrZ-yR-B34" id="uhq-9S-QqH">
@@ -392,6 +366,62 @@
                                     <outlet property="spaceConstraint" destination="r3z-W1-lCw" id="Ajm-at-mTG"/>
                                     <outlet property="widthConstraint" destination="ACl-HK-gmo" id="byD-Vc-w1d"/>
                                 </connections>
+                            </tableViewCell>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupHeader" id="NsU-nV-goQ" customClass="StatsStandardBorderedTableViewCell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NsU-nV-goQ" id="OPf-SX-yan">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Group Header Text" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="34I-h9-bIY">
+                                            <rect key="frame" x="15" y="11" width="159" height="24"/>
+                                            <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="17"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TwoColumnHeader" id="WBd-y5-W0R" customClass="StatsStandardBorderedTableViewCell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="WBd-y5-W0R" id="cD1-0K-RTg">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" verticalHuggingPriority="251" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bzi-VH-bvX">
+                                            <rect key="frame" x="15" y="11" width="515" height="21"/>
+                                            <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="15"/>
+                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="200" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q6H-bo-zk6">
+                                            <rect key="frame" x="540" y="11" width="44" height="21"/>
+                                            <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="15"/>
+                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="centerY" secondItem="Bzi-VH-bvX" secondAttribute="centerY" id="Dn5-oD-Q0T"/>
+                                        <constraint firstItem="Bzi-VH-bvX" firstAttribute="leading" secondItem="cD1-0K-RTg" secondAttribute="leadingMargin" constant="7" id="GYe-s2-90A"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="q6H-bo-zk6" secondAttribute="trailing" constant="8" id="cAv-IN-Vsw"/>
+                                        <constraint firstItem="Bzi-VH-bvX" firstAttribute="baseline" secondItem="q6H-bo-zk6" secondAttribute="baseline" id="uGc-pf-NtC"/>
+                                        <constraint firstItem="q6H-bo-zk6" firstAttribute="leading" secondItem="Bzi-VH-bvX" secondAttribute="trailing" constant="10" id="zfC-3C-i3c"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="LoadingIndicator" id="TXP-s2-pkt" userLabel="LoadingIndicator" customClass="StatsStandardBorderedTableViewCell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="TXP-s2-pkt" id="hlb-Dk-s65">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <activityIndicatorView opaque="NO" tag="100" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="X4C-gb-alc">
+                                            <rect key="frame" x="290" y="12" width="20" height="20"/>
+                                        </activityIndicatorView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="centerY" secondItem="X4C-gb-alc" secondAttribute="centerY" id="2NV-b9-5pV"/>
+                                        <constraint firstAttribute="centerX" secondItem="X4C-gb-alc" secondAttribute="centerX" id="eD7-ig-mWg"/>
+                                    </constraints>
+                                </tableViewCellContentView>
                             </tableViewCell>
                         </prototypes>
                         <connections>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -111,7 +111,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupHeader" id="Ex4-nH-VUK" customClass="StatsSelectableTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupHeader" id="Ex4-nH-VUK" customClass="StatsStandardBorderedTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ex4-nH-VUK" id="aL3-p0-bNa">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -125,7 +125,7 @@
                                     </subviews>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupSelector" id="vr8-L0-G3G" userLabel="GroupSelector" customClass="StatsSelectableTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupSelector" id="vr8-L0-G3G" userLabel="GroupSelector" customClass="StatsStandardBorderedTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="vr8-L0-G3G" id="0qW-oh-xTV">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -147,7 +147,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TwoColumnHeader" id="zkK-fE-70Y" customClass="StatsSelectableTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TwoColumnHeader" id="zkK-fE-70Y" customClass="StatsStandardBorderedTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zkK-fE-70Y" id="OP0-Uc-wLW">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -224,7 +224,7 @@
                                     <outlet property="widthConstraint" destination="Or5-mw-k16" id="Bam-7b-oHo"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MoreRow" id="xct-fr-svw" userLabel="MoreRow" customClass="StatsSelectableTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MoreRow" id="xct-fr-svw" userLabel="MoreRow" customClass="StatsStandardBorderedTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="xct-fr-svw" id="9ex-YE-WVE">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -246,7 +246,7 @@
                                     <segue destination="uuT-Sq-uB0" kind="show" identifier="ViewAll" id="ljy-WF-WHT"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="GroupTotalsRow" id="NuU-bX-mTY" userLabel="GroupTotalsRow" customClass="StatsSelectableTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="GroupTotalsRow" id="NuU-bX-mTY" userLabel="GroupTotalsRow" customClass="StatsStandardBorderedTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NuU-bX-mTY" id="vYe-7i-oUA">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -265,7 +265,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="NoResultsRow" rowHeight="100" id="DDa-Lh-zDs" userLabel="NoResultsRow" customClass="StatsSelectableTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="NoResultsRow" rowHeight="100" id="DDa-Lh-zDs" userLabel="NoResultsRow" customClass="StatsStandardBorderedTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="DDa-Lh-zDs" id="0Bj-bw-PZy">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -310,10 +310,11 @@
         <scene sceneID="nII-vT-hUT">
             <objects>
                 <tableViewController id="uuT-Sq-uB0" customClass="StatsViewAllTableViewController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="URJ-3C-2Md">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="URJ-3C-2Md">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="492"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="0.90980392160000001" green="0.94117647059999998" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TwoColumnHeader" id="3VH-u4-nO4" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -12,8 +12,12 @@
             <string>OpenSans-Bold</string>
             <string>OpenSans-Bold</string>
             <string>OpenSans-Bold</string>
+            <string>OpenSans-Bold</string>
+            <string>OpenSans-Bold</string>
         </mutableArray>
         <mutableArray key="OpenSans-Regular.ttf">
+            <string>OpenSans</string>
+            <string>OpenSans</string>
             <string>OpenSans</string>
             <string>OpenSans</string>
             <string>OpenSans</string>
@@ -170,7 +174,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TwoColumnRow" id="fhY-TT-0EH" userLabel="TwoColumnRow" customClass="StatsSelectableTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TwoColumnRow" id="fhY-TT-0EH" userLabel="TwoColumnRow" customClass="StatsTwoColumnTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="fhY-TT-0EH" id="Dnr-8L-jIZ">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -211,6 +215,14 @@
                                         </mask>
                                     </variation>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="iconImageView" destination="p4X-m5-Nld" id="vGG-5N-ZJU"/>
+                                    <outlet property="leadingEdgeConstraint" destination="XsQ-gt-qaQ" id="Uc0-wa-tLH"/>
+                                    <outlet property="leftLabel" destination="GAp-0f-HXa" id="RhP-wA-2kf"/>
+                                    <outlet property="rightLabel" destination="Rwp-nF-8c1" id="uEP-I2-NDN"/>
+                                    <outlet property="spaceConstraint" destination="jMx-Mh-VzX" id="sTM-S5-2Gw"/>
+                                    <outlet property="widthConstraint" destination="Or5-mw-k16" id="Bam-7b-oHo"/>
+                                </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="MoreRow" id="xct-fr-svw" userLabel="MoreRow" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
@@ -230,6 +242,9 @@
                                         <constraint firstItem="pXf-GO-N9N" firstAttribute="leading" secondItem="9ex-YE-WVE" secondAttribute="leadingMargin" constant="7" id="uJl-dn-Tqg"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <segue destination="uuT-Sq-uB0" kind="show" identifier="ViewAll" id="ljy-WF-WHT"/>
+                                </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="GroupTotalsRow" id="NuU-bX-mTY" userLabel="GroupTotalsRow" customClass="StatsSelectableTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
@@ -290,6 +305,103 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Q7L-pU-m4M" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2468" y="103"/>
+        </scene>
+        <!--Stats View All Table View Controller-->
+        <scene sceneID="nII-vT-hUT">
+            <objects>
+                <tableViewController id="uuT-Sq-uB0" customClass="StatsViewAllTableViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="URJ-3C-2Md">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="492"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TwoColumnHeader" id="3VH-u4-nO4" customClass="StatsSelectableTableViewCell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3VH-u4-nO4" id="cTT-cp-nYc">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" verticalHuggingPriority="251" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ntT-Lp-D8q">
+                                            <rect key="frame" x="15" y="11" width="515" height="21"/>
+                                            <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="15"/>
+                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="200" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MPE-sk-sci">
+                                            <rect key="frame" x="540" y="11" width="44" height="21"/>
+                                            <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="15"/>
+                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="ntT-Lp-D8q" firstAttribute="baseline" secondItem="MPE-sk-sci" secondAttribute="baseline" id="FbP-gb-g6i"/>
+                                        <constraint firstItem="MPE-sk-sci" firstAttribute="leading" secondItem="ntT-Lp-D8q" secondAttribute="trailing" constant="10" id="IvB-au-8dK"/>
+                                        <constraint firstItem="ntT-Lp-D8q" firstAttribute="leading" secondItem="cTT-cp-nYc" secondAttribute="leadingMargin" constant="7" id="JWw-Gt-pSU"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="MPE-sk-sci" secondAttribute="trailing" constant="8" id="nu9-mQ-PAb"/>
+                                        <constraint firstAttribute="centerY" secondItem="ntT-Lp-D8q" secondAttribute="centerY" id="xep-WE-YjZ"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TwoColumnRow" id="VrZ-yR-B34" userLabel="TwoColumnRow" customClass="StatsTwoColumnTableViewCell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="VrZ-yR-B34" id="uhq-9S-QqH">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" tag="300" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gGi-jP-Jd7">
+                                            <rect key="frame" x="15" y="12" width="20" height="20"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="20" id="8FH-1A-hdE"/>
+                                                <constraint firstAttribute="width" constant="20" id="ACl-HK-gmo"/>
+                                            </constraints>
+                                        </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" verticalHuggingPriority="251" text="Example Label Goes Here" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F2J-1J-H3d">
+                                            <rect key="frame" x="43" y="11" width="488" height="21"/>
+                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="15"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="200" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="10000" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wsv-mI-upz">
+                                            <rect key="frame" x="541" y="11" width="43" height="21"/>
+                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="15"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="trailingMargin" secondItem="Wsv-mI-upz" secondAttribute="trailing" constant="8" id="3of-io-zcn"/>
+                                        <constraint firstItem="Wsv-mI-upz" firstAttribute="leading" secondItem="F2J-1J-H3d" secondAttribute="trailing" constant="10" id="4rA-kv-xFP"/>
+                                        <constraint firstAttribute="centerY" secondItem="gGi-jP-Jd7" secondAttribute="centerY" id="PJ8-XE-2Al"/>
+                                        <constraint firstItem="gGi-jP-Jd7" firstAttribute="top" secondItem="uhq-9S-QqH" secondAttribute="topMargin" constant="-8" id="ZC1-e6-Uiy"/>
+                                        <constraint firstItem="Wsv-mI-upz" firstAttribute="baseline" secondItem="F2J-1J-H3d" secondAttribute="baseline" id="ejs-3G-xbI"/>
+                                        <constraint firstAttribute="centerY" secondItem="F2J-1J-H3d" secondAttribute="centerY" id="lH3-Ba-Zzq"/>
+                                        <constraint firstItem="F2J-1J-H3d" firstAttribute="leading" secondItem="gGi-jP-Jd7" secondAttribute="trailing" constant="8" id="r3z-W1-lCw"/>
+                                        <constraint firstItem="gGi-jP-Jd7" firstAttribute="leading" secondItem="uhq-9S-QqH" secondAttribute="leadingMargin" constant="7" id="trM-8x-7LH"/>
+                                    </constraints>
+                                    <variation key="default">
+                                        <mask key="constraints">
+                                            <exclude reference="ZC1-e6-Uiy"/>
+                                        </mask>
+                                    </variation>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="iconImageView" destination="gGi-jP-Jd7" id="x90-kE-eRp"/>
+                                    <outlet property="leadingEdgeConstraint" destination="trM-8x-7LH" id="9Gr-lx-JfI"/>
+                                    <outlet property="leftLabel" destination="F2J-1J-H3d" id="qii-Ug-Ne5"/>
+                                    <outlet property="rightLabel" destination="Wsv-mI-upz" id="1GW-QS-TIs"/>
+                                    <outlet property="spaceConstraint" destination="r3z-W1-lCw" id="Ajm-at-mTG"/>
+                                    <outlet property="widthConstraint" destination="ACl-HK-gmo" id="byD-Vc-w1d"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="uuT-Sq-uB0" id="86X-zi-Xmq"/>
+                            <outlet property="delegate" destination="uuT-Sq-uB0" id="cAe-ur-XRK"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="yjI-9F-acs" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3279" y="157"/>
         </scene>
         <!--Stats-->
         <scene sceneID="VEy-zh-BAL">

--- a/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.h
+++ b/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+
+@interface StatsBorderedCellBackgroundView : UIView
+
+- (instancetype)initWithFrame:(CGRect)frame andSelected:(BOOL)selected;
+
+@property (nonatomic, strong) UIView *theBoxView;
+@property (nonatomic, strong) UIView *contentBackgroundView;
+@property (nonatomic, strong) UIView *dividerView;
+
+@end

--- a/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.m
+++ b/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.m
@@ -1,0 +1,47 @@
+#import "StatsBorderedCellBackgroundView.h"
+#import "WPStyleGuide+Stats.h"
+
+@implementation StatsBorderedCellBackgroundView
+
+
+- (instancetype)initWithFrame:(CGRect)frame andSelected:(BOOL)selected
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        self.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+        
+        _theBoxView = [[UIView alloc] initWithFrame:CGRectZero];
+        _theBoxView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        _theBoxView.backgroundColor = [UIColor colorWithRed:210.0/255.0 green:222.0/255.0 blue:238.0/255.0 alpha:1.0];
+        [self addSubview:_theBoxView];
+        
+        _contentBackgroundView = [[UIView alloc] initWithFrame:CGRectZero];
+        _contentBackgroundView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        _contentBackgroundView.backgroundColor = selected ? [UIColor whiteColor] : [WPStyleGuide statsUltraLightGray];
+        [self addSubview:_contentBackgroundView];
+        
+        _dividerView = [[UIView alloc] initWithFrame:CGRectZero];
+        _dividerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        _dividerView.backgroundColor = [WPStyleGuide statsLightGray];
+        [self addSubview:_dividerView];
+    }
+    
+    return self;
+}
+
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    CGFloat borderSidePadding = IS_IPHONE ? RPTVCHorizontalOuterPadding - 1.0f : 0.0f;
+    CGFloat bottomPadding = 1.0f;
+    CGFloat sidePadding = IS_IPHONE ? RPTVCHorizontalOuterPadding : 0.0f;
+    
+    self.theBoxView.frame = CGRectMake(borderSidePadding, 0.0, CGRectGetWidth(self.frame) - 2 * borderSidePadding, CGRectGetHeight(self.frame));
+    self.contentBackgroundView.frame = CGRectMake(sidePadding, 0.0, CGRectGetWidth(self.frame) - 2 * sidePadding, CGRectGetHeight(self.frame));
+    self.dividerView.frame = CGRectMake(CGRectGetMinX(self.contentBackgroundView.frame), CGRectGetHeight(self.frame) - bottomPadding, CGRectGetWidth(self.contentBackgroundView.frame), bottomPadding);
+}
+
+
+@end

--- a/WordPressCom-Stats-iOS/StatsGroup.h
+++ b/WordPressCom-Stats-iOS/StatsGroup.h
@@ -1,19 +1,26 @@
 #import <Foundation/Foundation.h>
 #import "StatsItem.h"
+#import "StatsSection.h"
 
 @interface StatsGroup : NSObject
 
-@property (nonatomic, strong)   NSArray *items; // StatsItem
-@property (nonatomic, assign)   BOOL moreItemsExist;
-@property (nonatomic, copy)     NSString *titlePrimary;
-@property (nonatomic, copy)     NSString *titleSecondary;
-@property (nonatomic, strong)   NSURL *iconUrl;
-@property (nonatomic, copy)     NSString *totalCount;
+@property (nonatomic, assign, readonly) StatsSection statsSection;
+@property (nonatomic, assign, readonly) StatsSubSection statsSubSection;
+@property (nonatomic, copy, readonly) NSString *groupTitle;
+@property (nonatomic, copy, readonly) NSString *titlePrimary;
+@property (nonatomic, copy, readonly) NSString *titleSecondary;
+
+@property (nonatomic, strong) NSArray *items; // StatsItem
+@property (nonatomic, assign) BOOL moreItemsExist;
+@property (nonatomic, strong) NSURL *iconUrl;
+@property (nonatomic, copy)   NSString *totalCount;
 
 @property (nonatomic, assign, getter=isExpanded) BOOL expanded;
 @property (nonatomic, assign) BOOL errorWhileRetrieving;
 @property (nonatomic, readonly) NSUInteger numberOfRows;
 @property (nonatomic, assign) NSUInteger offsetRows;
+
+- (instancetype)initWithStatsSection:(StatsSection)statsSection andStatsSubSection:(StatsSubSection)statsSubSection;
 
 - (StatsItem *)statsItemForTableViewRow:(NSInteger)row;
 

--- a/WordPressCom-Stats-iOS/StatsGroup.m
+++ b/WordPressCom-Stats-iOS/StatsGroup.m
@@ -1,6 +1,28 @@
 #import "StatsGroup.h"
 
+@interface StatsGroup ()
+
+@property (nonatomic, copy, readwrite) NSString *groupTitle;
+@property (nonatomic, copy, readwrite) NSString *titlePrimary;
+@property (nonatomic, copy, readwrite) NSString *titleSecondary;
+
+@end
+
 @implementation StatsGroup
+
+- (instancetype)initWithStatsSection:(StatsSection)statsSection andStatsSubSection:(StatsSubSection)statsSubSection
+{
+    self = [super init];
+    if (self) {
+        _statsSection = statsSection;
+        _statsSubSection = statsSubSection;
+        
+        [self setUpTitles];
+    }
+    
+    return self;
+}
+
 
 - (NSUInteger)numberOfRows
 {
@@ -44,6 +66,65 @@
     }
     
     return nil;
+}
+
+
+- (void)setUpTitles
+{
+    switch (self.statsSection) {
+        case StatsSectionClicks:
+            self.groupTitle = NSLocalizedString(@"Clicks", @"Title for stats section for Clicks");
+            self.titlePrimary = NSLocalizedString(@"Link", @"");
+            self.titleSecondary = NSLocalizedString(@"Clicks", @"");
+            break;
+        case StatsSectionComments:
+            self.groupTitle = NSLocalizedString(@"Comments", @"Title for stats section for Comments");
+            self.titlePrimary = self.statsSubSection == StatsSubSectionCommentsByAuthor ? NSLocalizedString(@"Author", @"") : NSLocalizedString(@"Title", @"");
+            self.titleSecondary = NSLocalizedString(@"Comments", @"");
+            break;
+        case StatsSectionCountry:
+            self.groupTitle = NSLocalizedString(@"Countries", @"Title for stats section for Countries");
+            self.titlePrimary = NSLocalizedString(@"Country", @"");
+            self.titleSecondary = NSLocalizedString(@"Views", @"");
+            break;
+        case StatsSectionEvents:
+            self.groupTitle = NSLocalizedString(@"Published", @"Title for stats section for Events");
+            break;
+        case StatsSectionFollowers:
+            self.groupTitle = NSLocalizedString(@"Followers", @"Title for stats section for Followers");
+            self.titlePrimary = NSLocalizedString(@"Follower", @"");
+            self.titleSecondary = NSLocalizedString(@"Since", @"");
+            break;
+        case StatsSectionPosts:
+            self.groupTitle = NSLocalizedString(@"Posts & Pages", @"Title for stats section for Posts & Pages");
+            self.titlePrimary = NSLocalizedString(@"Title", @"");
+            self.titleSecondary = NSLocalizedString(@"Views", @"");
+            break;
+        case StatsSectionPublicize:
+            self.groupTitle = NSLocalizedString(@"Publicize", @"Title for stats section for Publicize");
+            self.titlePrimary = NSLocalizedString(@"Service", @"");
+            self.titleSecondary = NSLocalizedString(@"Followers", @"");
+            break;
+        case StatsSectionReferrers:
+            self.groupTitle = NSLocalizedString(@"Referrers", @"Title for stats section for Referrers");
+            self.titlePrimary = NSLocalizedString(@"Referrer", @"");
+            self.titleSecondary = NSLocalizedString(@"Views", @"");
+            break;
+        case StatsSectionTagsCategories:
+            self.groupTitle = NSLocalizedString(@"Tags & Categories", @"Title for stats section for Tags & Categories");
+            self.titlePrimary = NSLocalizedString(@"Topic", @"");
+            self.titleSecondary = NSLocalizedString(@"Views", @"");
+            break;
+        case StatsSectionVideos:
+            self.groupTitle = NSLocalizedString(@"Videos", @"Title for stats section for Videos");
+            self.titlePrimary = NSLocalizedString(@"Video", @"");
+            self.titleSecondary = NSLocalizedString(@"Views", @"");
+            break;
+            
+        default:
+            break;
+    }
+
 }
 
 @end

--- a/WordPressCom-Stats-iOS/StatsSection.h
+++ b/WordPressCom-Stats-iOS/StatsSection.h
@@ -1,0 +1,22 @@
+typedef NS_ENUM(NSInteger, StatsSection) {
+    StatsSectionGraph,
+    StatsSectionPeriodHeader,
+    StatsSectionEvents,
+    StatsSectionPosts,
+    StatsSectionReferrers,
+    StatsSectionClicks,
+    StatsSectionCountry,
+    StatsSectionVideos,
+    StatsSectionComments,
+    StatsSectionTagsCategories,
+    StatsSectionFollowers,
+    StatsSectionPublicize
+};
+
+typedef NS_ENUM(NSInteger, StatsSubSection) {
+    StatsSubSectionCommentsByAuthor,
+    StatsSubSectionCommentsByPosts,
+    StatsSubSectionFollowersDotCom,
+    StatsSubSectionFollowersEmail,
+    StatsSubSectionNone
+};

--- a/WordPressCom-Stats-iOS/StatsSection.h
+++ b/WordPressCom-Stats-iOS/StatsSection.h
@@ -14,7 +14,7 @@ typedef NS_ENUM(NSInteger, StatsSection) {
 };
 
 typedef NS_ENUM(NSInteger, StatsSubSection) {
-    StatsSubSectionCommentsByAuthor,
+    StatsSubSectionCommentsByAuthor = 100,
     StatsSubSectionCommentsByPosts,
     StatsSubSectionFollowersDotCom,
     StatsSubSectionFollowersEmail,

--- a/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.m
@@ -2,59 +2,7 @@
 #import <UIImage+Util.h>
 #import <WPStyleGuide.h>
 #import "WPStyleGuide+Stats.h"
-
-@interface StatsBorderedCellBackgroundView : UIView
-
-- (instancetype)initWithFrame:(CGRect)frame andSelected:(BOOL)selected;
-
-@property (nonatomic, strong) UIView *theBoxView;
-@property (nonatomic, strong) UIView *contentBackgroundView;
-@property (nonatomic, strong) UIView *dividerView;
-
-@end
-
-@implementation StatsBorderedCellBackgroundView
-
-- (instancetype)initWithFrame:(CGRect)frame andSelected:(BOOL)selected
-{
-    self = [super initWithFrame:frame];
-    if (self) {
-        self.backgroundColor = [WPStyleGuide itsEverywhereGrey];
-        
-        _theBoxView = [[UIView alloc] initWithFrame:CGRectZero];
-        _theBoxView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        _theBoxView.backgroundColor = [UIColor colorWithRed:210.0/255.0 green:222.0/255.0 blue:238.0/255.0 alpha:1.0];
-        [self addSubview:_theBoxView];
-        
-        _contentBackgroundView = [[UIView alloc] initWithFrame:CGRectZero];
-        _contentBackgroundView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        _contentBackgroundView.backgroundColor = selected ? [UIColor whiteColor] : [WPStyleGuide statsUltraLightGray];
-        [self addSubview:_contentBackgroundView];
-        
-        _dividerView = [[UIView alloc] initWithFrame:CGRectZero];
-        _dividerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        _dividerView.backgroundColor = [WPStyleGuide statsLightGray];
-        [self addSubview:_dividerView];
-    }
-    
-    return self;
-}
-
-
-- (void)layoutSubviews
-{
-    [super layoutSubviews];
-    
-    CGFloat borderSidePadding = IS_IPHONE ? RPTVCHorizontalOuterPadding - 1.0f : 0.0f;
-    CGFloat bottomPadding = 1.0f;
-    CGFloat sidePadding = IS_IPHONE ? RPTVCHorizontalOuterPadding : 0.0f;
-
-    self.theBoxView.frame = CGRectMake(borderSidePadding, 0.0, CGRectGetWidth(self.frame) - 2 * borderSidePadding, CGRectGetHeight(self.frame));
-    self.contentBackgroundView.frame = CGRectMake(sidePadding, 0.0, CGRectGetWidth(self.frame) - 2 * sidePadding, CGRectGetHeight(self.frame));
-    self.dividerView.frame = CGRectMake(CGRectGetMinX(self.contentBackgroundView.frame), CGRectGetHeight(self.frame) - bottomPadding, CGRectGetWidth(self.contentBackgroundView.frame), bottomPadding);
-}
-
-@end
+#import "StatsBorderedCellBackgroundView.h"
 
 @interface StatsSelectableTableViewCell ()
 

--- a/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
@@ -1,0 +1,13 @@
+//
+//  StatsStandardBorderedTableViewCell.h
+//  WordPressCom-Stats-iOS
+//
+//  Created by Aaron Douglas on 1/21/15.
+//  Copyright (c) 2015 Automattic Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface StatsStandardBorderedTableViewCell : UITableViewCell
+
+@end

--- a/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.m
@@ -1,0 +1,24 @@
+#import "StatsStandardBorderedTableViewCell.h"
+#import "WPStyleGuide+Stats.h"
+#import "StatsBorderedCellBackgroundView.h"
+
+@implementation StatsStandardBorderedTableViewCell
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    self.backgroundView.frame = self.bounds;
+    self.selectedBackgroundView.frame = self.bounds;
+}
+
+
+- (void)awakeFromNib
+{
+    [super awakeFromNib];
+    
+    self.backgroundView = [[StatsBorderedCellBackgroundView alloc] initWithFrame:self.bounds andSelected:YES];
+    self.selectedBackgroundView = [[StatsBorderedCellBackgroundView alloc] initWithFrame:self.bounds andSelected:NO];
+}
+
+@end

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -285,11 +285,7 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
         [tableView beginUpdates];
         [tableView reloadRowsAtIndexPaths:@[graphIndexPath] withRowAnimation:UITableViewRowAnimationNone];
         [tableView endUpdates];
-    } else if ([[self cellIdentifierForIndexPath:indexPath] isEqualToString:StatsTableViewAllCellIdentifier]) {
-        // Placeholder for full screen details
-        [tableView deselectRowAtIndexPath:indexPath animated:YES];
     } else if ([[self cellIdentifierForIndexPath:indexPath] isEqualToString:StatsTableTwoColumnCellIdentifier]) {
-        // Placeholder for full screen details
         [tableView deselectRowAtIndexPath:indexPath animated:YES];
         
         StatsGroup *statsGroup = [self statsDataForStatsSection:statsSection];

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -348,6 +348,7 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
         viewAllVC.statsSection = statsSection;
         viewAllVC.statsSubSection = statsSubSection;
         viewAllVC.statsService = self.statsService;
+        viewAllVC.statsDelegate = self.statsDelegate;
     }
 }
 

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -97,13 +97,13 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
     
     NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(applicationDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
+    
+    [self retrieveStatsSkipGraph:NO];
 }
 
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    
-    [self retrieveStatsSkipGraph:NO];
 }
 
 - (void)didReceiveMemoryWarning {

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -350,6 +350,8 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
         viewAllVC.statsService = self.statsService;
         viewAllVC.statsDelegate = self.statsDelegate;
     }
+    
+    [self.tableView deselectRowAtIndexPath:indexPath animated:NO];
 }
 
 

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.h
@@ -1,0 +1,13 @@
+#import "StatsSelectableTableViewCell.h"
+
+@interface StatsTwoColumnTableViewCell : StatsSelectableTableViewCell
+
+@property (nonatomic, copy) NSString *leftText;
+@property (nonatomic, copy) NSString *rightText;
+@property (nonatomic, strong) NSURL *imageURL;
+@property (nonatomic, assign) NSUInteger indentLevel;
+@property (nonatomic, assign) BOOL selectable;
+
+- (void)doneSettingProperties;
+
+@end

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.h
@@ -1,6 +1,7 @@
 #import "StatsSelectableTableViewCell.h"
+#import "StatsStandardBorderedTableViewCell.h"
 
-@interface StatsTwoColumnTableViewCell : StatsSelectableTableViewCell
+@interface StatsTwoColumnTableViewCell : StatsStandardBorderedTableViewCell
 
 @property (nonatomic, copy) NSString *leftText;
 @property (nonatomic, copy) NSString *rightText;

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
@@ -1,0 +1,68 @@
+#import "StatsTwoColumnTableViewCell.h"
+#import "WPStyleGuide+Stats.h"
+#import <WPImageSource.h>
+
+@interface StatsTwoColumnTableViewCell ()
+
+@property (nonatomic, weak) IBOutlet UILabel *leftLabel;
+@property (nonatomic, weak) IBOutlet UILabel *rightLabel;
+@property (nonatomic, weak) IBOutlet UIImageView *iconImageView;
+@property (nonatomic, weak) IBOutlet NSLayoutConstraint *widthConstraint;
+@property (nonatomic, weak) IBOutlet NSLayoutConstraint *spaceConstraint;
+@property (nonatomic, weak) IBOutlet NSLayoutConstraint *leadingEdgeConstraint;
+
+@end
+
+@implementation StatsTwoColumnTableViewCell
+
+- (void)doneSettingProperties
+{
+    self.leftLabel.text = self.leftText;
+    self.rightLabel.text = self.rightText;
+
+    if (self.selectable) {
+        self.selectionStyle = UITableViewCellSelectionStyleDefault;
+    }
+    
+    self.iconImageView.image = nil;
+
+    // Hide the image if one isn't set
+    if (self.imageURL) {
+        [[WPImageSource sharedSource] downloadImageForURL:self.imageURL withSuccess:^(UIImage *image) {
+            self.iconImageView.image = image;
+            self.iconImageView.backgroundColor = [UIColor clearColor];
+        } failure:^(NSError *error) {
+            DDLogWarn(@"Unable to download icon %@", error);
+        }];
+    } else {
+        self.widthConstraint.constant = 0.0f;
+        self.spaceConstraint.constant = 0.0f;
+    }
+    
+    BOOL isNestedRow = self.indentLevel > 1;
+    if (isNestedRow) {
+        self.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+    }
+    
+    CGFloat indentWidth = self.indentLevel * 7.0f;
+    self.leadingEdgeConstraint.constant = indentWidth;
+    
+    [self setNeedsLayout];
+}
+
+- (void)prepareForReuse
+{
+    [super prepareForReuse];
+    
+    self.leftLabel.text = nil;
+    self.rightLabel.text = nil;
+    self.iconImageView.image = nil;
+    
+    self.widthConstraint.constant = 20.0f;
+    self.spaceConstraint.constant = 8.0f;
+    self.backgroundColor = [UIColor whiteColor];
+    self.selectionStyle = UITableViewCellSelectionStyleNone;
+}
+
+
+@end

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
@@ -1,6 +1,7 @@
 #import "StatsTwoColumnTableViewCell.h"
 #import "WPStyleGuide+Stats.h"
 #import <WPImageSource.h>
+#import "StatsBorderedCellBackgroundView.h"
 
 @interface StatsTwoColumnTableViewCell ()
 
@@ -63,6 +64,5 @@
     self.backgroundColor = [UIColor whiteColor];
     self.selectionStyle = UITableViewCellSelectionStyleNone;
 }
-
 
 @end

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
@@ -42,7 +42,8 @@
     
     BOOL isNestedRow = self.indentLevel > 1;
     if (isNestedRow) {
-        self.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+        StatsBorderedCellBackgroundView *backgroundView = (StatsBorderedCellBackgroundView *)self.backgroundView;
+        backgroundView.contentBackgroundView.backgroundColor = [WPStyleGuide itsEverywhereGrey];
     }
     
     CGFloat indentWidth = self.indentLevel * 7.0f;
@@ -61,7 +62,8 @@
     
     self.widthConstraint.constant = 20.0f;
     self.spaceConstraint.constant = 8.0f;
-    self.backgroundColor = [UIColor whiteColor];
+    StatsBorderedCellBackgroundView *backgroundView = (StatsBorderedCellBackgroundView *)self.backgroundView;
+    backgroundView.contentBackgroundView.backgroundColor = [UIColor whiteColor];
     self.selectionStyle = UITableViewCellSelectionStyleNone;
 }
 

--- a/WordPressCom-Stats-iOS/StatsViewAllTableViewController.h
+++ b/WordPressCom-Stats-iOS/StatsViewAllTableViewController.h
@@ -1,0 +1,14 @@
+#import <UIKit/UIKit.h>
+#import "StatsSummary.h"
+#import "WPStatsService.h"
+#import "StatsSection.h"
+
+@interface StatsViewAllTableViewController : UITableViewController
+
+@property (nonatomic, strong) NSDate *selectedDate;
+@property (nonatomic, assign) StatsPeriodUnit periodUnit;
+@property (nonatomic, assign) StatsSection statsSection;
+@property (nonatomic, assign) StatsSubSection statsSubSection;
+@property (nonatomic, strong) WPStatsService *statsService;
+
+@end

--- a/WordPressCom-Stats-iOS/StatsViewAllTableViewController.h
+++ b/WordPressCom-Stats-iOS/StatsViewAllTableViewController.h
@@ -2,6 +2,7 @@
 #import "StatsSummary.h"
 #import "WPStatsService.h"
 #import "StatsSection.h"
+#import "WPStatsViewController.h"
 
 @interface StatsViewAllTableViewController : UITableViewController
 
@@ -10,5 +11,6 @@
 @property (nonatomic, assign) StatsSection statsSection;
 @property (nonatomic, assign) StatsSubSection statsSubSection;
 @property (nonatomic, strong) WPStatsService *statsService;
+@property (nonatomic, weak) id<WPStatsViewControllerDelegate> statsDelegate;
 
 @end

--- a/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
@@ -87,8 +87,10 @@ static NSString *const StatsTableLoadingIndicatorCellIdentifier = @"LoadingIndic
                             indentLevel:item.depth
                              selectable:item.actions.count > 0 || item.children.count > 0];
     } else if ([identifier isEqualToString:StatsTableLoadingIndicatorCellIdentifier]) {
-        UIActivityIndicatorView *indicator = [cell.contentView viewWithTag:100];
+        UIActivityIndicatorView *indicator = (UIActivityIndicatorView *)[cell.contentView viewWithTag:100];
         [indicator startAnimating];
+    } else if ([identifier isEqualToString:StatsTableGroupHeaderCellIdentifier]) {
+        [self configureSectionGroupHeaderCell:cell];
     }
     
     return cell;
@@ -169,5 +171,28 @@ static NSString *const StatsTableLoadingIndicatorCellIdentifier = @"LoadingIndic
     statsCell.selectable = selectable;
     [statsCell doneSettingProperties];
 }
+
+
+- (void)configureSectionGroupHeaderCell:(UITableViewCell *)cell
+{
+    NSString *headerText = self.statsGroup.groupTitle;
+    
+    UILabel *label = (UILabel *)[cell.contentView viewWithTag:100];
+    label.text = headerText;
+}
+
+
+- (void)configureSectionTwoColumnHeaderCell:(UITableViewCell *)cell
+{
+    NSString *leftText = self.statsGroup.titlePrimary;
+    NSString *rightText = self.statsGroup.titleSecondary;
+    
+    UILabel *label1 = (UILabel *)[cell.contentView viewWithTag:100];
+    label1.text = leftText;
+    
+    UILabel *label2 = (UILabel *)[cell.contentView viewWithTag:200];
+    label2.text = rightText;
+}
+
 
 @end

--- a/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
@@ -220,6 +220,17 @@ static NSString *const StatsTableLoadingIndicatorCellIdentifier = @"LoadingIndic
     
     if (self.statsSection == StatsSectionPosts) {
         [self.statsService retrievePostsForDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];
+    } else if (self.statsSection == StatsSectionReferrers) {
+        [self.statsService retrieveReferrersForDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];
+    } else if (self.statsSection == StatsSectionClicks) {
+        [self.statsService retrieveClicksForDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];
+    } else if (self.statsSection == StatsSectionCountry) {
+        [self.statsService retrieveCountriesForDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];
+    } else if (self.statsSection == StatsSectionVideos) {
+        [self.statsService retrieveVideosForDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];
+    } else if (self.statsSection == StatsSectionFollowers) {
+        StatsFollowerType followerType = self.statsSubSection == StatsSubSectionFollowersDotCom ? StatsFollowerTypeDotCom : StatsFollowerTypeEmail;
+        [self.statsService retrieveFollowersOfType:followerType forDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];
     }
 }
 

--- a/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
@@ -1,5 +1,10 @@
 #import "StatsViewAllTableViewController.h"
 #import "StatsGroup.h"
+#import "StatsTwoColumnTableViewCell.h"
+#import "WPStyleGuide+Stats.h"
+#import "StatsTableSectionHeaderView.h"
+
+static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSectionHeaderSimpleBorder";
 
 @interface StatsViewAllTableViewController ()
 
@@ -12,8 +17,21 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    self.tableView.tableHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 20.0f)];
+    self.tableView.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+    [self.tableView registerClass:[StatsTableSectionHeaderView class] forHeaderFooterViewReuseIdentifier:StatsTableSectionHeaderSimpleBorder];
+    
+    UIRefreshControl *refreshControl = [UIRefreshControl new];
+    [refreshControl addTarget:self action:@selector(retrieveStats) forControlEvents:UIControlEventValueChanged];
+    self.refreshControl = refreshControl;
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+    [self.refreshControl beginRefreshing];
+    [self retrieveStats];
+}
 
 - (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
@@ -35,15 +53,82 @@
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"TwoColumnRow" forIndexPath:indexPath];
     
+    StatsItem *item = self.statsGroup.items[indexPath.row];
+    
+    [self configureTwoColumnRowCell:cell
+                       withLeftText:item.label
+                          rightText:item.value
+                        andImageURL:item.iconURL
+                        indentLevel:item.depth
+                         selectable:item.actions.count > 0 || item.children.count > 0];
+    
     return cell;
 }
 
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+{
+    StatsTableSectionHeaderView *headerView = [tableView dequeueReusableHeaderFooterViewWithIdentifier:StatsTableSectionHeaderSimpleBorder];
+    
+    return headerView;
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+{
+    StatsTableSectionHeaderView *footerView = [tableView dequeueReusableHeaderFooterViewWithIdentifier:StatsTableSectionHeaderSimpleBorder];
+    footerView.footer = YES;
+    
+    return footerView;
+}
+
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    return 1.0f;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+{
+    return 10.0f;
+}
 
 #pragma mark - Private methods
 
 - (void)retrieveStats
 {
     [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
+    
+    if (self.statsGroup) {
+        self.statsGroup = nil;
+        [self.tableView reloadData];
+    }
+    
+    StatsGroupCompletion completion = ^(StatsGroup *group, NSError *error) {
+        [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+        [self.refreshControl endRefreshing];
+
+        self.statsGroup = group;
+        [self.tableView reloadData];
+    };
+    
+    if (self.statsSection == StatsSectionPosts) {
+        [self.statsService retrievePostsForDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];
+    }
+}
+
+- (void)configureTwoColumnRowCell:(UITableViewCell *)cell
+                     withLeftText:(NSString *)leftText
+                        rightText:(NSString *)rightText
+                      andImageURL:(NSURL *)imageURL
+                      indentLevel:(NSUInteger)indentLevel
+                       selectable:(BOOL)selectable
+{
+    StatsTwoColumnTableViewCell *statsCell = (StatsTwoColumnTableViewCell *)cell;
+    statsCell.leftText = leftText;
+    statsCell.rightText = rightText;
+    statsCell.imageURL = imageURL;
+    statsCell.indentLevel = indentLevel;
+    statsCell.selectable = selectable;
+    [statsCell doneSettingProperties];
 }
 
 @end

--- a/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
@@ -1,0 +1,49 @@
+#import "StatsViewAllTableViewController.h"
+#import "StatsGroup.h"
+
+@interface StatsViewAllTableViewController ()
+
+@property (nonatomic, strong) StatsGroup *statsGroup;
+
+@end
+
+@implementation StatsViewAllTableViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+}
+
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+#pragma mark - Table view data source
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 1;
+}
+
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.statsGroup.items.count;
+}
+
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"TwoColumnRow" forIndexPath:indexPath];
+    
+    return cell;
+}
+
+
+#pragma mark - Private methods
+
+- (void)retrieveStats
+{
+    [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
+}
+
+@end

--- a/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
@@ -65,7 +65,7 @@ static NSString *const StatsTableLoadingIndicatorCellIdentifier = @"LoadingIndic
         case 0:
             identifier = StatsTableTwoColumnHeaderCellIdentifier;
             break;
-        case 2:
+        case 1:
             if (self.statsGroup.items == nil) {
                 identifier = StatsTableLoadingIndicatorCellIdentifier;
                 break;

--- a/WordPressCom-Stats-iOS/WPStatsService.h
+++ b/WordPressCom-Stats-iOS/WPStatsService.h
@@ -65,6 +65,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
 
 - (void)retrieveTodayStatsWithCompletionHandler:(StatsSummaryCompletion)completion failureHandler:(void (^)(NSError *))failureHandler;
 
+- (void)cancelAnyRunningOperations;
 - (void)expireAllItemsInCache;
 
 @end

--- a/WordPressCom-Stats-iOS/WPStatsService.h
+++ b/WordPressCom-Stats-iOS/WPStatsService.h
@@ -5,7 +5,12 @@
 
 typedef void (^StatsSummaryCompletion)(StatsSummary *summary);
 typedef void (^StatsVisitsCompletion)(StatsVisits *visits, NSError *error);
-typedef void (^StatsItemsCompletion)(StatsGroup *group, NSError *error);
+typedef void (^StatsGroupCompletion)(StatsGroup *group, NSError *error);
+
+typedef NS_ENUM(NSUInteger, StatsFollowerType) {
+    StatsFollowerTypeDotCom,
+    StatsFollowerTypeEmail
+};
 
 @class WPStatsServiceRemote;
 
@@ -18,19 +23,45 @@ typedef void (^StatsItemsCompletion)(StatsGroup *group, NSError *error);
 - (void)retrieveAllStatsForDate:(NSDate *)date
                         andUnit:(StatsPeriodUnit)unit
     withVisitsCompletionHandler:(StatsVisitsCompletion)visitsCompletion
-        eventsCompletionHandler:(StatsItemsCompletion)eventsCompletion
-         postsCompletionHandler:(StatsItemsCompletion)postsCompletion
-     referrersCompletionHandler:(StatsItemsCompletion)referrersCompletion
-        clicksCompletionHandler:(StatsItemsCompletion)clicksCompletion
-       countryCompletionHandler:(StatsItemsCompletion)countryCompletion
-        videosCompletionHandler:(StatsItemsCompletion)videosCompletion
-commentsAuthorCompletionHandler:(StatsItemsCompletion)commentsAuthorsCompletion
- commentsPostsCompletionHandler:(StatsItemsCompletion)commentsPostsCompletion
-tagsCategoriesCompletionHandler:(StatsItemsCompletion)tagsCategoriesCompletion
-followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
- followersEmailCompletionHandler:(StatsItemsCompletion)followersEmailCompletion
-      publicizeCompletionHandler:(StatsItemsCompletion)publicizeCompletion
+        eventsCompletionHandler:(StatsGroupCompletion)eventsCompletion
+         postsCompletionHandler:(StatsGroupCompletion)postsCompletion
+     referrersCompletionHandler:(StatsGroupCompletion)referrersCompletion
+        clicksCompletionHandler:(StatsGroupCompletion)clicksCompletion
+       countryCompletionHandler:(StatsGroupCompletion)countryCompletion
+        videosCompletionHandler:(StatsGroupCompletion)videosCompletion
+commentsAuthorCompletionHandler:(StatsGroupCompletion)commentsAuthorsCompletion
+ commentsPostsCompletionHandler:(StatsGroupCompletion)commentsPostsCompletion
+tagsCategoriesCompletionHandler:(StatsGroupCompletion)tagsCategoriesCompletion
+followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
+ followersEmailCompletionHandler:(StatsGroupCompletion)followersEmailCompletion
+      publicizeCompletionHandler:(StatsGroupCompletion)publicizeCompletion
      andOverallCompletionHandler:(void (^)())completionHandler;
+
+- (void)retrievePostsForDate:(NSDate *)date
+                     andUnit:(StatsPeriodUnit)unit
+       withCompletionHandler:(StatsGroupCompletion)completionHandler;
+
+- (void)retrieveReferrersForDate:(NSDate *)date
+                         andUnit:(StatsPeriodUnit)unit
+           withCompletionHandler:(StatsGroupCompletion)completionHandler;
+
+- (void)retrieveClicksForDate:(NSDate *)date
+                      andUnit:(StatsPeriodUnit)unit
+        withCompletionHandler:(StatsGroupCompletion)completionHandler;
+
+- (void)retrieveCountriesForDate:(NSDate *)date
+                         andUnit:(StatsPeriodUnit)unit
+           withCompletionHandler:(StatsGroupCompletion)completionHandler;
+
+- (void)retrieveVideosForDate:(NSDate *)date
+                      andUnit:(StatsPeriodUnit)unit
+        withCompletionHandler:(StatsGroupCompletion)completionHandler;
+
+- (void)retrieveFollowersOfType:(StatsFollowerType)followersType
+                        forDate:(NSDate *)date
+                        andUnit:(StatsPeriodUnit)unit
+          withCompletionHandler:(StatsGroupCompletion)completionHandler;
+
 
 - (void)retrieveTodayStatsWithCompletionHandler:(StatsSummaryCompletion)completion failureHandler:(void (^)(NSError *))failureHandler;
 

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -7,23 +7,7 @@
 #import "StatsSummary.h"
 #import "StatsEphemory.h"
 #import "StatsDateUtilities.h"
-
-typedef NS_ENUM(NSInteger, StatsCache) {
-    StatsCacheNone,
-    StatsCacheVisits,
-    StatsCacheEvents,
-    StatsCachePosts,
-    StatsCacheReferrers,
-    StatsCacheClicks,
-    StatsCacheCountry,
-    StatsCacheVideos,
-    StatsCacheCommentsAuthors,
-    StatsCacheCommentsPosts,
-    StatsCacheTagsCategories,
-    StatsCacheFollowersDotCom,
-    StatsCacheFollowersEmail,
-    StatsCachePublicize
-};
+#import "StatsSection.h"
 
 @interface WPStatsService ()
 
@@ -89,60 +73,60 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
     }
     
     NSDate *endDate = [self.dateUtilities calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
-    NSMutableDictionary *cacheDictionary = [self.ephemory objectForKey:@[@(unit), endDate]];
+    NSMutableDictionary *cacheDictionary = [self.ephemory objectForKey:@[@"BatchStats", @(unit), endDate]];
     DDLogVerbose(@"Cache count: %@", @(cacheDictionary.count));
     
     if (cacheDictionary && cacheDictionary.count == 13) {
         if (visitsCompletion) {
-            visitsCompletion(cacheDictionary[@(StatsCacheVisits)], nil);
+            visitsCompletion(cacheDictionary[@(StatsSectionGraph)], nil);
         }
 
         if (eventsCompletion) {
-            eventsCompletion(cacheDictionary[@(StatsCacheEvents)], nil);
+            eventsCompletion(cacheDictionary[@(StatsSectionEvents)], nil);
         }
 
         if (postsCompletion) {
-            postsCompletion(cacheDictionary[@(StatsCachePosts)], nil);
+            postsCompletion(cacheDictionary[@(StatsSectionPosts)], nil);
         }
     
         if (referrersCompletion) {
-            referrersCompletion(cacheDictionary[@(StatsCacheReferrers)], nil);
+            referrersCompletion(cacheDictionary[@(StatsSectionReferrers)], nil);
         }
     
         if (clicksCompletion) {
-            clicksCompletion(cacheDictionary[@(StatsCacheClicks)], nil);
+            clicksCompletion(cacheDictionary[@(StatsSectionClicks)], nil);
         }
     
         if (countryCompletion) {
-            countryCompletion(cacheDictionary[@(StatsCacheCountry)], nil);
+            countryCompletion(cacheDictionary[@(StatsSectionCountry)], nil);
         }
     
         if (videosCompletion) {
-            videosCompletion(cacheDictionary[@(StatsCacheVideos)], nil);
+            videosCompletion(cacheDictionary[@(StatsSectionVideos)], nil);
         }
     
         if (commentsAuthorsCompletion) {
-            commentsAuthorsCompletion(cacheDictionary[@(StatsCacheCommentsAuthors)], nil);
+            commentsAuthorsCompletion(cacheDictionary[@(StatsSubSectionCommentsByAuthor)], nil);
         }
         
         if (commentsPostsCompletion) {
-            commentsPostsCompletion(cacheDictionary[@(StatsCacheCommentsPosts)], nil);
+            commentsPostsCompletion(cacheDictionary[@(StatsSubSectionCommentsByPosts)], nil);
         }
     
         if (tagsCategoriesCompletion) {
-            tagsCategoriesCompletion(cacheDictionary[@(StatsCacheTagsCategories)], nil);
+            tagsCategoriesCompletion(cacheDictionary[@(StatsSectionTagsCategories)], nil);
         }
     
         if (followersDotComCompletion) {
-            followersDotComCompletion(cacheDictionary[@(StatsCacheFollowersDotCom)], nil);
+            followersDotComCompletion(cacheDictionary[@(StatsSubSectionFollowersDotCom)], nil);
         }
     
         if (followersEmailCompletion) {
-            followersEmailCompletion(cacheDictionary[@(StatsCacheFollowersEmail)], nil);
+            followersEmailCompletion(cacheDictionary[@(StatsSubSectionFollowersEmail)], nil);
         }
     
         if (publicizeCompletion) {
-            publicizeCompletion(cacheDictionary[@(StatsCachePublicize)], nil);
+            publicizeCompletion(cacheDictionary[@(StatsSectionPublicize)], nil);
         }
         
         completionHandler();
@@ -150,24 +134,24 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
         return;
     } else {
         cacheDictionary = [NSMutableDictionary new];
-        [self.ephemory setObject:cacheDictionary forKey:@[@(unit), endDate]];
+        [self.ephemory setObject:cacheDictionary forKey:@[@"BatchStats", @(unit), endDate]];
     }
 
     [self.remote cancelAllRemoteOperations];
     [self.remote batchFetchStatsForDate:endDate
                                 andUnit:unit
             withVisitsCompletionHandler:[self remoteVisitsCompletionWithCache:cacheDictionary andCompletionHandler:visitsCompletion]
-                eventsCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheEvents andCompletionHandler:eventsCompletion]
-                 postsCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCachePosts andCompletionHandler:postsCompletion]
-             referrersCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheReferrers andCompletionHandler:referrersCompletion]
-                clicksCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheClicks andCompletionHandler:clicksCompletion]
-               countryCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheCountry andCompletionHandler:countryCompletion]
-                videosCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheVideos andCompletionHandler:videosCompletion]
+                eventsCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionEvents andCompletionHandler:eventsCompletion]
+                 postsCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionPosts andCompletionHandler:postsCompletion]
+             referrersCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionReferrers andCompletionHandler:referrersCompletion]
+                clicksCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionClicks andCompletionHandler:clicksCompletion]
+               countryCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionCountry andCompletionHandler:countryCompletion]
+                videosCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionVideos andCompletionHandler:videosCompletion]
               commentsCompletionHandler:[self remoteCommentsCompletionWithCache:cacheDictionary andCommentsAuthorsCompletion:commentsAuthorsCompletion commentsPostsCompletion:commentsPostsCompletion]
-        tagsCategoriesCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheTagsCategories andCompletionHandler:tagsCategoriesCompletion]
-       followersDotComCompletionHandler:[self remoteFollowersCompletionWithCache:cacheDictionary cacheType:StatsCacheFollowersDotCom andCompletionHandler:followersDotComCompletion]
-        followersEmailCompletionHandler:[self remoteFollowersCompletionWithCache:cacheDictionary cacheType:StatsCacheFollowersEmail andCompletionHandler:followersEmailCompletion]
-             publicizeCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCachePublicize andCompletionHandler:publicizeCompletion]
+        tagsCategoriesCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionTagsCategories andCompletionHandler:tagsCategoriesCompletion]
+       followersDotComCompletionHandler:[self remoteFollowersCompletionWithCache:cacheDictionary followerType:StatsFollowerTypeDotCom andCompletionHandler:followersDotComCompletion]
+        followersEmailCompletionHandler:[self remoteFollowersCompletionWithCache:cacheDictionary followerType:StatsFollowerTypeEmail andCompletionHandler:followersEmailCompletion]
+             publicizeCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionPublicize andCompletionHandler:publicizeCompletion]
             andOverallCompletionHandler:^
     {
         completionHandler();
@@ -179,8 +163,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                      andUnit:(StatsPeriodUnit)unit
        withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchPostsStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
-    
+    [self.remote fetchPostsStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil forStatsSection:StatsSectionPosts andCompletionHandler:completionHandler]];
 }
 
 
@@ -188,7 +171,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                          andUnit:(StatsPeriodUnit)unit
            withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchReferrersStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
+    [self.remote fetchReferrersStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil forStatsSection:StatsSectionReferrers andCompletionHandler:completionHandler]];
 }
 
 
@@ -196,7 +179,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                       andUnit:(StatsPeriodUnit)unit
         withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchClicksStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
+    [self.remote fetchClicksStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil  forStatsSection:StatsSectionClicks andCompletionHandler:completionHandler]];
 }
 
 
@@ -204,7 +187,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                          andUnit:(StatsPeriodUnit)unit
            withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchCountryStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
+    [self.remote fetchCountryStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil  forStatsSection:StatsSectionCountry andCompletionHandler:completionHandler]];
 }
 
 
@@ -212,7 +195,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                       andUnit:(StatsPeriodUnit)unit
         withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchVideosStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
+    [self.remote fetchVideosStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil forStatsSection:StatsSectionVideos andCompletionHandler:completionHandler]];
 }
 
 
@@ -221,7 +204,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                         andUnit:(StatsPeriodUnit)unit
           withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchFollowersStatsForFollowerType:followersType date:date andUnit:unit withCompletionHandler:[self remoteFollowersCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
+    [self.remote fetchFollowersStatsForFollowerType:followersType date:date andUnit:unit withCompletionHandler:[self remoteFollowersCompletionWithCache:nil followerType:followersType andCompletionHandler:completionHandler]];
 }
 
 
@@ -280,7 +263,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
 {
     return ^(StatsVisits *visits, NSError *error)
     {
-        cacheDictionary[@(StatsCacheVisits)] = visits;
+        cacheDictionary[@(StatsSectionGraph)] = visits;
         visits.errorWhileRetrieving = error != nil;
         
         if (visitsCompletion) {
@@ -290,18 +273,16 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
 }
 
 
-- (StatsRemoteItemsCompletion)remoteItemCompletionWithCache:(NSMutableDictionary *)cacheDictionary cacheType:(StatsCache)cacheType andCompletionHandler:(StatsGroupCompletion)groupCompletion
+- (StatsRemoteItemsCompletion)remoteItemCompletionWithCache:(NSMutableDictionary *)cacheDictionary forStatsSection:(StatsSection)statsSection andCompletionHandler:(StatsGroupCompletion)groupCompletion
 {
     return ^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
     {
-        StatsGroup *groupResult = [StatsGroup new];
+        StatsGroup *groupResult = [[StatsGroup alloc] initWithStatsSection:statsSection andStatsSubSection:StatsSubSectionNone];
         groupResult.items = items;
         groupResult.moreItemsExist = moreViewsAvailable;
         groupResult.errorWhileRetrieving = error != nil;
         
-        if (!cacheDictionary && cacheType != StatsCacheNone) {
-            cacheDictionary[@(cacheType)] = groupResult;
-        }
+        cacheDictionary[@(statsSection)] = groupResult;
         
         if (groupCompletion) {
             groupCompletion(groupResult, error);
@@ -316,18 +297,16 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
 {
     return ^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
     {
-        StatsGroup *commentsAuthorsResult = [StatsGroup new];
+        StatsGroup *commentsAuthorsResult = [[StatsGroup alloc] initWithStatsSection:StatsSectionComments andStatsSubSection:StatsSubSectionCommentsByAuthor];
         commentsAuthorsResult.items = items.firstObject;
         commentsAuthorsResult.errorWhileRetrieving = error != nil;
         
-        StatsGroup *commentsPostsResult = [StatsGroup new];
+        StatsGroup *commentsPostsResult = [[StatsGroup alloc] initWithStatsSection:StatsSectionComments andStatsSubSection:StatsSubSectionCommentsByPosts];
         commentsPostsResult.items = items.lastObject;
         commentsPostsResult.errorWhileRetrieving = error != nil;
         
-        if (!cacheDictionary) {
-            cacheDictionary[@(StatsCacheCommentsAuthors)] = commentsAuthorsResult;
-            cacheDictionary[@(StatsCacheCommentsPosts)] = commentsPostsResult;
-        }
+        cacheDictionary[@(StatsSubSectionCommentsByAuthor)] = commentsAuthorsResult;
+        cacheDictionary[@(StatsSubSectionCommentsByPosts)] = commentsPostsResult;
         
         if (commentsAuthorsCompletion) {
             commentsAuthorsCompletion(commentsAuthorsResult, error);
@@ -340,17 +319,18 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
 }
 
 
-- (StatsRemoteItemsCompletion)remoteFollowersCompletionWithCache:(NSMutableDictionary *)cacheDictionary cacheType:(StatsCache)cacheType andCompletionHandler:(StatsGroupCompletion)groupCompletion
+- (StatsRemoteItemsCompletion)remoteFollowersCompletionWithCache:(NSMutableDictionary *)cacheDictionary followerType:(StatsFollowerType)followerType andCompletionHandler:(StatsGroupCompletion)groupCompletion
 {
     return ^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
     {
-        StatsGroup *followersResult = [StatsGroup new];
+        StatsSubSection statsSubSection = followerType == StatsFollowerTypeDotCom ? StatsSubSectionFollowersDotCom : StatsSubSectionFollowersEmail;
+        StatsGroup *followersResult = [[StatsGroup alloc] initWithStatsSection:StatsSectionFollowers andStatsSubSection:statsSubSection];
         followersResult.items = items;
         followersResult.moreItemsExist = moreViewsAvailable;
         followersResult.totalCount = totalViews;
         followersResult.errorWhileRetrieving = error != nil;
         
-        cacheDictionary[@(cacheType)] = followersResult;
+        cacheDictionary[@(statsSubSection)] = followersResult;
         
         for (StatsItem *item in items) {
             NSString *age = [self dateAgeForDate:item.date];

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -264,7 +264,11 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
     return ^(StatsVisits *visits, NSError *error)
     {
         cacheDictionary[@(StatsSectionGraph)] = visits;
-        visits.errorWhileRetrieving = error != nil;
+        
+        if (error) {
+            DDLogError(@"Error while fetching Visits: %@", error);
+            visits.errorWhileRetrieving = YES;
+        }
         
         if (visitsCompletion) {
             visitsCompletion(visits, error);

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -257,6 +257,11 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
 }
 
 
+- (void)cancelAnyRunningOperations
+{
+    [self.remote cancelAllRemoteOperations];
+}
+
 #pragma mark - Private completion handler helpers
 
 - (StatsRemoteVisitsCompletion)remoteVisitsCompletionWithCache:(NSMutableDictionary *)cacheDictionary andCompletionHandler:(StatsVisitsCompletion)visitsCompletion

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -9,6 +9,7 @@
 #import "StatsDateUtilities.h"
 
 typedef NS_ENUM(NSInteger, StatsCache) {
+    StatsCacheNone,
     StatsCacheVisits,
     StatsCacheEvents,
     StatsCachePosts,
@@ -178,9 +179,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                      andUnit:(StatsPeriodUnit)unit
        withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchPostsStatsForDate:date andUnit:unit withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error) {
-        
-    }];
+    [self.remote fetchPostsStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
     
 }
 
@@ -189,7 +188,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                          andUnit:(StatsPeriodUnit)unit
            withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    
+    [self.remote fetchReferrersStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
 }
 
 
@@ -197,7 +196,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                       andUnit:(StatsPeriodUnit)unit
         withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    
+    [self.remote fetchClicksStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
 }
 
 
@@ -205,7 +204,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                          andUnit:(StatsPeriodUnit)unit
            withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    
+    [self.remote fetchCountryStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
 }
 
 
@@ -213,7 +212,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                       andUnit:(StatsPeriodUnit)unit
         withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    
+    [self.remote fetchVideosStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
 }
 
 
@@ -222,7 +221,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                         andUnit:(StatsPeriodUnit)unit
           withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    
+    [self.remote fetchFollowersStatsForFollowerType:followersType date:date andUnit:unit withCompletionHandler:[self remoteFollowersCompletionWithCache:nil cacheType:StatsCacheNone andCompletionHandler:completionHandler]];
 }
 
 
@@ -300,7 +299,9 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
         groupResult.moreItemsExist = moreViewsAvailable;
         groupResult.errorWhileRetrieving = error != nil;
         
-        cacheDictionary[@(cacheType)] = groupResult;
+        if (!cacheDictionary && cacheType != StatsCacheNone) {
+            cacheDictionary[@(cacheType)] = groupResult;
+        }
         
         if (groupCompletion) {
             groupCompletion(groupResult, error);
@@ -318,12 +319,15 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
         StatsGroup *commentsAuthorsResult = [StatsGroup new];
         commentsAuthorsResult.items = items.firstObject;
         commentsAuthorsResult.errorWhileRetrieving = error != nil;
-        cacheDictionary[@(StatsCacheCommentsAuthors)] = commentsAuthorsResult;
         
         StatsGroup *commentsPostsResult = [StatsGroup new];
         commentsPostsResult.items = items.lastObject;
         commentsPostsResult.errorWhileRetrieving = error != nil;
-        cacheDictionary[@(StatsCacheCommentsPosts)] = commentsPostsResult;
+        
+        if (!cacheDictionary) {
+            cacheDictionary[@(StatsCacheCommentsAuthors)] = commentsAuthorsResult;
+            cacheDictionary[@(StatsCacheCommentsPosts)] = commentsPostsResult;
+        }
         
         if (commentsAuthorsCompletion) {
             commentsAuthorsCompletion(commentsAuthorsResult, error);

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -69,18 +69,18 @@ typedef NS_ENUM(NSInteger, StatsCache) {
 - (void)retrieveAllStatsForDate:(NSDate *)date
                         andUnit:(StatsPeriodUnit)unit
     withVisitsCompletionHandler:(StatsVisitsCompletion)visitsCompletion
-        eventsCompletionHandler:(StatsItemsCompletion)eventsCompletion
-         postsCompletionHandler:(StatsItemsCompletion)postsCompletion
-     referrersCompletionHandler:(StatsItemsCompletion)referrersCompletion
-        clicksCompletionHandler:(StatsItemsCompletion)clicksCompletion
-       countryCompletionHandler:(StatsItemsCompletion)countryCompletion
-        videosCompletionHandler:(StatsItemsCompletion)videosCompletion
-commentsAuthorCompletionHandler:(StatsItemsCompletion)commentsAuthorsCompletion
- commentsPostsCompletionHandler:(StatsItemsCompletion)commentsPostsCompletion
-tagsCategoriesCompletionHandler:(StatsItemsCompletion)tagsCategoriesCompletion
-followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
- followersEmailCompletionHandler:(StatsItemsCompletion)followersEmailCompletion
-      publicizeCompletionHandler:(StatsItemsCompletion)publicizeCompletion
+        eventsCompletionHandler:(StatsGroupCompletion)eventsCompletion
+         postsCompletionHandler:(StatsGroupCompletion)postsCompletion
+     referrersCompletionHandler:(StatsGroupCompletion)referrersCompletion
+        clicksCompletionHandler:(StatsGroupCompletion)clicksCompletion
+       countryCompletionHandler:(StatsGroupCompletion)countryCompletion
+        videosCompletionHandler:(StatsGroupCompletion)videosCompletion
+commentsAuthorCompletionHandler:(StatsGroupCompletion)commentsAuthorsCompletion
+ commentsPostsCompletionHandler:(StatsGroupCompletion)commentsPostsCompletion
+tagsCategoriesCompletionHandler:(StatsGroupCompletion)tagsCategoriesCompletion
+followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
+ followersEmailCompletionHandler:(StatsGroupCompletion)followersEmailCompletion
+      publicizeCompletionHandler:(StatsGroupCompletion)publicizeCompletion
      andOverallCompletionHandler:(void (^)())completionHandler
 {
     if (!completionHandler) {
@@ -155,183 +155,74 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
     [self.remote cancelAllRemoteOperations];
     [self.remote batchFetchStatsForDate:endDate
                                 andUnit:unit
-            withVisitsCompletionHandler:^(StatsVisits *visits, NSError *error)
-     {
-         cacheDictionary[@(StatsCacheVisits)] = visits;
-         visits.errorWhileRetrieving = error != nil;
-         
-         if (visitsCompletion) {
-             visitsCompletion(visits, error);
-         }
-     }
-                 eventsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
-     {
-         StatsGroup *eventsResult = [StatsGroup new];
-         eventsResult.items = items;
-         eventsResult.moreItemsExist = moreViewsAvailable;
-         eventsResult.errorWhileRetrieving = error != nil;
-
-         cacheDictionary[@(StatsCacheEvents)] = eventsResult;
-         
-         if (eventsCompletion) {
-             eventsCompletion(eventsResult, error);
-         }
-     }
-                  postsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
-     {
-         StatsGroup *postsResult = [StatsGroup new];
-         postsResult.items = items;
-         postsResult.titlePrimary = NSLocalizedString(@"Posts & Pages", @"Title for stats section for Posts & Pages");
-         postsResult.moreItemsExist = moreViewsAvailable;
-         postsResult.errorWhileRetrieving = error != nil;
-
-         cacheDictionary[@(StatsCachePosts)] = postsResult;
-
-         if (postsCompletion) {
-             postsCompletion(postsResult, error);
-         }
-     }
-             referrersCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
-     {
-         StatsGroup *referrersResult = [StatsGroup new];
-         referrersResult.items = items;
-         referrersResult.moreItemsExist = moreViewsAvailable;
-		 referrersResult.errorWhileRetrieving = error != nil;
-		 
-         cacheDictionary[@(StatsCacheReferrers)] = referrersResult;
-
-         if (referrersCompletion) {
-             referrersCompletion(referrersResult, error);
-         }
-     }
-                clicksCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
-     {
-         StatsGroup *clicksResult = [StatsGroup new];
-         clicksResult.items = items;
-         clicksResult.moreItemsExist = moreViewsAvailable;
-         clicksResult.errorWhileRetrieving = error != nil;
-		 
-         cacheDictionary[@(StatsCacheClicks)] = clicksResult;
-         
-         if (clicksCompletion) {
-             clicksCompletion(clicksResult, error);
-         }
-     }
-               countryCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
-     {
-         StatsGroup *countriesResult = [StatsGroup new];
-         countriesResult.items = items;
-         countriesResult.moreItemsExist = moreViewsAvailable;
-         countriesResult.errorWhileRetrieving = error != nil;
-
-         cacheDictionary[@(StatsCacheCountry)] = countriesResult;
-         
-         if (countryCompletion) {
-             countryCompletion(countriesResult, error);
-         }
-     }
-                videosCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
-     {
-         StatsGroup *videosResult = [StatsGroup new];
-         videosResult.items = items;
-         videosResult.moreItemsExist = moreViewsAvailable;
-         videosResult.errorWhileRetrieving = error != nil;
-
-         cacheDictionary[@(StatsCacheVideos)] = videosResult;
-
-         if (videosCompletion) {
-             videosCompletion(videosResult, error);
-         }
-     }
-              commentsCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
-     {
-         StatsGroup *commentsAuthorsResult = [StatsGroup new];
-         commentsAuthorsResult.items = items.firstObject;
-         commentsAuthorsResult.errorWhileRetrieving = error != nil;
-         cacheDictionary[@(StatsCacheCommentsAuthors)] = commentsAuthorsResult;
-
-         StatsGroup *commentsPostsResult = [StatsGroup new];
-         commentsPostsResult.items = items.lastObject;
-         commentsPostsResult.errorWhileRetrieving = error != nil;
-         cacheDictionary[@(StatsCacheCommentsPosts)] = commentsPostsResult;
-         
-         if (commentsAuthorsCompletion) {
-             commentsAuthorsCompletion(commentsAuthorsResult, error);
-         }
-         
-         if (commentsPostsCompletion) {
-             commentsPostsCompletion(commentsPostsResult, error);
-         }
-     }
-        tagsCategoriesCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
-     {
-         StatsGroup *tagsCategoriesResult = [StatsGroup new];
-         tagsCategoriesResult.items = items;
-         tagsCategoriesResult.moreItemsExist = moreViewsAvailable;
-         tagsCategoriesResult.errorWhileRetrieving = error != nil;
-
-         cacheDictionary[@(StatsCacheTagsCategories)] = tagsCategoriesResult;
-
-         if (tagsCategoriesCompletion) {
-             tagsCategoriesCompletion(tagsCategoriesResult, error);
-         }
-     }
-       followersDotComCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
-     {
-         StatsGroup *followersDotComResult = [StatsGroup new];
-         followersDotComResult.items = items;
-         followersDotComResult.moreItemsExist = moreViewsAvailable;
-         followersDotComResult.totalCount = totalViews;
-         followersDotComResult.errorWhileRetrieving = error != nil;
-
-         cacheDictionary[@(StatsCacheFollowersDotCom)] = followersDotComResult;
-
-         for (StatsItem *item in items) {
-             NSString *age = [self dateAgeForDate:item.date];
-             item.value = age;
-         }
-         
-         if (followersDotComCompletion) {
-             followersDotComCompletion(followersDotComResult, error);
-         }
-     }
-         followersEmailCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
-     {
-         StatsGroup *followersEmailResult = [StatsGroup new];
-         followersEmailResult.items = items;
-         followersEmailResult.moreItemsExist = moreViewsAvailable;
-         followersEmailResult.totalCount = totalViews;
-         followersEmailResult.errorWhileRetrieving = error != nil;
-
-         cacheDictionary[@(StatsCacheFollowersEmail)] = followersEmailResult;
-
-         for (StatsItem *item in items) {
-             NSString *age = [self dateAgeForDate:item.date];
-             item.value = age;
-         }
-         
-         if (followersEmailCompletion) {
-             followersEmailCompletion(followersEmailResult, error);
-         }
-     }
-
-              publicizeCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
-    {
-        StatsGroup *publicizeResult = [StatsGroup new];
-        publicizeResult.items = items;
-        publicizeResult.moreItemsExist = moreViewsAvailable;
-        publicizeResult.errorWhileRetrieving = error != nil;
-
-        cacheDictionary[@(StatsCachePublicize)] = publicizeResult;
-
-        if (publicizeCompletion) {
-            publicizeCompletion(publicizeResult, nil);
-        }
-    }
-             andOverallCompletionHandler:^
+            withVisitsCompletionHandler:[self remoteVisitsCompletionWithCache:cacheDictionary andCompletionHandler:visitsCompletion]
+                eventsCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheEvents andCompletionHandler:eventsCompletion]
+                 postsCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCachePosts andCompletionHandler:postsCompletion]
+             referrersCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheReferrers andCompletionHandler:referrersCompletion]
+                clicksCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheClicks andCompletionHandler:clicksCompletion]
+               countryCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheCountry andCompletionHandler:countryCompletion]
+                videosCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheVideos andCompletionHandler:videosCompletion]
+              commentsCompletionHandler:[self remoteCommentsCompletionWithCache:cacheDictionary andCommentsAuthorsCompletion:commentsAuthorsCompletion commentsPostsCompletion:commentsPostsCompletion]
+        tagsCategoriesCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCacheTagsCategories andCompletionHandler:tagsCategoriesCompletion]
+       followersDotComCompletionHandler:[self remoteFollowersCompletionWithCache:cacheDictionary cacheType:StatsCacheFollowersDotCom andCompletionHandler:followersDotComCompletion]
+        followersEmailCompletionHandler:[self remoteFollowersCompletionWithCache:cacheDictionary cacheType:StatsCacheFollowersEmail andCompletionHandler:followersEmailCompletion]
+             publicizeCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary cacheType:StatsCachePublicize andCompletionHandler:publicizeCompletion]
+            andOverallCompletionHandler:^
     {
         completionHandler();
     }];
+}
+
+
+- (void)retrievePostsForDate:(NSDate *)date
+                     andUnit:(StatsPeriodUnit)unit
+       withCompletionHandler:(StatsGroupCompletion)completionHandler
+{
+    [self.remote fetchPostsStatsForDate:date andUnit:unit withCompletionHandler:^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error) {
+        
+    }];
+    
+}
+
+
+- (void)retrieveReferrersForDate:(NSDate *)date
+                         andUnit:(StatsPeriodUnit)unit
+           withCompletionHandler:(StatsGroupCompletion)completionHandler
+{
+    
+}
+
+
+- (void)retrieveClicksForDate:(NSDate *)date
+                      andUnit:(StatsPeriodUnit)unit
+        withCompletionHandler:(StatsGroupCompletion)completionHandler
+{
+    
+}
+
+
+- (void)retrieveCountriesForDate:(NSDate *)date
+                         andUnit:(StatsPeriodUnit)unit
+           withCompletionHandler:(StatsGroupCompletion)completionHandler
+{
+    
+}
+
+
+- (void)retrieveVideosForDate:(NSDate *)date
+                      andUnit:(StatsPeriodUnit)unit
+        withCompletionHandler:(StatsGroupCompletion)completionHandler
+{
+    
+}
+
+
+- (void)retrieveFollowersOfType:(StatsFollowerType)followersType
+                        forDate:(NSDate *)date
+                        andUnit:(StatsPeriodUnit)unit
+          withCompletionHandler:(StatsGroupCompletion)completionHandler
+{
+    
 }
 
 
@@ -382,6 +273,94 @@ followersDotComCompletionHandler:(StatsItemsCompletion)followersDotComCompletion
 {
     [self.ephemory removeAllObjects];
 }
+
+
+#pragma mark - Private completion handler helpers
+
+- (StatsRemoteVisitsCompletion)remoteVisitsCompletionWithCache:(NSMutableDictionary *)cacheDictionary andCompletionHandler:(StatsVisitsCompletion)visitsCompletion
+{
+    return ^(StatsVisits *visits, NSError *error)
+    {
+        cacheDictionary[@(StatsCacheVisits)] = visits;
+        visits.errorWhileRetrieving = error != nil;
+        
+        if (visitsCompletion) {
+            visitsCompletion(visits, error);
+        }
+    };
+}
+
+
+- (StatsRemoteItemsCompletion)remoteItemCompletionWithCache:(NSMutableDictionary *)cacheDictionary cacheType:(StatsCache)cacheType andCompletionHandler:(StatsGroupCompletion)groupCompletion
+{
+    return ^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
+    {
+        StatsGroup *groupResult = [StatsGroup new];
+        groupResult.items = items;
+        groupResult.moreItemsExist = moreViewsAvailable;
+        groupResult.errorWhileRetrieving = error != nil;
+        
+        cacheDictionary[@(cacheType)] = groupResult;
+        
+        if (groupCompletion) {
+            groupCompletion(groupResult, error);
+        }
+    };
+}
+
+
+- (StatsRemoteItemsCompletion)remoteCommentsCompletionWithCache:(NSMutableDictionary *)cacheDictionary
+                                    andCommentsAuthorsCompletion:(StatsGroupCompletion)commentsAuthorsCompletion
+                                        commentsPostsCompletion:(StatsGroupCompletion)commentsPostsCompletion
+{
+    return ^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
+    {
+        StatsGroup *commentsAuthorsResult = [StatsGroup new];
+        commentsAuthorsResult.items = items.firstObject;
+        commentsAuthorsResult.errorWhileRetrieving = error != nil;
+        cacheDictionary[@(StatsCacheCommentsAuthors)] = commentsAuthorsResult;
+        
+        StatsGroup *commentsPostsResult = [StatsGroup new];
+        commentsPostsResult.items = items.lastObject;
+        commentsPostsResult.errorWhileRetrieving = error != nil;
+        cacheDictionary[@(StatsCacheCommentsPosts)] = commentsPostsResult;
+        
+        if (commentsAuthorsCompletion) {
+            commentsAuthorsCompletion(commentsAuthorsResult, error);
+        }
+        
+        if (commentsPostsCompletion) {
+            commentsPostsCompletion(commentsPostsResult, error);
+        }
+    };
+}
+
+
+- (StatsRemoteItemsCompletion)remoteFollowersCompletionWithCache:(NSMutableDictionary *)cacheDictionary cacheType:(StatsCache)cacheType andCompletionHandler:(StatsGroupCompletion)groupCompletion
+{
+    return ^(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error)
+    {
+        StatsGroup *followersResult = [StatsGroup new];
+        followersResult.items = items;
+        followersResult.moreItemsExist = moreViewsAvailable;
+        followersResult.totalCount = totalViews;
+        followersResult.errorWhileRetrieving = error != nil;
+        
+        cacheDictionary[@(cacheType)] = followersResult;
+        
+        for (StatsItem *item in items) {
+            NSString *age = [self dateAgeForDate:item.date];
+            item.value = age;
+        }
+        
+        if (groupCompletion) {
+            groupCompletion(followersResult, error);
+        }
+    };
+}
+
+
+#pragma mark - Private helper methods
 
 
 // TODO - Extract this into a separate class that's unit testable

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
@@ -1,16 +1,11 @@
 #import <Foundation/Foundation.h>
 #import "StatsSummary.h"
 #import "StatsVisits.h"
+#import "WPStatsService.h"
 
 typedef void (^StatsRemoteSummaryCompletion)(StatsSummary *summary, NSError *error);
 typedef void (^StatsRemoteVisitsCompletion)(StatsVisits *visits, NSError *error);
 typedef void (^StatsRemoteItemsCompletion)(NSArray *items, NSString *totalViews, BOOL moreViewsAvailable, NSError *error);
-
-typedef NS_ENUM(NSUInteger, StatsFollowerType) {
-    StatsFollowerTypeDotCom,
-    StatsFollowerTypeEmail
-};
-
 
 @interface WPStatsServiceRemote : NSObject
 

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -90,19 +90,19 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         [mutableOperations addObject:[self operationForEventsForDate:date andUnit:unit withCompletionHandler:eventsCompletion]];
     }
     if (postsCompletion) {
-        [mutableOperations addObject:[self operationForPostsForDate:date andUnit:unit withCompletionHandler:postsCompletion]];
+        [mutableOperations addObject:[self operationForPostsForDate:date andUnit:unit viewAll:NO withCompletionHandler:postsCompletion]];
     }
     if (referrersCompletion) {
-        [mutableOperations addObject:[self operationForReferrersForDate:date andUnit:unit withCompletionHandler:referrersCompletion]];
+        [mutableOperations addObject:[self operationForReferrersForDate:date andUnit:unit viewAll:NO withCompletionHandler:referrersCompletion]];
     }
     if (clicksCompletion) {
-        [mutableOperations addObject:[self operationForClicksForDate:date andUnit:unit withCompletionHandler:clicksCompletion]];
+        [mutableOperations addObject:[self operationForClicksForDate:date andUnit:unit viewAll:NO withCompletionHandler:clicksCompletion]];
     }
     if (countryCompletion) {
-        [mutableOperations addObject:[self operationForCountryForDate:date andUnit:unit withCompletionHandler:countryCompletion]];
+        [mutableOperations addObject:[self operationForCountryForDate:date andUnit:unit viewAll:NO withCompletionHandler:countryCompletion]];
     }
     if (videosCompletion) {
-        [mutableOperations addObject:[self operationForVideosForDate:date andUnit:unit withCompletionHandler:videosCompletion]];
+        [mutableOperations addObject:[self operationForVideosForDate:date andUnit:unit viewAll:NO withCompletionHandler:videosCompletion]];
     }
     if (commentsCompletion) {
         [mutableOperations addObject:[self operationForCommentsForDate:date andUnit:unit withCompletionHandler:commentsCompletion]];
@@ -111,10 +111,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         [mutableOperations addObject:[self operationForTagsCategoriesForDate:date andUnit:unit withCompletionHandler:tagsCategoriesCompletion]];
     }
     if (followersDotComCompletion) {
-        [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeDotCom forDate:date andUnit:unit withCompletionHandler:followersDotComCompletion]];
+        [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeDotCom forDate:date andUnit:unit viewAll:NO withCompletionHandler:followersDotComCompletion]];
     }
     if (followersEmailCompletion) {
-        [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeEmail forDate:date andUnit:unit withCompletionHandler:followersEmailCompletion]];
+        [mutableOperations addObject:[self operationForFollowersOfType:StatsFollowerTypeEmail forDate:date andUnit:unit viewAll:NO withCompletionHandler:followersEmailCompletion]];
     }
     if (publicizeCompletion) {
         [mutableOperations addObject:[self operationForPublicizeForDate:date andUnit:unit withCompletionHandler:publicizeCompletion]];
@@ -171,7 +171,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForPostsForDate:date andUnit:unit withCompletionHandler:completionHandler];
+    AFHTTPRequestOperation *operation = [self operationForPostsForDate:date andUnit:unit viewAll:YES withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -182,7 +182,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForReferrersForDate:date andUnit:unit withCompletionHandler:completionHandler];
+    AFHTTPRequestOperation *operation = [self operationForReferrersForDate:date andUnit:unit viewAll:YES withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -193,7 +193,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForClicksForDate:date andUnit:unit withCompletionHandler:completionHandler];
+    AFHTTPRequestOperation *operation = [self operationForClicksForDate:date andUnit:unit viewAll:YES withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -204,7 +204,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForCountryForDate:date andUnit:unit withCompletionHandler:completionHandler];
+    AFHTTPRequestOperation *operation = [self operationForCountryForDate:date andUnit:unit viewAll:YES withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -215,7 +215,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForVideosForDate:date andUnit:unit withCompletionHandler:completionHandler];
+    AFHTTPRequestOperation *operation = [self operationForVideosForDate:date andUnit:unit viewAll:YES withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -249,7 +249,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 {
     NSParameterAssert(date != nil);
     
-    AFHTTPRequestOperation *operation = [self operationForFollowersOfType:followerType forDate:date andUnit:unit withCompletionHandler:completionHandler];
+    AFHTTPRequestOperation *operation = [self operationForFollowersOfType:followerType forDate:date andUnit:unit viewAll:YES withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -414,6 +414,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 
 - (AFHTTPRequestOperation *)operationForPostsForDate:(NSDate *)date
                                              andUnit:(StatsPeriodUnit)unit
+                                             viewAll:(BOOL)viewAll
                                withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
@@ -449,7 +450,8 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date]};
+                                 @"date"   : [self siteLocalStringForDate:date],
+                                 @"max"    : (viewAll ? @0 : @10) };
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForTopPosts]
                                                                  parameters:parameters
                                                                     success:handler
@@ -460,6 +462,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 
 - (AFHTTPRequestOperation *)operationForReferrersForDate:(NSDate *)date
                                                  andUnit:(StatsPeriodUnit)unit
+                                                 viewAll:(BOOL)viewAll
                                    withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
@@ -535,7 +538,8 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date]};
+                                 @"date"   : [self siteLocalStringForDate:date],
+                                 @"max"    : (viewAll ? @0 : @10) };
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForReferrers]
                                                                 parameters:parameters
@@ -548,7 +552,8 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 
 - (AFHTTPRequestOperation *)operationForClicksForDate:(NSDate *)date
                                               andUnit:(StatsPeriodUnit)unit
-                                withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
+                                              viewAll:(BOOL)viewAll
+                               withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
@@ -603,7 +608,8 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date]};
+                                 @"date"   : [self siteLocalStringForDate:date],
+                                 @"max"    : (viewAll ? @0 : @10) };
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForClicks]
                                                                 parameters:parameters
@@ -615,6 +621,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 
 - (AFHTTPRequestOperation *)operationForCountryForDate:(NSDate *)date
                                                andUnit:(StatsPeriodUnit)unit
+                                               viewAll:(BOOL)viewAll
                                  withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
@@ -645,7 +652,8 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date]};
+                                 @"date"   : [self siteLocalStringForDate:date],
+                                 @"max"    : (viewAll ? @0 : @10) };
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForCountryViews]
                                                                 parameters:parameters
@@ -658,6 +666,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 
 - (AFHTTPRequestOperation *)operationForVideosForDate:(NSDate *)date
                                               andUnit:(StatsPeriodUnit)unit
+                                              viewAll:(BOOL)viewAll
                                 withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
@@ -694,7 +703,8 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date]};
+                                 @"date"   : [self siteLocalStringForDate:date],
+                                 @"max"    : (viewAll ? @0 : @10) };
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForVideos]
                                                                 parameters:parameters
@@ -822,6 +832,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 - (AFHTTPRequestOperation *)operationForFollowersOfType:(StatsFollowerType)followerType
                                                 forDate:(NSDate *)date
                                                 andUnit:(StatsPeriodUnit)unit
+                                                viewAll:(BOOL)viewAll
                                   withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
@@ -855,7 +866,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
                                  @"date"   : [self siteLocalStringForDate:date],
                                  @"type"   : followerType == StatsFollowerTypeDotCom ? @"wpcom" : @"email",
-                                 @"max"    : @7}; // TODO - Change this to a non-fixed value?
+                                 @"max"    : (viewAll ? @0 : @7) };
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForFollowers]
                                                                 parameters:parameters


### PR DESCRIPTION
Closes #116 

Implements View All for posts, referrers, clicks, countries, videos and followers. Also made a few architectural improvements with StatsGroup and code reuse between the original stats view controller and the view all controller. More work could be done to share additional logic but this is a decent first attempt. :smile: 

![viewallanimated](https://cloud.githubusercontent.com/assets/373903/5962351/ee1456fc-a7a8-11e4-8dcc-7f1490173f9e.gif)

