### PR TITLE
Fixed subsection selections

### DIFF
--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -428,7 +428,7 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
             break;
     }
     
-    self.selectedSubsections[@(section)] = @(subSection);
+    self.selectedSubsections[@(statsSection)] = @(subSection);
     NSInteger newSectionCount = [self tableView:self.tableView numberOfRowsInSection:section];
     
     NSUInteger sectionNumber = [self.sections indexOfObject:@(statsSection)];


### PR DESCRIPTION
Fixes #156 

Used the wrong section number when storing selected subsections in the dictionary.