### PR TITLE
Table section borders working properly on iPad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ DerivedData
 #
 Pods/
 
+.idea

--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -213,14 +213,16 @@
 		9367D9D51A6EB5770033911A /* Cells */ = {
 			isa = PBXGroup;
 			children = (
-				936E74A21A688E6F0048F552 /* StatsSelectableTableViewCell.h */,
-				936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */,
-				9367D9D61A6EB5A90033911A /* StatsTwoColumnTableViewCell.h */,
-				9367D9D71A6EB5A90033911A /* StatsTwoColumnTableViewCell.m */,
 				9367D9DA1A7018350033911A /* StatsBorderedCellBackgroundView.h */,
 				9367D9DB1A7018350033911A /* StatsBorderedCellBackgroundView.m */,
+				936E74A21A688E6F0048F552 /* StatsSelectableTableViewCell.h */,
+				936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */,
 				9367D9DD1A70194D0033911A /* StatsStandardBorderedTableViewCell.h */,
 				9367D9DE1A70194D0033911A /* StatsStandardBorderedTableViewCell.m */,
+				936E74A51A69A8990048F552 /* StatsTableSectionHeaderView.h */,
+				936E74A61A69A8990048F552 /* StatsTableSectionHeaderView.m */,
+				9367D9D61A6EB5A90033911A /* StatsTwoColumnTableViewCell.h */,
+				9367D9D71A6EB5A90033911A /* StatsTwoColumnTableViewCell.m */,
 			);
 			name = Cells;
 			sourceTree = "<group>";
@@ -362,8 +364,6 @@
 				9367D9D51A6EB5770033911A /* Cells */,
 				936B22491958C65A0058C828 /* Graph */,
 				93FABB7C1A115D90000C15ED /* SiteStats.storyboard */,
-				936E74A51A69A8990048F552 /* StatsTableSectionHeaderView.h */,
-				936E74A61A69A8990048F552 /* StatsTableSectionHeaderView.m */,
 				93FABB811A126DC5000C15ED /* StatsTableViewController.h */,
 				93FABB821A126DC5000C15ED /* StatsTableViewController.m */,
 				9367D9D21A6EAEBB0033911A /* StatsViewAllTableViewController.h */,

--- a/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.m
+++ b/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.m
@@ -34,9 +34,9 @@
 {
     [super layoutSubviews];
     
-    CGFloat borderSidePadding = IS_IPHONE ? RPTVCHorizontalOuterPadding - 1.0f : 0.0f;
+    CGFloat borderSidePadding = RPTVCHorizontalOuterPadding - 1.0f;
     CGFloat bottomPadding = 1.0f;
-    CGFloat sidePadding = IS_IPHONE ? RPTVCHorizontalOuterPadding : 0.0f;
+    CGFloat sidePadding = RPTVCHorizontalOuterPadding;
     
     self.theBoxView.frame = CGRectMake(borderSidePadding, 0.0, CGRectGetWidth(self.frame) - 2 * borderSidePadding, CGRectGetHeight(self.frame));
     self.contentBackgroundView.frame = CGRectMake(sidePadding, 0.0, CGRectGetWidth(self.frame) - 2 * sidePadding, CGRectGetHeight(self.frame));

--- a/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
@@ -1,11 +1,3 @@
-//
-//  StatsStandardBorderedTableViewCell.h
-//  WordPressCom-Stats-iOS
-//
-//  Created by Aaron Douglas on 1/21/15.
-//  Copyright (c) 2015 Automattic Inc. All rights reserved.
-//
-
 #import <UIKit/UIKit.h>
 
 @interface StatsStandardBorderedTableViewCell : UITableViewCell

--- a/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
@@ -1,5 +1,6 @@
 #import <UIKit/UIKit.h>
+#import <WPTableViewCell.h>
 
-@interface StatsStandardBorderedTableViewCell : UITableViewCell
+@interface StatsStandardBorderedTableViewCell : WPTableViewCell
 
 @end

--- a/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
+++ b/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
@@ -58,7 +58,7 @@
         self.frame = frame;
     }
 
-    CGFloat borderSidePadding = IS_IPHONE ? RPTVCHorizontalOuterPadding - 1.0f : 0.0f; // Just to the left of the container
+    CGFloat borderSidePadding = RPTVCHorizontalOuterPadding - 1.0f; // Just to the left of the container
     self.theBoxView.frame = CGRectMake(borderSidePadding, self.isFooter ? -1.0f : 0.0f, CGRectGetWidth(self.frame) - 2 * borderSidePadding, 1.0f);
 }
 

