### PR TITLE
Expanded rows now get a dark border treatment

### DIFF
--- a/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.h
+++ b/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.h
@@ -4,9 +4,8 @@
 
 - (instancetype)initWithFrame:(CGRect)frame andSelected:(BOOL)selected;
 
-@property (nonatomic, strong) UIView *theBoxView;
 @property (nonatomic, strong) UIView *contentBackgroundView;
-@property (nonatomic, strong) UIView *dividerView;
 @property (nonatomic, assign) BOOL bottomBorderEnabled;
+@property (nonatomic, assign) BOOL topBorderDarkEnabled;
 
 @end

--- a/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.m
+++ b/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.m
@@ -39,7 +39,7 @@
 
         _topDividerView = [[UIView alloc] initWithFrame:CGRectZero];
         _topDividerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        _topDividerView.backgroundColor = [WPStyleGuide statsDarkGray];
+        _topDividerView.backgroundColor = [WPStyleGuide statsMediumGray];
         _topDividerView.hidden = YES;
         [self addSubview:_topDividerView];
     }

--- a/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.m
+++ b/WordPressCom-Stats-iOS/StatsBorderedCellBackgroundView.m
@@ -1,6 +1,16 @@
 #import "StatsBorderedCellBackgroundView.h"
 #import "WPStyleGuide+Stats.h"
 
+
+@interface StatsBorderedCellBackgroundView ()
+
+@property (nonatomic, strong) UIView *theBoxView;
+@property (nonatomic, strong) UIView *bottomDividerView;
+@property (nonatomic, strong) UIView *topDividerView;
+
+@end
+
+
 @implementation StatsBorderedCellBackgroundView
 
 
@@ -9,6 +19,7 @@
     self = [super initWithFrame:frame];
     if (self) {
         self.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+        _topBorderDarkEnabled = NO;
         _bottomBorderEnabled = YES;
         
         _theBoxView = [[UIView alloc] initWithFrame:CGRectZero];
@@ -21,10 +32,16 @@
         _contentBackgroundView.backgroundColor = selected ? [UIColor whiteColor] : [WPStyleGuide statsUltraLightGray];
         [self addSubview:_contentBackgroundView];
         
-        _dividerView = [[UIView alloc] initWithFrame:CGRectZero];
-        _dividerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-        _dividerView.backgroundColor = [WPStyleGuide statsLightGray];
-        [self addSubview:_dividerView];
+        _bottomDividerView = [[UIView alloc] initWithFrame:CGRectZero];
+        _bottomDividerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        _bottomDividerView.backgroundColor = [WPStyleGuide statsLightGray];
+        [self addSubview:_bottomDividerView];
+
+        _topDividerView = [[UIView alloc] initWithFrame:CGRectZero];
+        _topDividerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+        _topDividerView.backgroundColor = [WPStyleGuide statsDarkGray];
+        _topDividerView.hidden = YES;
+        [self addSubview:_topDividerView];
     }
     
     return self;
@@ -41,7 +58,16 @@
     
     self.theBoxView.frame = CGRectMake(borderSidePadding, 0.0, CGRectGetWidth(self.frame) - 2 * borderSidePadding, CGRectGetHeight(self.frame));
     self.contentBackgroundView.frame = CGRectMake(sidePadding, 0.0, CGRectGetWidth(self.frame) - 2 * sidePadding, CGRectGetHeight(self.frame));
-    self.dividerView.frame = CGRectMake(CGRectGetMinX(self.contentBackgroundView.frame), CGRectGetHeight(self.frame) - bottomPadding, CGRectGetWidth(self.contentBackgroundView.frame), bottomPadding);
+    self.bottomDividerView.frame = CGRectMake(CGRectGetMinX(self.contentBackgroundView.frame), CGRectGetHeight(self.frame) - bottomPadding, CGRectGetWidth(self.contentBackgroundView.frame), bottomPadding);
+    self.topDividerView.frame = CGRectMake(CGRectGetMinX(self.contentBackgroundView.frame), 0.0f, CGRectGetWidth(self.contentBackgroundView.frame), 1.0f);
+}
+
+
+- (void)setTopBorderDarkEnabled:(BOOL)topBorderDarkEnabled
+{
+    _topBorderDarkEnabled = topBorderDarkEnabled;
+    
+    self.topDividerView.hidden = !topBorderDarkEnabled;
 }
 
 

--- a/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
@@ -3,6 +3,7 @@
 
 @interface StatsStandardBorderedTableViewCell : WPTableViewCell
 
+@property (nonatomic, assign) BOOL topBorderDarkEnabled;
 @property (nonatomic, assign) BOOL bottomBorderEnabled;
 
 @end

--- a/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.m
@@ -18,6 +18,7 @@
     [super awakeFromNib];
     
     _bottomBorderEnabled = YES;
+    _topBorderDarkEnabled = NO;
     self.backgroundView = [[StatsBorderedCellBackgroundView alloc] initWithFrame:self.bounds andSelected:YES];
     self.selectedBackgroundView = [[StatsBorderedCellBackgroundView alloc] initWithFrame:self.bounds andSelected:NO];
 }
@@ -31,6 +32,17 @@
     StatsBorderedCellBackgroundView *selectedBackgroundView = (StatsBorderedCellBackgroundView *)self.selectedBackgroundView;
     backgroundView.bottomBorderEnabled = bottomBorderEnabled;
     selectedBackgroundView.bottomBorderEnabled = bottomBorderEnabled;
