### PR TITLE
De-janked Y-Axis Labels 

### DIFF
--- a/WordPressCom-Stats-iOS/WPStatsGraphBackgroundView.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphBackgroundView.m
@@ -77,20 +77,23 @@ static CGFloat const AxisPadding = 18.0f;
         CGContextStrokePath(context);
         
         UILabel *yIncrement = [self axisLabelWithText:[NSString stringWithFormat:@" %@", @(stepValue*tick)]];
-        yIncrement.center = CGPointMake(CGRectGetWidth(rect) - CGRectGetMidX(yIncrement.frame) - 6.0f, linePosition);
+        yIncrement.center = CGPointMake(CGRectGetWidth(rect) - CGRectGetMidX(yIncrement.frame) - 2.0f, linePosition);
         [self addSubview:yIncrement];
     }
 }
 
 - (UILabel *)axisLabelWithText:(NSString *)text {
-    UILabel *label = [[UILabel alloc] init];
+    UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 28.0f, 17.0f)];
     label.text = text;
-    label.font = [WPStyleGuide axisLabelFont];
+    label.textAlignment = NSTextAlignmentRight;
+    label.adjustsFontSizeToFitWidth = YES;
+    label.minimumScaleFactor = 0.5;
+    label.font = [WPStyleGuide axisLabelFontSmaller];
     label.textColor = [WPStyleGuide littleEddieGrey];
-    label.backgroundColor = [UIColor whiteColor];
-    label.opaque = YES;
+    label.backgroundColor = [UIColor clearColor];
+    label.opaque = NO;
     label.isAccessibilityElement = NO;
-    [label sizeToFit];
+    
     return label;
 }
 

--- a/WordPressCom-Stats-iOS/WPStatsGraphBackgroundView.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphBackgroundView.m
@@ -66,6 +66,10 @@ static CGFloat const AxisPadding = 18.0f;
     }
     CGFloat yAxisStepSize = yAxisHeight/yAxisTicks;
     
+    for (UIView *view in self.subviews) {
+        [view removeFromSuperview];
+    }
+    
     for (NSUInteger tick = 0; tick <= yAxisTicks; tick++) {
         CGFloat linePosition = yAxisStartPoint + yAxisHeight - (yAxisStepSize * tick) - 2.0f;
         CGContextMoveToPoint(context, xAxisStartPoint, linePosition);

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.h
@@ -6,6 +6,7 @@ extern const CGFloat StatsCVerticalOuterPadding;
 @interface WPStyleGuide (Stats)
 
 + (UIFont *)axisLabelFont;
++ (UIFont *)axisLabelFontSmaller;
 
 + (UIColor *)statsLighterOrangeTransparent;
 + (UIColor *)statsLighterOrange;

--- a/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
+++ b/WordPressCom-Stats-iOS/WPStyleGuide+Stats.m
@@ -11,6 +11,12 @@ const CGFloat StatsVCVerticalOuterPadding = 16.0f;
 }
 
 
++ (UIFont *)axisLabelFontSmaller
+{
+    return [[self axisLabelFont] fontWithSize:8.0f];
+}
+
+
 + (UIColor *)statsLighterOrange
 {
     return [UIColor colorWithRed:0.965 green:0.718 blue:0.494 alpha:1]; /*#f6b77e*/


### PR DESCRIPTION
Closes #180 

1. Removed y-axis labels during a `drawRect:` to prevent subviews from being added over and over and over and over. This isn't terribly efficient so it should be addressed in the future when adding in the value change animations for the bars.
2. Reduced font size for y-axis labels back to what it was before #173.
3. Fixed y-axis label size so that font can be reduced in the case where the number is too large.

![ios simulator screen shot feb 12 2015 1 52 18 pm](https://cloud.githubusercontent.com/assets/373903/6175770/4aa83a2a-b2bf-11e4-823d-818c56e15cda.png)

cc: @jancavan