### PR TITLE
Remove indentation from cells that are nested

### DIFF
--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -844,7 +844,8 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
                               rightText:item.value
                             andImageURL:item.iconURL
                             indentLevel:item.depth
-                             indentable:item.children.count > 0
+                             indentable:NO
+                             expandable:item.children.count > 0
                                expanded:item.expanded
                              selectable:item.actions.count > 0 || item.children.count > 0
                         forStatsSection:statsSection];
@@ -1099,6 +1100,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
                       andImageURL:(NSURL *)imageURL
                       indentLevel:(NSUInteger)indentLevel
                        indentable:(BOOL)indentable
+                       expandable:(BOOL)expandable
                          expanded:(BOOL)expanded
                        selectable:(BOOL)selectable
                   forStatsSection:(StatsSection)statsSection
@@ -1112,6 +1114,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
     statsCell.showCircularIcon = showCircularIcon;
     statsCell.indentLevel = indentLevel;
     statsCell.indentable = indentable;
+    statsCell.expandable = expandable;
     statsCell.expanded = expanded;
     statsCell.selectable = selectable;
     [statsCell doneSettingProperties];

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.h
@@ -10,6 +10,7 @@
 @property (nonatomic, assign) NSUInteger indentLevel;
 @property (nonatomic, assign) BOOL selectable;
 @property (nonatomic, assign) BOOL indentable;
+@property (nonatomic, assign) BOOL expandable;
 @property (nonatomic, assign) BOOL expanded;
 
 - (void)doneSettingProperties;

--- a/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/StatsTwoColumnTableViewCell.m
@@ -22,7 +22,7 @@
 {
     self.leftLabel.text = self.leftText;
     self.rightLabel.text = self.rightText;
-    self.indentChevronLabel.hidden = !self.indentable;
+    self.indentChevronLabel.hidden = !self.expandable;
 
     if (self.selectable) {
         self.selectionStyle = UITableViewCellSelectionStyleDefault;
@@ -62,8 +62,8 @@
         self.indentChevronLabel.text = @"";
     }
     
-    CGFloat indentWidth = self.indentLevel * 8.0f + 7.0f;
-    indentWidth += self.indentable || self.indentLevel > 1 ? 28.0f : 0.0f;
+    CGFloat indentWidth = self.indentable ? self.indentLevel * 8.0f + 7.0f : 15.0f;
+    indentWidth += self.expandable || self.indentLevel > 1 ? 28.0f : 0.0f;
     self.leadingEdgeConstraint.constant = indentWidth;
     
     [self setNeedsLayout];


### PR DESCRIPTION
Closes #179 

Makes the indentation on expandable cells optional and by default turn off the behavior.

![ios simulator screen shot feb 12 2015 7 14 07 pm](https://cloud.githubusercontent.com/assets/373903/6180643/8a3372ee-b2ed-11e4-8fc5-8e34620ed7e2.png)
