### PR TITLE
Fixed label alignments when left label is blank

### DIFF
--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -221,8 +221,8 @@
                                         <constraint firstItem="Rwp-nF-8c1" firstAttribute="leading" secondItem="GAp-0f-HXa" secondAttribute="trailing" constant="10" id="RaW-kA-vQK"/>
                                         <constraint firstAttribute="centerY" secondItem="p4X-m5-Nld" secondAttribute="centerY" id="XTA-mJ-ta4"/>
                                         <constraint firstItem="p4X-m5-Nld" firstAttribute="leading" secondItem="Dnr-8L-jIZ" secondAttribute="leadingMargin" constant="43" id="XsQ-gt-qaQ"/>
+                                        <constraint firstAttribute="centerY" secondItem="Rwp-nF-8c1" secondAttribute="centerY" id="c2y-Bi-kSh"/>
                                         <constraint firstItem="GAp-0f-HXa" firstAttribute="leading" secondItem="p4X-m5-Nld" secondAttribute="trailing" constant="8" id="jMx-Mh-VzX"/>
-                                        <constraint firstItem="Rwp-nF-8c1" firstAttribute="baseline" secondItem="GAp-0f-HXa" secondAttribute="baseline" id="mna-l6-qeG"/>
                                         <constraint firstItem="p4X-m5-Nld" firstAttribute="top" secondItem="Dnr-8L-jIZ" secondAttribute="topMargin" constant="-8" id="oGv-TS-QBX"/>
                                     </constraints>
                                     <variation key="default">

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -1054,8 +1054,20 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
             case StatsSectionClicks:
                 text = NSLocalizedString(@"No clicks recorded", @"");
                 break;
+            case StatsSectionComments:
+                text = NSLocalizedString(@"No comments posted", @"");
+                break;
+            case StatsSectionCountry:
+                text = NSLocalizedString(@"No countries recorded", @"");
+                break;
             case StatsSectionEvents:
                 text = NSLocalizedString(@"No items published during this timeframe", @"");
+                break;
+            case StatsSectionFollowers:
+                text = NSLocalizedString(@"No followers", @"");
+                break;
+            case StatsSectionPosts:
+                text = NSLocalizedString(@"No posts or pages viewed", @"");
                 break;
             case StatsSectionPublicize:
                 text = NSLocalizedString(@"No publicize followers recorded", @"");
@@ -1069,8 +1081,9 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
             case StatsSectionVideos:
                 text = NSLocalizedString(@"No videos played", @"");
                 break;
-            default:
-                text = NSLocalizedString(@"No posts or pages viewed", @"");
+            case StatsSectionGraph:
+            case StatsSectionPeriodHeader:
+            case StatsSectionWebVersion:
                 break;
         }
     }


### PR DESCRIPTION
Closes #184 

This PR is based off the 182-default-messages-branch (by accident). Merge after #183.

![ios simulator screen shot feb 12 2015 10 49 59 am](https://cloud.githubusercontent.com/assets/373903/6172224/f85cb7ec-b2a4-11e4-9a8d-3e83f3fa1a8b.png)

cc: @daniloercoli