### PR TITLE
Switch to Gravatar mystery man & rounded icons for authors

### DIFF
--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -827,7 +827,8 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
                             indentLevel:item.depth
                              indentable:item.children.count > 0
                                expanded:item.expanded
-                             selectable:item.actions.count > 0 || item.children.count > 0];
+                             selectable:item.actions.count > 0 || item.children.count > 0
+                        forStatsSection:statsSection];
     } else if ([cellIdentifier isEqualToString:StatsTableViewWebVersionCellIdentifier]) {
         UILabel *label = (UILabel *)[cell.contentView viewWithTag:100];
         label.text = NSLocalizedString(@"View Web Version", @"View Web Version button in stats");
@@ -1066,11 +1067,15 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
                        indentable:(BOOL)indentable
                          expanded:(BOOL)expanded
                        selectable:(BOOL)selectable
+                  forStatsSection:(StatsSection)statsSection
 {
+    BOOL showCircularIcon = (statsSection == StatsSectionComments || statsSection == StatsSectionFollowers);
+
     StatsTwoColumnTableViewCell *statsCell = (StatsTwoColumnTableViewCell *)cell;
     statsCell.leftText = leftText;
     statsCell.rightText = rightText;
     statsCell.imageURL = imageURL;
+    statsCell.showCircularIcon = showCircularIcon;
     statsCell.indentLevel = indentLevel;
     statsCell.indentable = indentable;
     statsCell.expanded = expanded;

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.h
@@ -6,6 +6,7 @@
 @property (nonatomic, copy) NSString *leftText;
 @property (nonatomic, copy) NSString *rightText;
 @property (nonatomic, strong) NSURL *imageURL;
+@property (nonatomic, assign) BOOL showCircularIcon;
 @property (nonatomic, assign) NSUInteger indentLevel;
 @property (nonatomic, assign) BOOL selectable;
 @property (nonatomic, assign) BOOL indentable;

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
@@ -55,8 +55,8 @@
         self.indentChevronLabel.text = @"";
     }
     
-    CGFloat indentWidth = self.indentLevel * 7.0f + 8.0f;
-    indentWidth += self.indentable ? 28.0f : 0.0f;
+    CGFloat indentWidth = self.indentLevel * 8.0f + 7.0f;
+    indentWidth += self.indentable || self.indentLevel > 1 ? 28.0f : 0.0f;
     self.leadingEdgeConstraint.constant = indentWidth;
     
     [self setNeedsLayout];
@@ -73,6 +73,7 @@
     
     self.widthConstraint.constant = 20.0f;
     self.spaceConstraint.constant = 8.0f;
+    self.leadingEdgeConstraint.constant = 43.0f;
     StatsBorderedCellBackgroundView *backgroundView = (StatsBorderedCellBackgroundView *)self.backgroundView;
     backgroundView.contentBackgroundView.backgroundColor = [UIColor whiteColor];
     self.selectionStyle = UITableViewCellSelectionStyleNone;

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
@@ -25,6 +25,7 @@
 
     if (self.selectable) {
         self.selectionStyle = UITableViewCellSelectionStyleDefault;
+        self.leftLabel.textColor = [WPStyleGuide wordPressBlue];
     }
     
     self.iconImageView.image = nil;
@@ -67,6 +68,7 @@
     
     self.leftLabel.text = nil;
     self.rightLabel.text = nil;
+    self.leftLabel.textColor = [UIColor blackColor];
     self.iconImageView.image = nil;
     
     self.widthConstraint.constant = 20.0f;

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
@@ -2,6 +2,7 @@
 #import "WPStyleGuide+Stats.h"
 #import <WPImageSource.h>
 #import "StatsBorderedCellBackgroundView.h"
+#import <QuartzCore/QuartzCore.h>
 
 @interface StatsTwoColumnTableViewCell ()
 
@@ -32,6 +33,12 @@
 
     // Hide the image if one isn't set
     if (self.imageURL) {
+        if (self.showCircularIcon) {
+            self.iconImageView.layer.cornerRadius = 10.0f;
+            self.iconImageView.layer.masksToBounds = YES;
+            [self.iconImageView.layer setNeedsDisplay];
+        }
+
         [[WPImageSource sharedSource] downloadImageForURL:self.imageURL withSuccess:^(UIImage *image) {
             self.iconImageView.image = image;
             self.iconImageView.backgroundColor = [UIColor clearColor];
@@ -62,10 +69,11 @@
     [self setNeedsLayout];
 }
 
+
 - (void)prepareForReuse
 {
     [super prepareForReuse];
-    
+
     self.leftLabel.text = nil;
     self.rightLabel.text = nil;
     self.leftLabel.textColor = [UIColor blackColor];
@@ -78,6 +86,11 @@
     backgroundView.contentBackgroundView.backgroundColor = [UIColor whiteColor];
     self.selectionStyle = UITableViewCellSelectionStyleNone;
     self.accessoryType = UITableViewCellAccessoryNone;
+ 
+    self.showCircularIcon = NO;
+    self.iconImageView.layer.cornerRadius = 0.0f;
+    self.iconImageView.layer.masksToBounds = NO;
+    [self.iconImageView.layer setNeedsDisplay];
 }
 
 @end

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -641,7 +641,9 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
             StatsItem *statsItem = [StatsItem new];
             statsItem.label = [countryInfoDict[key] stringForKey:@"country_full"];
             statsItem.value = [self localizedStringForNumber:[view numberForKey:@"views"]];
-            statsItem.iconURL = [NSURL URLWithString:[countryInfoDict[key] stringForKey:@"flat_flag_icon"]];
+            NSURLComponents *components = [NSURLComponents componentsWithString:[countryInfoDict[key] stringForKey:@"flat_flag_icon"]];
+            components.query = @"s=60";
+            statsItem.iconURL = components.URL;
             
             [items addObject:statsItem];
         }

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -641,7 +641,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
             StatsItem *statsItem = [StatsItem new];
             statsItem.label = [countryInfoDict[key] stringForKey:@"country_full"];
             statsItem.value = [self localizedStringForNumber:[view numberForKey:@"views"]];
-            statsItem.iconURL = [NSURL URLWithString:[countryInfoDict[key] stringForKey:@"flag_icon"]];
+            statsItem.iconURL = [NSURL URLWithString:[countryInfoDict[key] stringForKey:@"flat_flag_icon"]];
             
             [items addObject:statsItem];
         }

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -730,7 +730,9 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         for (NSDictionary *author in authors) {
             StatsItem *item = [StatsItem new];
             item.label = [author stringForKey:@"name"];
-            item.iconURL = [NSURL URLWithString:[author stringForKey:@"gravatar"]];
+            NSURLComponents *components = [NSURLComponents componentsWithString:[author stringForKey:@"gravatar"]];
+            components.query = @"d=mm&s=60";
+            item.iconURL = components.URL;
             item.value = [self localizedStringForNumber:[author numberForKey:@"comments"]];
             // TODO follow data
             
@@ -851,7 +853,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         for (NSDictionary *subscriber in subscribers) {
             StatsItem *statsItem = [StatsItem new];
             statsItem.label = [subscriber stringForKey:@"label"];
-            statsItem.iconURL = [NSURL URLWithString:[subscriber stringForKey:@"avatar"]];
+            NSURLComponents *components = [NSURLComponents componentsWithString:[subscriber stringForKey:@"avatar"]];
+            components.query = @"?d=mm&s=60";
+            statsItem.iconURL = components.URL;
+
             statsItem.date = [self.rfc3339DateFormatter dateFromString:[subscriber stringForKey:@"date_subscribed"]];
             
             

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -856,7 +856,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
             StatsItem *statsItem = [StatsItem new];
             statsItem.label = [subscriber stringForKey:@"label"];
             NSURLComponents *components = [NSURLComponents componentsWithString:[subscriber stringForKey:@"avatar"]];
-            components.query = @"?d=mm&s=60";
+            components.query = @"d=mm&s=60";
             statsItem.iconURL = components.URL;
 
             statsItem.date = [self.rfc3339DateFormatter dateFromString:[subscriber stringForKey:@"date_subscribed"]];

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -641,9 +641,13 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
             StatsItem *statsItem = [StatsItem new];
             statsItem.label = [countryInfoDict[key] stringForKey:@"country_full"];
             statsItem.value = [self localizedStringForNumber:[view numberForKey:@"views"]];
-            NSURLComponents *components = [NSURLComponents componentsWithString:[countryInfoDict[key] stringForKey:@"flat_flag_icon"]];
-            components.query = @"s=60";
-            statsItem.iconURL = components.URL;
+
+            NSString *urlString = [countryInfoDict[key] stringForKey:@"flat_flag_icon"];
+            if (urlString.length > 0) {
+                NSURLComponents *components = [NSURLComponents componentsWithString:urlString];
+                components.query = @"s=60";
+                statsItem.iconURL = components.URL;
+            }
             
             [items addObject:statsItem];
         }
@@ -732,9 +736,12 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         for (NSDictionary *author in authors) {
             StatsItem *item = [StatsItem new];
             item.label = [author stringForKey:@"name"];
-            NSURLComponents *components = [NSURLComponents componentsWithString:[author stringForKey:@"gravatar"]];
-            components.query = @"d=mm&s=60";
-            item.iconURL = components.URL;
+            NSString *urlString = [author stringForKey:@"gravatar"];
+            if (urlString.length > 0) {
+                NSURLComponents *components = [NSURLComponents componentsWithString:urlString];
+                components.query = @"d=mm&s=60";
+                item.iconURL = components.URL;
+            }
             item.value = [self localizedStringForNumber:[author numberForKey:@"comments"]];
             // TODO follow data
             
@@ -855,9 +862,13 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         for (NSDictionary *subscriber in subscribers) {
             StatsItem *statsItem = [StatsItem new];
             statsItem.label = [subscriber stringForKey:@"label"];
-            NSURLComponents *components = [NSURLComponents componentsWithString:[subscriber stringForKey:@"avatar"]];
-            components.query = @"d=mm&s=60";
-            statsItem.iconURL = components.URL;
+            
+            NSString *urlString = [subscriber stringForKey:@"avatar"];
+            if (urlString.length > 0) {
+                NSURLComponents *components = [NSURLComponents componentsWithString:urlString];
+                components.query = @"d=mm&s=60";
+                statsItem.iconURL = components.URL;
+            }
 
             statsItem.date = [self.rfc3339DateFormatter dateFromString:[subscriber stringForKey:@"date_subscribed"]];
             

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -900,22 +900,22 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
             
             if ([serviceID isEqualToString:@"facebook"]) {
                 serviceLabel = @"Facebook";
-                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/2343ec78a04c6ea9d80806345d31fd78?s=48"];
+                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/2343ec78a04c6ea9d80806345d31fd78?s=60"];
             } else if ([serviceID isEqualToString:@"twitter"]) {
                 serviceLabel = @"Twitter";
-                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/7905d1c4e12c54933a44d19fcd5f9356?s=48"];
+                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/7905d1c4e12c54933a44d19fcd5f9356?s=60"];
             } else if ([serviceID isEqualToString:@"tumblr"]) {
                 serviceLabel = @"Tumblr";
-                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/84314f01e87cb656ba5f382d22d85134?s=48"];
+                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/84314f01e87cb656ba5f382d22d85134?s=60"];
             } else if ([serviceID isEqualToString:@"google_plus"]) {
                 serviceLabel = @"Google+";
-                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/4a4788c1dfc396b1f86355b274cc26b3?s=48"];
+                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/4a4788c1dfc396b1f86355b274cc26b3?s=60"];
             } else if ([serviceID isEqualToString:@"linkedin"]) {
                 serviceLabel = @"LinkedIn";
-                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/f54db463750940e0e7f7630fe327845e?s=48"];
+                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/f54db463750940e0e7f7630fe327845e?s=60"];
             } else if ([serviceID isEqualToString:@"path"]) {
                 serviceLabel = @"Path";
-                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/3a03c8ce5bf1271fb3760bb6e79b02c1?s=48"];
+                iconURL = [NSURL URLWithString:@"https://secure.gravatar.com/blavatar/3a03c8ce5bf1271fb3760bb6e79b02c1?s=60"];
             }
             
             statsItem.label = serviceLabel;

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
@@ -485,13 +485,13 @@
          XCTAssertTrue(moreViewsAvailable);
          XCTAssertNil(error);
          
-         XCTAssertEqual(12, items.count);
+         XCTAssertEqual(10, items.count);
          
          StatsItem *item = items[0];
          XCTAssertTrue([item.label isEqualToString:@"United States"]);
-         XCTAssertTrue([@"23" isEqualToString:item.value]);
+         XCTAssertTrue([@"8" isEqualToString:item.value]);
          XCTAssertNil(item.itemID);
-         XCTAssertTrue([item.iconURL.absoluteString isEqualToString:@"https://secure.gravatar.com/blavatar/5a83891a81b057fed56930a6aaaf7b3c?s=48"]);
+         XCTAssertTrue([item.iconURL.absoluteString isEqualToString:@"https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=60"]);
          XCTAssertEqual(0, item.actions.count);
          XCTAssertEqual(0, item.children.count);
          
@@ -589,7 +589,7 @@
          StatsItem *author1 = authorItems.firstObject;
          XCTAssertTrue([@"Aaron Douglas" isEqualToString:author1.label]);
          XCTAssertTrue([@"20" isEqualToString:author1.value]);
-         XCTAssertTrue([author1.iconURL.absoluteString isEqualToString:@"https://1.gravatar.com/avatar/db127a496309f2717657d6f6167abd49?s=64&amp;d=https%3A%2F%2F1.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D64&amp;r=R"]);
+         XCTAssertTrue([author1.iconURL.absoluteString isEqualToString:@"https://1.gravatar.com/avatar/db127a496309f2717657d6f6167abd49?d=mm&s=60"]);
          XCTAssertEqual(0, author1.actions.count);
          XCTAssertEqual(0, author1.children.count);
          
@@ -674,7 +674,7 @@
          XCTAssertTrue([@"ritu929" isEqualToString:item1.label]);
          XCTAssertNil(item1.value);
          XCTAssertNotNil(item1.date);
-         XCTAssertTrue([item1.iconURL.absoluteString isEqualToString:@"https://0.gravatar.com/avatar/624b89cb0c8b9136f9629dd7bcab0517?s=64&amp;d=https%3A%2F%2F0.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D64&amp;r=G"]);
+         XCTAssertTrue([item1.iconURL.absoluteString isEqualToString:@"https://0.gravatar.com/avatar/624b89cb0c8b9136f9629dd7bcab0517?d=mm&s=60"]);
          XCTAssertEqual(0, item1.actions.count);
          XCTAssertEqual(0, item1.children.count);
          
@@ -710,7 +710,7 @@
          XCTAssertTrue([@"user1@example.com" isEqualToString:item1.label]);
          XCTAssertNil(item1.value);
          XCTAssertNotNil(item1.date);
-         XCTAssertTrue([item1.iconURL.absoluteString isEqualToString:@"https://2.gravatar.com/avatar/e82142697283897ad7444810e5975895?s=64&amp;d=https%3A%2F%2F2.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D64&amp;r=G"]);
+         XCTAssertTrue([item1.iconURL.absoluteString isEqualToString:@"https://2.gravatar.com/avatar/e82142697283897ad7444810e5975895?d=mm&s=60"]);
          XCTAssertEqual(0, item1.actions.count);
          XCTAssertEqual(0, item1.children.count);
          

--- a/WordPressCom-Stats-iOSTests/stats-v1.1-country-views-day.json
+++ b/WordPressCom-Stats-iOSTests/stats-v1.1-country-views-day.json
@@ -1,22 +1,30 @@
 {
-    "date": "2014-11-06",
+    "date": "2015-02-06",
     "days": {
-        "2014-11-06": {
+        "2015-02-06": {
             "views": [
                       {
                       "country_code": "US",
-                      "views": 23
+                      "views": 8
+                      },
+                      {
+                      "country_code": "TW",
+                      "views": 6
                       },
                       {
                       "country_code": "DE",
-                      "views": 7
-                      },
-                      {
-                      "country_code": "GB",
                       "views": 4
                       },
                       {
-                      "country_code": "BR",
+                      "country_code": "IN",
+                      "views": 4
+                      },
+                      {
+                      "country_code": "PH",
+                      "views": 4
+                      },
+                      {
+                      "country_code": "GR",
                       "views": 3
                       },
                       {
@@ -24,98 +32,82 @@
                       "views": 3
                       },
                       {
-                      "country_code": "IN",
-                      "views": 3
-                      },
-                      {
-                      "country_code": "VN",
-                      "views": 3
-                      },
-                      {
-                      "country_code": "JP",
-                      "views": 3
-                      },
-                      {
-                      "country_code": "IL",
+                      "country_code": "BR",
                       "views": 2
                       },
                       {
-                      "country_code": "KR",
+                      "country_code": "CA",
                       "views": 2
                       },
                       {
-                      "country_code": "RU",
+                      "country_code": "HU",
                       "views": 2
-                      },
-                      {
-                      "country_code": "TW",
-                      "views": 1
                       }
                       ],
-            "other_views": 11,
-            "total_views": 67
+            "other_views": 17,
+            "total_views": 55
         }
     },
     "country-info": {
         "US": {
             "flag_icon": "https://secure.gravatar.com/blavatar/5a83891a81b057fed56930a6aaaf7b3c?s=48",
+            "flat_flag_icon": "https://secure.gravatar.com/blavatar/9f4faa5ad0c723474f7a6d810172447c?s=48",
             "country_full": "United States",
             "map_region": "021"
         },
+        "TW": {
+            "flag_icon": "https://secure.gravatar.com/blavatar/f983fff0dda7387746b697cfd865e657?s=48",
+            "flat_flag_icon": "https://secure.gravatar.com/blavatar/2c224480a40527ee89d7340d4396e8e6?s=48",
+            "country_full": "Taiwan",
+            "map_region": "030"
+        },
+        "PH": {
+            "flag_icon": "https://secure.gravatar.com/blavatar/9fb5caa12630ee351f854526887036b5?s=48",
+            "flat_flag_icon": "https://secure.gravatar.com/blavatar/b45edf6312236c2ed67e9d6943b41862?s=48",
+            "country_full": "Philippines",
+            "map_region": "035"
+        },
         "DE": {
             "flag_icon": "https://secure.gravatar.com/blavatar/e13c43aa12cd8aada2ffb1663970374f?s=48",
+            "flat_flag_icon": "https://secure.gravatar.com/blavatar/82f933cabd7491369097f681958bdaed?s=48",
             "country_full": "Germany",
             "map_region": "155"
         },
-        "GB": {
-            "flag_icon": "https://secure.gravatar.com/blavatar/45d1fd3f398678452fd02153f569ce01?s=48",
-            "country_full": "United Kingdom",
-            "map_region": "154"
-        },
-        "JP": {
-            "flag_icon": "https://secure.gravatar.com/blavatar/bd3a57cba61df97cc0f73363dea7dc4d?s=48",
-            "country_full": "Japan",
-            "map_region": "030"
-        },
-        "VN": {
-            "flag_icon": "https://secure.gravatar.com/blavatar/dd0d10af3ce85b0dc0bb7bbceea4f5e7?s=48",
-            "country_full": "Viet Nam",
-            "map_region": "035"
-        },
         "IN": {
             "flag_icon": "https://secure.gravatar.com/blavatar/217b6ac82c316e3a176351cef1d2d0b6?s=48",
+            "flat_flag_icon": "https://secure.gravatar.com/blavatar/d449a857f065ec5ddf1e7a086001a541?s=48",
             "country_full": "India",
             "map_region": "034"
         },
-        "BR": {
-            "flag_icon": "https://secure.gravatar.com/blavatar/2eb39070460892f8d51479ce95484f09?s=48",
-            "country_full": "Brazil",
-            "map_region": "005"
-        },
         "FR": {
             "flag_icon": "https://secure.gravatar.com/blavatar/bff4fa191e38bc0a316410b8fd2958fd?s=48",
+            "flat_flag_icon": "https://secure.gravatar.com/blavatar/8139b3de98c828078f8a0f7deec0c79b?s=48",
             "country_full": "France",
             "map_region": "155"
         },
-        "KR": {
-            "flag_icon": "https://secure.gravatar.com/blavatar/58397002edf3840131193e59d82d3cb8?s=48",
-            "country_full": "Republic of Korea",
-            "map_region": "030"
+        "GR": {
+            "flag_icon": "https://secure.gravatar.com/blavatar/b6b7e68f84a52ab815467a6fbec1f3c0?s=48",
+            "flat_flag_icon": "https://secure.gravatar.com/blavatar/9b9c3f808361ec2e84526c44eb42944c?s=48",
+            "country_full": "Greece",
+            "map_region": "039"
         },
-        "RU": {
-            "flag_icon": "https://secure.gravatar.com/blavatar/ba1ad9dc288f3d105f2512336502c473?s=48",
-            "country_full": "Russian Federation",
+        "CA": {
+            "flag_icon": "https://secure.gravatar.com/blavatar/7f3085b2665ac78346be5923724ba4c6?s=48",
+            "flat_flag_icon": "https://secure.gravatar.com/blavatar/685ac009247bf3378158ee41c3f8f250?s=48",
+            "country_full": "Canada",
+            "map_region": "021"
+        },
+        "HU": {
+            "flag_icon": "https://secure.gravatar.com/blavatar/33a7eb058641623442e0f785b2b1e112?s=48",
+            "flat_flag_icon": "https://secure.gravatar.com/blavatar/cc6139c667fe0f8c1a0b609c01c4c51e?s=48",
+            "country_full": "Hungary",
             "map_region": "151"
         },
-        "IL": {
-            "flag_icon": "https://secure.gravatar.com/blavatar/201a002496cebf356519bec9edba5c05?s=48",
-            "country_full": "Israel",
-            "map_region": "145"
-        },
-        "TW": {
-            "flag_icon": "https://secure.gravatar.com/blavatar/f983fff0dda7387746b697cfd865e657?s=48",
-            "country_full": "Taiwan",
-            "map_region": "030"
+        "BR": {
+            "flag_icon": "https://secure.gravatar.com/blavatar/2eb39070460892f8d51479ce95484f09?s=48",
+            "flat_flag_icon": "https://secure.gravatar.com/blavatar/254e046ea74f30ab535952b4ce25f0cb?s=48",
+            "country_full": "Brazil",
+            "map_region": "005"
         }
     }
 }


### PR DESCRIPTION
Closes #167 

1. Switch to Mystery Man for authors/commenters where a Gravatar doesn't exist.
2. Switch to flat flag icons.
3. Override Gravatar icon sizes to be 60px. Image view frame is 20x20 so while this wastes data on non-retina devices, it keeps the image looking nice on up to 3x devices.

![ios simulator screen shot feb 8 2015 11 00 07 am](https://cloud.githubusercontent.com/assets/373903/6097375/a8f74576-af81-11e4-9a26-503f140a5df5.png)

cc: @jancavan