### PR TITLE
Added property to disable the bottom border on cells

### DIFF
--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -117,18 +117,22 @@
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupHeader" id="Ex4-nH-VUK" customClass="StatsStandardBorderedTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupHeader" rowHeight="30" id="Ex4-nH-VUK" customClass="StatsStandardBorderedTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ex4-nH-VUK" id="aL3-p0-bNa">
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Group Header Text" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UHc-xu-haN">
-                                            <rect key="frame" x="23" y="11" width="159" height="24"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" tag="100" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Group Header Text" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UHc-xu-haN">
+                                            <rect key="frame" x="23" y="5" width="159" height="24"/>
                                             <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="17"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="UHc-xu-haN" firstAttribute="leading" secondItem="aL3-p0-bNa" secondAttribute="leadingMargin" constant="15" id="A8P-6P-WvN"/>
+                                        <constraint firstAttribute="bottom" secondItem="UHc-xu-haN" secondAttribute="bottom" id="j1C-rq-Y3W"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="GroupSelector" id="vr8-L0-G3G" userLabel="GroupSelector" customClass="StatsStandardBorderedTableViewCell">

--- a/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.h
+++ b/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.h
@@ -7,5 +7,6 @@
 @property (nonatomic, strong) UIView *theBoxView;
 @property (nonatomic, strong) UIView *contentBackgroundView;
 @property (nonatomic, strong) UIView *dividerView;
+@property (nonatomic, assign) BOOL bottomBorderEnabled;
 
 @end

--- a/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.m
+++ b/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.m
@@ -9,6 +9,7 @@
     self = [super initWithFrame:frame];
     if (self) {
         self.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+        _bottomBorderEnabled = YES;
         
         _theBoxView = [[UIView alloc] initWithFrame:CGRectZero];
         _theBoxView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
@@ -35,7 +36,7 @@
     [super layoutSubviews];
     
     CGFloat borderSidePadding = StatsVCHorizontalOuterPadding - 1.0f;
-    CGFloat bottomPadding = 1.0f;
+    CGFloat bottomPadding = self.bottomBorderEnabled ? 1.0f : 0.0f;
     CGFloat sidePadding = StatsVCHorizontalOuterPadding;
     
     self.theBoxView.frame = CGRectMake(borderSidePadding, 0.0, CGRectGetWidth(self.frame) - 2 * borderSidePadding, CGRectGetHeight(self.frame));

--- a/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
@@ -3,4 +3,6 @@
 
 @interface StatsStandardBorderedTableViewCell : WPTableViewCell
 
+@property (nonatomic, assign) BOOL bottomBorderEnabled;
+
 @end

--- a/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.m
@@ -17,8 +17,20 @@
 {
     [super awakeFromNib];
     
+    _bottomBorderEnabled = YES;
     self.backgroundView = [[StatsBorderedCellBackgroundView alloc] initWithFrame:self.bounds andSelected:YES];
     self.selectedBackgroundView = [[StatsBorderedCellBackgroundView alloc] initWithFrame:self.bounds andSelected:NO];
+}
+
+
+- (void)setBottomBorderEnabled:(BOOL)bottomBorderEnabled
+{
+    _bottomBorderEnabled = bottomBorderEnabled;
+    
+    StatsBorderedCellBackgroundView *backgroundView = (StatsBorderedCellBackgroundView *)self.backgroundView;
+    StatsBorderedCellBackgroundView *selectedBackgroundView = (StatsBorderedCellBackgroundView *)self.selectedBackgroundView;
+    backgroundView.bottomBorderEnabled = bottomBorderEnabled;
+    selectedBackgroundView.bottomBorderEnabled = bottomBorderEnabled;
 }
 
 @end

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -16,6 +16,7 @@
 
 static CGFloat const StatsTableGraphHeight = 185.0f;
 static CGFloat const StatsTableNoResultsHeight = 100.0f;
+static CGFloat const StatsTableGroupHeaderHeight = 30.0f;
 static NSInteger const StatsTableRowDataOffsetStandard = 2;
 static NSInteger const StatsTableRowDataOffsetWithoutGroupHeader = 1;
 static NSInteger const StatsTableRowDataOffsetWithGroupSelector = 3;
@@ -232,6 +233,8 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
 
     if ([cellIdentifier isEqualToString:StatsTableGraphCellIdentifier]) {
         return StatsTableGraphHeight;
+    } else if ([cellIdentifier isEqualToString:StatsTableGroupHeaderCellIdentifier]) {
+        return StatsTableGroupHeaderHeight;
     } else if ([cellIdentifier isEqualToString:StatsTableNoResultsCellIdentifier]) {
         return StatsTableNoResultsHeight;
     }
@@ -939,13 +942,15 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
 }
 
 
-- (void)configureSectionGroupHeaderCell:(UITableViewCell *)cell withStatsSection:(StatsSection)statsSection
+- (void)configureSectionGroupHeaderCell:(StatsStandardBorderedTableViewCell *)cell withStatsSection:(StatsSection)statsSection
 {
     StatsGroup *statsGroup = [self statsDataForStatsSection:statsSection];
     NSString *headerText = statsGroup.groupTitle;
     
     UILabel *label = (UILabel *)[cell.contentView viewWithTag:100];
     label.text = headerText;
+    
+    cell.bottomBorderEnabled = NO;
 }
 
 


### PR DESCRIPTION
Closes #168 

Added a conditional property to allow the bottom border (cell divider) to be eliminated when needed. By default the border is enabled which was the behavior prior to this change.

After:
![Group Header No Divider](https://cloud.githubusercontent.com/assets/373903/6081910/95a94d48-ade2-11e4-8faa-b1dcffab9e76.png)

cc: @jancavan