### PR TITLE
Properly calculate dates without mixing timezones

### DIFF
--- a/WordPressCom-Stats-iOS/StatsDateUtilities.h
+++ b/WordPressCom-Stats-iOS/StatsDateUtilities.h
@@ -3,6 +3,8 @@
 
 @interface StatsDateUtilities : NSObject
 
+- (instancetype)initWithTimeZone:(NSTimeZone *)timeZone;
+
 - (NSDate *)calculateEndDateForPeriodUnit:(StatsPeriodUnit)unit withDateWithinPeriod:(NSDate *)date;
 
 @end

--- a/WordPressCom-Stats-iOS/StatsDateUtilities.m
+++ b/WordPressCom-Stats-iOS/StatsDateUtilities.m
@@ -1,10 +1,39 @@
 #import "StatsDateUtilities.h"
 
+@interface StatsDateUtilities ()
+
+@property (nonatomic, strong) NSTimeZone *timeZone;
+
+@end
+
 @implementation StatsDateUtilities
+
+- (instancetype)init
+{
+    self = [self initWithTimeZone:[NSTimeZone systemTimeZone]];
+    if (self) {
+        
+    }
+    
+    return self;
+}
+
+
+- (instancetype)initWithTimeZone:(NSTimeZone *)timeZone
+{
+    self = [super init];
+    if (self) {
+        _timeZone = timeZone;
+    }
+    
+    return self;
+}
+
 
 - (NSDate *)calculateEndDateForPeriodUnit:(StatsPeriodUnit)unit withDateWithinPeriod:(NSDate *)date
 {
     NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    calendar.timeZone = self.timeZone;
     
     if (unit == StatsPeriodUnitDay) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -814,7 +814,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
         [self configureSectionGraphSelectableCell:cell forRow:indexPath.row];
         
     } else if ([cellIdentifier isEqualToString:StatsTableGroupHeaderCellIdentifier]) {
-        [self configureSectionGroupHeaderCell:cell
+        [self configureSectionGroupHeaderCell:(StatsStandardBorderedTableViewCell *)cell
                              withStatsSection:statsSection];
         
     } else if ([cellIdentifier isEqualToString:StatsTableGroupSelectorCellIdentifier]) {

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -163,7 +163,9 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                      andUnit:(StatsPeriodUnit)unit
        withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchPostsStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil forStatsSection:StatsSectionPosts andCompletionHandler:completionHandler]];
+    NSDate *endDate = [self.dateUtilities calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
+
+    [self.remote fetchPostsStatsForDate:endDate andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil forStatsSection:StatsSectionPosts andCompletionHandler:completionHandler]];
 }
 
 
@@ -171,7 +173,9 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                          andUnit:(StatsPeriodUnit)unit
            withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchReferrersStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil forStatsSection:StatsSectionReferrers andCompletionHandler:completionHandler]];
+    NSDate *endDate = [self.dateUtilities calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
+
+    [self.remote fetchReferrersStatsForDate:endDate andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil forStatsSection:StatsSectionReferrers andCompletionHandler:completionHandler]];
 }
 
 
@@ -179,7 +183,9 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                       andUnit:(StatsPeriodUnit)unit
         withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchClicksStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil  forStatsSection:StatsSectionClicks andCompletionHandler:completionHandler]];
+    NSDate *endDate = [self.dateUtilities calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
+    
+    [self.remote fetchClicksStatsForDate:endDate andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil  forStatsSection:StatsSectionClicks andCompletionHandler:completionHandler]];
 }
 
 
@@ -187,7 +193,9 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                          andUnit:(StatsPeriodUnit)unit
            withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchCountryStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil  forStatsSection:StatsSectionCountry andCompletionHandler:completionHandler]];
+    NSDate *endDate = [self.dateUtilities calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
+    
+    [self.remote fetchCountryStatsForDate:endDate andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil  forStatsSection:StatsSectionCountry andCompletionHandler:completionHandler]];
 }
 
 
@@ -195,7 +203,9 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                       andUnit:(StatsPeriodUnit)unit
         withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchVideosStatsForDate:date andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil forStatsSection:StatsSectionVideos andCompletionHandler:completionHandler]];
+    NSDate *endDate = [self.dateUtilities calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
+    
+    [self.remote fetchVideosStatsForDate:endDate andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil forStatsSection:StatsSectionVideos andCompletionHandler:completionHandler]];
 }
 
 
