### PR TITLE
Updated no data messages for three sections

### DIFF
--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -1054,8 +1054,20 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
             case StatsSectionClicks:
                 text = NSLocalizedString(@"No clicks recorded", @"");
                 break;
+            case StatsSectionComments:
+                text = NSLocalizedString(@"No comments posted", @"");
+                break;
+            case StatsSectionCountry:
+                text = NSLocalizedString(@"No countries recorded", @"");
+                break;
             case StatsSectionEvents:
                 text = NSLocalizedString(@"No items published during this timeframe", @"");
+                break;
+            case StatsSectionFollowers:
+                text = NSLocalizedString(@"No followers", @"");
+                break;
+            case StatsSectionPosts:
+                text = NSLocalizedString(@"No posts or pages viewed", @"");
                 break;
             case StatsSectionPublicize:
                 text = NSLocalizedString(@"No publicize followers recorded", @"");
@@ -1069,8 +1081,9 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
             case StatsSectionVideos:
                 text = NSLocalizedString(@"No videos played", @"");
                 break;
-            default:
-                text = NSLocalizedString(@"No posts or pages viewed", @"");
+            case StatsSectionGraph:
+            case StatsSectionPeriodHeader:
+            case StatsSectionWebVersion:
                 break;
         }
     }


### PR DESCRIPTION
Closes #182 

Updated case statement to explicitly define error message for each section. This will also then result in a compiler warning when new sections are defined and not included in the logic.

cc: @daniloercoli for review