+}
+
+
+- (void)setTopBorderDarkEnabled:(BOOL)topBorderDarkEnabled
+{
+    _topBorderDarkEnabled = topBorderDarkEnabled;
+
+    StatsBorderedCellBackgroundView *backgroundView = (StatsBorderedCellBackgroundView *)self.backgroundView;
+    StatsBorderedCellBackgroundView *selectedBackgroundView = (StatsBorderedCellBackgroundView *)self.selectedBackgroundView;
+    backgroundView.topBorderDarkEnabled = topBorderDarkEnabled;
+    selectedBackgroundView.topBorderDarkEnabled = topBorderDarkEnabled;
 }
 
 @end

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
@@ -53,7 +53,7 @@
     BOOL isNestedRow = self.indentLevel > 1;
     if (isNestedRow || self.expanded) {
         StatsBorderedCellBackgroundView *backgroundView = (StatsBorderedCellBackgroundView *)self.backgroundView;
-        backgroundView.contentBackgroundView.backgroundColor = [WPStyleGuide itsEverywhereGrey];
+        backgroundView.contentBackgroundView.backgroundColor = [WPStyleGuide statsNestedCellBackground];
     }
     
     if (self.expanded) {
@@ -91,6 +91,14 @@
     self.iconImageView.layer.cornerRadius = 0.0f;
     self.iconImageView.layer.masksToBounds = NO;
     [self.iconImageView.layer setNeedsDisplay];
+}
+
+
+- (void)setExpanded:(BOOL)expanded
+{
+    _expanded = expanded;
+    
+    self.topBorderDarkEnabled = expanded;
 }
 
 @end

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
@@ -18,6 +18,8 @@ extern const CGFloat StatsCVerticalOuterPadding;
 + (UIColor *)statsLessDarkGrey;
 + (UIColor *)statsLightGrayZeroValue;
 
++ (UIColor *)statsNestedCellBackground;
+
 + (UIFont *)subtitleFontBoldItalic;
 
 @end

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
@@ -12,6 +12,7 @@ extern const CGFloat StatsCVerticalOuterPadding;
 + (UIColor *)statsDarkerOrange;
 
 + (UIColor *)statsMediumBlue;
++ (UIColor *)statsMediumGray;
 + (UIColor *)statsLightGray;
 + (UIColor *)statsUltraLightGray;
 + (UIColor *)statsDarkGray;

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
@@ -50,6 +50,12 @@ const CGFloat StatsVCVerticalOuterPadding = 16.0f;
     return [UIColor colorWithRed:0.576 green:0.651 blue:0.753 alpha:1]; /*#93a6c0*/
 }
 
++ (UIColor *)statsNestedCellBackground
+{
+    // AKA Calypso $gray-light
+    return [UIColor colorWithRed:0.953 green:0.965 blue:0.973 alpha:1]; /*#f3f6f8*/
+}
+
 + (UIColor *)statsUltraLightGray
 {
     return [UIColor colorWithRed:0.957 green:0.973 blue:0.98 alpha:1]; /*#f4f8fa*/

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
@@ -10,45 +10,60 @@ const CGFloat StatsVCVerticalOuterPadding = 16.0f;
     return [WPFontManager openSansRegularFontOfSize:12.0];
 }
 
+
 + (UIColor *)statsLighterOrange
 {
     return [UIColor colorWithRed:0.965 green:0.718 blue:0.494 alpha:1]; /*#f6b77e*/
 }
+
 
 + (UIColor *)statsLighterOrangeTransparent
 {
     return [UIColor colorWithRed:0.965 green:0.718 blue:0.494 alpha:0.3]; /*#f6b77e*/
 }
 
+
 + (UIColor *)statsMediumBlue
 {
     return [UIColor colorWithRed:0 green:0.667 blue:0.863 alpha:1]; /*#00aadc*/
 }
+
+
++ (UIColor *)statsMediumGray
+{
+    return [UIColor colorWithRed:0.824 green:0.871 blue:0.902 alpha:1]; /*#d2dee6*/
+}
+
 
 + (UIColor *)statsDarkerOrange
 {
     return [self jazzyOrange];
 }
 
+
 + (UIColor *)statsDarkGray
 {
     return [UIColor colorWithRed:0.196 green:0.255 blue:0.333 alpha:1]; /*#324155*/
 }
+
 
 + (UIColor *)statsLessDarkGrey
 {
     return [UIColor colorWithRed:0.345 green:0.447 blue:0.584 alpha:1]; /*#587295*/
 }
 
+
 + (UIColor *)statsLightGray
 {
     return [UIColor colorWithRed:0.91 green:0.941 blue:0.961 alpha:1]; /*#e8f0f5*/
 }
 
+
 + (UIColor *)statsLightGrayZeroValue
 {
     return [UIColor colorWithRed:0.576 green:0.651 blue:0.753 alpha:1]; /*#93a6c0*/
 }
+
 
 + (UIColor *)statsNestedCellBackground
 {
@@ -56,10 +71,12 @@ const CGFloat StatsVCVerticalOuterPadding = 16.0f;
     return [UIColor colorWithRed:0.953 green:0.965 blue:0.973 alpha:1]; /*#f3f6f8*/
 }
 
+
 + (UIColor *)statsUltraLightGray
 {
     return [UIColor colorWithRed:0.957 green:0.973 blue:0.98 alpha:1]; /*#f4f8fa*/
 }
+
 
 + (UIFont *)subtitleFontBoldItalic
 {


### PR DESCRIPTION
Closes #163 

There is the double coloring on the lines but I think it's fine for this first release. It's not terribly fugly at least :smile: 

![ios simulator screen shot feb 10 2015 11 35 57 am](https://cloud.githubusercontent.com/assets/373903/6133945/e5fda556-b11a-11e4-9016-fe9adfcddb38.png)

cc: @jancavan