### PR TITLE
Adjust font size of graph bar axis label to be larger

### DIFF
--- a/WordPressCom-Stats-iOS/WPStatsGraphBarCell.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphBarCell.m
@@ -129,8 +129,11 @@
 }
 
 - (UILabel *)axisLabelWithText:(NSString *)text {
-    UILabel *label = [[UILabel alloc] init];
+    UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, CGRectGetWidth(self.frame), 17.0f)];
     label.text = text;
+    label.textAlignment = NSTextAlignmentCenter;
+    label.adjustsFontSizeToFitWidth = YES;
+    label.minimumScaleFactor = 0.5;
     label.font = [WPStyleGuide axisLabelFont];
     
     if (self.selected) {
@@ -141,7 +144,6 @@
 
     label.backgroundColor = [UIColor clearColor];
     label.opaque = YES;
-    [label sizeToFit];
     return label;
 }
 

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
@@ -7,7 +7,7 @@ const CGFloat StatsVCVerticalOuterPadding = 16.0f;
 @implementation WPStyleGuide (Stats)
 
 + (UIFont *)axisLabelFont {
-    return [WPFontManager openSansRegularFontOfSize:8.0];
+    return [WPFontManager openSansRegularFontOfSize:12.0];
 }
 
 + (UIColor *)statsLighterOrange


### PR DESCRIPTION
Closes #173 

Made axis label font 12pt instead of 8pt and adjust the font size up to 50% if the text doesn't fit in the frame.

![ios simulator screen shot feb 9 2015 4 09 35 pm](https://cloud.githubusercontent.com/assets/373903/6117967/101c017a-b076-11e4-918c-49991772eaa2.png)