### PR TITLE
Fix the indent for nestable rows

### DIFF
--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
@@ -55,8 +55,8 @@
         self.indentChevronLabel.text = @"";
     }
     
-    CGFloat indentWidth = self.indentLevel * 7.0f + 8.0f;
-    indentWidth += self.indentable ? 28.0f : 0.0f;
+    CGFloat indentWidth = self.indentLevel * 8.0f + 7.0f;
+    indentWidth += self.indentable || self.indentLevel > 1 ? 28.0f : 0.0f;
     self.leadingEdgeConstraint.constant = indentWidth;
     
     [self setNeedsLayout];
@@ -73,6 +73,7 @@
     
     self.widthConstraint.constant = 20.0f;
     self.spaceConstraint.constant = 8.0f;
+    self.leadingEdgeConstraint.constant = 43.0f;
     StatsBorderedCellBackgroundView *backgroundView = (StatsBorderedCellBackgroundView *)self.backgroundView;
     backgroundView.contentBackgroundView.backgroundColor = [UIColor whiteColor];
     self.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
@@ -25,6 +25,7 @@
 
     if (self.selectable) {
         self.selectionStyle = UITableViewCellSelectionStyleDefault;
+        self.leftLabel.textColor = [WPStyleGuide wordPressBlue];
     }
     
     self.iconImageView.image = nil;
@@ -67,6 +68,7 @@
     
     self.leftLabel.text = nil;
     self.rightLabel.text = nil;
+    self.leftLabel.textColor = [UIColor blackColor];
     self.iconImageView.image = nil;
     
     self.widthConstraint.constant = 20.0f;


### PR DESCRIPTION
Fixes #164 

Corrects the indentation logic for cells that are nestable.

![Identing Correction](https://cloud.githubusercontent.com/assets/373903/6085754/27ef9990-ae02-11e4-9e59-d18731c2dff4.png)

cc:@jancavan