### PR TITLE
Loading indicator for entire table

### DIFF
--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -506,13 +506,19 @@
                                     <action selector="periodUnitControlDidChange:" destination="qzH-Vg-Gi3" eventType="valueChanged" id="hOE-hN-hw1"/>
                                 </connections>
                             </segmentedControl>
+                            <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="KIb-ye-eic">
+                                <rect key="frame" x="282" y="116" width="37" height="37"/>
+                                <color key="color" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                            </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="ENG-tq-nCx" firstAttribute="leading" secondItem="yO0-Lr-iKb" secondAttribute="leading" id="9Zh-6H-jIN"/>
+                            <constraint firstAttribute="centerX" secondItem="KIb-ye-eic" secondAttribute="centerX" id="Abw-qw-qtM"/>
                             <constraint firstItem="ysq-ij-dbS" firstAttribute="top" secondItem="IUN-av-KWH" secondAttribute="bottom" constant="8" id="Baf-6r-wmp"/>
                             <constraint firstItem="ysq-ij-dbS" firstAttribute="trailing" secondItem="yO0-Lr-iKb" secondAttribute="trailingMargin" id="IqO-Bi-pb0"/>
                             <constraint firstAttribute="trailing" secondItem="ENG-tq-nCx" secondAttribute="trailing" id="RNR-wQ-XR1"/>
+                            <constraint firstItem="KIb-ye-eic" firstAttribute="top" secondItem="IUN-av-KWH" secondAttribute="bottom" constant="52" id="TMF-p5-FmT"/>
                             <constraint firstAttribute="centerX" secondItem="ysq-ij-dbS" secondAttribute="centerX" id="ZcA-XO-INA"/>
                             <constraint firstItem="ENG-tq-nCx" firstAttribute="top" secondItem="ysq-ij-dbS" secondAttribute="bottom" constant="8" id="cJs-j1-1ro"/>
                             <constraint firstItem="ysq-ij-dbS" firstAttribute="leading" secondItem="yO0-Lr-iKb" secondAttribute="leadingMargin" id="elG-AZ-S2o"/>
@@ -522,6 +528,7 @@
                     <navigationItem key="navigationItem" title="Stats" id="DF4-gA-Ade"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
+                        <outlet property="activityIndicatorView" destination="KIb-ye-eic" id="xeq-HP-2xe"/>
                         <outlet property="periodSegmentControl" destination="ysq-ij-dbS" id="1DH-gj-zgx"/>
                     </connections>
                 </viewController>

--- a/WordPressCom-Stats-iOS/StatsTableViewController.h
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.h
@@ -2,6 +2,15 @@
 #import "WPStatsViewController.h"
 
 @protocol WPStatsViewControllerDelegate;
+@class StatsTableViewController;
+
+@protocol StatsTableViewControllerDelegate <NSObject>
+
+- (void)statsTableViewControllerDidBeginLoadingStats:(StatsTableViewController *)controller;
+- (void)statsTableViewControllerDidEndLoadingStats:(StatsTableViewController *)controller;
+
+@end
+
 
 @interface StatsTableViewController : UITableViewController
 
@@ -9,6 +18,7 @@
 @property (nonatomic, copy)   NSString *oauth2Token;
 @property (nonatomic, strong) NSTimeZone *siteTimeZone;
 @property (nonatomic, weak) id<WPStatsViewControllerDelegate> statsDelegate;