--- a/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
+++ b/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
@@ -20,8 +20,6 @@
         _theBoxView = [[UIView alloc] initWithFrame:CGRectZero];
         _theBoxView.backgroundColor = [UIColor colorWithRed:210.0/255.0 green:222.0/255.0 blue:238.0/255.0 alpha:1.0];
         [self.contentView addSubview:_theBoxView];
-        
-        [self setClipsToBounds:YES];
     }
     return self;
 }
@@ -59,7 +57,13 @@
     }
 
     CGFloat borderSidePadding = RPTVCHorizontalOuterPadding - 1.0f; // Just to the left of the container
-    self.theBoxView.frame = CGRectMake(borderSidePadding, self.isFooter ? -1.0f : 0.0f, CGRectGetWidth(self.frame) - 2 * borderSidePadding, 1.0f);
+    self.theBoxView.frame = CGRectMake(borderSidePadding, self.isFooter ? -1.0f : 0.0f, CGRectGetWidth(self.frame) - 2.0 * borderSidePadding, 1.0f);
+}
+
+- (void)prepareForReuse
+{
+    [super prepareForReuse];
+    self.footer = NO;
 }
 
 

--- a/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
+++ b/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
@@ -1,5 +1,6 @@
 #import "StatsTableSectionHeaderView.h"
 #import "WPStyleGuide+Stats.h"
+#import <WPTableViewCell.h>
 
 @interface StatsTableSectionHeaderView ()
 
@@ -8,6 +9,7 @@
 @end
 
 @implementation StatsTableSectionHeaderView
+
 
 - (instancetype)initWithReuseIdentifier:(NSString *)reuseIdentifier
 {
@@ -19,8 +21,28 @@
         _theBoxView.backgroundColor = [UIColor colorWithRed:210.0/255.0 green:222.0/255.0 blue:238.0/255.0 alpha:1.0];
         [self.contentView addSubview:_theBoxView];
         
+        [self setClipsToBounds:YES];
     }
     return self;
+}
+
+
+- (void)setFrame:(CGRect)frame {
+    CGFloat width = self.superview.frame.size.width;
+    // On iPad, add a margin around tables
+    if (IS_IPAD && width > WPTableViewFixedWidth) {
+        CGFloat x = (width - WPTableViewFixedWidth) / 2;
+        // If origin.x is not equal to x we add the value.
+        // This is a semi-fix / work around for an issue positioning cells on
+        // iOS 8 when editing a table view and the delete button is visible.
+        if (x != frame.origin.x) {
+            frame.origin.x += x;
+        } else {
+            frame.origin.x = x;
+        }
+        frame.size.width = WPTableViewFixedWidth;
+    }
+    [super setFrame:frame];
 }
 
 
@@ -28,8 +50,17 @@
 {
     [super layoutSubviews];
     
+    // Need to set the origin again on iPad (for margins)
+    CGFloat width = self.superview.frame.size.width;
+    if (IS_IPAD && width > WPTableViewFixedWidth) {
+        CGRect frame = self.frame;
+        frame.origin.x = (width - WPTableViewFixedWidth) / 2;
+        self.frame = frame;
+    }
+
     CGFloat borderSidePadding = IS_IPHONE ? RPTVCHorizontalOuterPadding - 1.0f : 0.0f; // Just to the left of the container
     self.theBoxView.frame = CGRectMake(borderSidePadding, self.isFooter ? -1.0f : 0.0f, CGRectGetWidth(self.frame) - 2 * borderSidePadding, 1.0f);
 }
+
 
 @end


### PR DESCRIPTION
Fixes #159 

A combination of bad conditional math for iPad devices and not resetting some properties on cell reuse caused the extremely bad way section bordered were rendered. Cleaned up the logic and add cell reuse resets. Also made sure all of the cells inherit `WPTableViewCell` so the margins are adjusted properly on the iPad.