### PR TITLE
Change left label when its selectable

### DIFF
--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
@@ -25,6 +25,7 @@
 
     if (self.selectable) {
         self.selectionStyle = UITableViewCellSelectionStyleDefault;
+        self.leftLabel.textColor = [WPStyleGuide wordPressBlue];
     }
     
     self.iconImageView.image = nil;
@@ -67,6 +68,7 @@
     
     self.leftLabel.text = nil;
     self.rightLabel.text = nil;
+    self.leftLabel.textColor = [UIColor blackColor];
     self.iconImageView.image = nil;
     
     self.widthConstraint.constant = 20.0f;


### PR DESCRIPTION
Closes #166

Makes the left table in the two column cells WordPress blue when it's selectable. I did not change the color on the View All cell as there is a disclosure indicator accessory view (the chevron on the right) to indicate the row is tappable. Eventually when there is a post details view this should probably get revisited for iOS compatibility rather than the web anchor coloring paradigm we're following.

![Selectable cell label color](https://cloud.githubusercontent.com/assets/373903/6082163/a9f3c8d0-ade4-11e4-8d7f-e8667f38dd88.png)

cc: @jancavan