+@property (nonatomic, weak) id<StatsTableViewControllerDelegate> statsTableDelegate;
 
 - (IBAction)periodUnitControlDidChange:(UISegmentedControl *)control;
 

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -485,6 +485,10 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
 {
     [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
     
+    if ([self.statsTableDelegate respondsToSelector:@selector(statsTableViewControllerDidBeginLoadingStats:)]) {
+        [self.statsTableDelegate statsTableViewControllerDidBeginLoadingStats:self];
+    }
+    
     [self.statsService retrieveAllStatsForDate:self.selectedDate
                                        andUnit:self.selectedPeriodUnit
                     withVisitsCompletionHandler:^(StatsVisits *visits, NSError *error)
@@ -661,6 +665,10 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
      {
          [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
          [self.refreshControl endRefreshing];
+         
+         if ([self.statsTableDelegate respondsToSelector:@selector(statsTableViewControllerDidEndLoadingStats:)]) {
+             [self.statsTableDelegate statsTableViewControllerDidEndLoadingStats:self];
+         }
      }];
 }
 

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -61,10 +61,8 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
     // Force load fonts from bundle
     [WPFontManager openSansBoldFontOfSize:1.0f];
     [WPFontManager openSansRegularFontOfSize:1.0f];
-
-    UIRefreshControl *refreshControl = [UIRefreshControl new];
-    [refreshControl addTarget:self action:@selector(refreshCurrentStats:) forControlEvents:UIControlEventValueChanged];
-    self.refreshControl = refreshControl;
+    
+    [self setupRefreshControl];
     
     self.sections =     @[ @(StatsSectionGraph),
                            @(StatsSectionPeriodHeader),
@@ -491,7 +489,9 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
 {
     [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
     
-    if ([self.statsTableDelegate respondsToSelector:@selector(statsTableViewControllerDidBeginLoadingStats:)]) {
+    if ([self.statsTableDelegate respondsToSelector:@selector(statsTableViewControllerDidBeginLoadingStats:)]
+        && self.refreshControl.isRefreshing == NO) {
+        self.refreshControl = nil;
         [self.statsTableDelegate statsTableViewControllerDidBeginLoadingStats:self];
     }
     
@@ -670,6 +670,8 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
                     andOverallCompletionHandler:^
      {
          [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+
+         [self setupRefreshControl];
          [self.refreshControl endRefreshing];
          
          if ([self.statsTableDelegate respondsToSelector:@selector(statsTableViewControllerDidEndLoadingStats:)]) {
@@ -1161,6 +1163,18 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
             
         }
     }
+}
+
+
+- (void)setupRefreshControl
+{
+    if (self.refreshControl) {
+        return;
+    }
+    
+    UIRefreshControl *refreshControl = [UIRefreshControl new];
+    [refreshControl addTarget:self action:@selector(refreshCurrentStats:) forControlEvents:UIControlEventValueChanged];
+    self.refreshControl = refreshControl;
 }
 
 @end

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -398,8 +398,12 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
     [WPAnalytics track:WPAnalyticsStatStatsTappedBarChart];
 
     self.selectedDate = date;
-    NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:[self.sections indexOfObject:@(StatsSectionPeriodHeader)]];
-    [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationFade];
+
+    NSUInteger section = [self.sections indexOfObject:@(StatsSectionPeriodHeader)];
+    if (section != NSNotFound) {
+        NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:section];
+        [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationFade];
+    }
     
     // Reset the data (except the graph) and refresh
     id graphData = self.sectionData[@(StatsSectionGraph)];
@@ -408,9 +412,11 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
 
     [self.tableView reloadData];
     
-    NSUInteger section = [self.sections indexOfObject:@(StatsSectionGraph)];
-    NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(self.selectedSummaryType + 1) inSection:section];
-    [self.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+    section = [self.sections indexOfObject:@(StatsSectionGraph)];
+    if (section != NSNotFound) {
+        NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(self.selectedSummaryType + 1) inSection:section];
+        [self.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+    }
     
     [self retrieveStatsSkipGraph:YES];
 }

--- a/WordPressCom-Stats-iOS/WPStatsViewController.h
+++ b/WordPressCom-Stats-iOS/WPStatsViewController.h
@@ -17,7 +17,6 @@
 @property (nonatomic, copy)   NSString *oauth2Token;
 @property (nonatomic, strong) NSTimeZone *siteTimeZone;
 @property (nonatomic, weak) id<WPStatsViewControllerDelegate> statsDelegate;
-@property (nonatomic, weak) IBOutlet UISegmentedControl *periodSegmentControl;
 
 - (IBAction)periodUnitControlDidChange:(UISegmentedControl *)control;
 

--- a/WordPressCom-Stats-iOS/WPStatsViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsViewController.m
@@ -1,9 +1,11 @@
 #import "WPStatsViewController.h"
 #import "StatsTableViewController.h"
 
-@interface WPStatsViewController ()
+@interface WPStatsViewController () <StatsTableViewControllerDelegate>
 
 @property (nonatomic, weak) StatsTableViewController *statsTableViewController;
+@property (nonatomic, weak) IBOutlet UISegmentedControl *periodSegmentControl;
+@property (nonatomic, weak) IBOutlet UIActivityIndicatorView *activityIndicatorView;
 
 @end
 
@@ -29,6 +31,7 @@
     tableVC.siteID = self.siteID;
     tableVC.siteTimeZone = self.siteTimeZone;
     tableVC.statsDelegate = self.statsDelegate;
+    tableVC.statsTableDelegate = self;
 }
 
 - (IBAction)periodUnitControlDidChange:(UISegmentedControl *)control
@@ -36,5 +39,19 @@
     [self.statsTableViewController periodUnitControlDidChange:control];
 }
 
+
+#pragma mark StatsTableViewControllerDelegate methods
+
+
+- (void)statsTableViewControllerDidBeginLoadingStats:(StatsTableViewController *)controller
+{
+    [self.activityIndicatorView startAnimating];
+}
+
+
+- (void)statsTableViewControllerDidEndLoadingStats:(StatsTableViewController *)controller
+{
+    [self.activityIndicatorView stopAnimating];
+}
 
 @end


### PR DESCRIPTION
Closes #165 

![ios simulator screen shot feb 10 2015 4 13 21 pm](https://cloud.githubusercontent.com/assets/373903/6138593/c58a9a20-b13f-11e4-8c71-fa99d6a8c1a0.png)

Added a floating activity loading indicator for the entire table. It somewhat mimics what's on Android but it's not the most visually appealing. Good enough for now; lets revisit to something more elegant.