@@ -204,7 +214,9 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                         andUnit:(StatsPeriodUnit)unit
           withCompletionHandler:(StatsGroupCompletion)completionHandler
 {
-    [self.remote fetchFollowersStatsForFollowerType:followersType date:date andUnit:unit withCompletionHandler:[self remoteFollowersCompletionWithCache:nil followerType:followersType andCompletionHandler:completionHandler]];
+    NSDate *endDate = [self.dateUtilities calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
+    
+    [self.remote fetchFollowersStatsForFollowerType:followersType date:endDate andUnit:unit withCompletionHandler:[self remoteFollowersCompletionWithCache:nil followerType:followersType andCompletionHandler:completionHandler]];
 }
 
 
@@ -400,7 +412,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
 - (StatsDateUtilities *)dateUtilities
 {
     if (!_dateUtilities) {
-        _dateUtilities = [[StatsDateUtilities alloc] init];
+        _dateUtilities = [[StatsDateUtilities alloc] initWithTimeZone:self.siteTimeZone];
     }
     
     return _dateUtilities;

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -44,6 +44,7 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
         _deviceDateFormatter = [NSDateFormatter new];
         _deviceDateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
         _deviceDateFormatter.dateFormat = @"yyyy-MM-dd";
+        _deviceDateFormatter.timeZone = timeZone;
         
         _deviceNumberFormatter = [NSNumberFormatter new];
         
@@ -356,7 +357,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     NSNumber *quantity = IS_IPAD ? @9 : @5;
     NSDictionary *parameters = @{@"quantity" : quantity,
                                  @"unit"     : [self stringForPeriodUnit:unit],
-                                 @"date"     : [self siteLocalStringForDate:date]};
+                                 @"date"     : [self deviceLocalStringForDate:date]};
     
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForVisits]
                                                                  parameters:parameters
@@ -400,8 +401,8 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         }
     };
     
-    NSDictionary *parameters = @{@"after"   : [self siteLocalStringForDate:[self calculateStartDateForPeriodUnit:unit withEndDate:date]],
-                                 @"before"  : [self siteLocalStringForDate:date],
+    NSDictionary *parameters = @{@"after"   : [self deviceLocalStringForDate:[self calculateStartDateForPeriodUnit:unit withEndDate:date]],
+                                 @"before"  : [self deviceLocalStringForDate:date],
                                  @"number"  : @10,
                                  @"fields"  : @"ID, title, URL"};
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForPosts]
@@ -450,7 +451,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date],
+                                 @"date"   : [self deviceLocalStringForDate:date],
                                  @"max"    : (viewAll ? @0 : @10) };
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForTopPosts]
                                                                  parameters:parameters
@@ -538,7 +539,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date],
+                                 @"date"   : [self deviceLocalStringForDate:date],
                                  @"max"    : (viewAll ? @0 : @10) };
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForReferrers]
@@ -608,7 +609,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date],
+                                 @"date"   : [self deviceLocalStringForDate:date],
                                  @"max"    : (viewAll ? @0 : @10) };
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForClicks]
@@ -658,7 +659,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date],
+                                 @"date"   : [self deviceLocalStringForDate:date],
                                  @"max"    : (viewAll ? @0 : @10) };
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForCountryViews]
@@ -709,7 +710,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date],
+                                 @"date"   : [self deviceLocalStringForDate:date],
                                  @"max"    : (viewAll ? @0 : @10) };
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForVideos]
@@ -772,7 +773,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date]};
+                                 @"date"   : [self deviceLocalStringForDate:date]};
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForComments]
                                                                 parameters:parameters
@@ -831,7 +832,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date]};
+                                 @"date"   : [self deviceLocalStringForDate:date]};
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForTagsCategories]
                                                                 parameters:parameters
@@ -882,7 +883,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date],
+                                 @"date"   : [self deviceLocalStringForDate:date],
                                  @"type"   : followerType == StatsFollowerTypeDotCom ? @"wpcom" : @"email",
                                  @"max"    : (viewAll ? @0 : @7) };
     
@@ -945,7 +946,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     };
     
     NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
-                                 @"date"   : [self siteLocalStringForDate:date]};
+                                 @"date"   : [self deviceLocalStringForDate:date]};
     
     AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForPublicize]
                                                                 parameters:parameters
@@ -1089,20 +1090,18 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     }
     
     NSDate *localDate = [self.deviceDateFormatter dateFromString:dateString];
-    
     return localDate;
 }
 
 
-- (NSString *)siteLocalStringForDate:(NSDate *)date
+- (NSString *)deviceLocalStringForDate:(NSDate *)date
 {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
     formatter.dateFormat = @"yyyy-MM-dd";
-    formatter.timeZone = self.siteTimeZone;
+    formatter.timeZone = [NSTimeZone systemTimeZone];
     
     NSString *todayString = [formatter stringFromDate:date];
-
     return todayString;
 }
 


### PR DESCRIPTION
Closes #181 #186 

Device and site timezones are being mixed up and in some cases not being used when dates are being calculated for end dates and passing dates to remote calls. Site timezone should be used in a very limited manner - really only for determining "today".

The other problem fixed was the individual "View All" calls were not calculating the end date to pass to the service and instead using the begin date.