### PR TITLE
Clarified how dates are used - site time zone is really limited now

### DIFF
--- a/StatsDemo/StatsDemo/Base.lproj/Main_iPad.storyboard
+++ b/StatsDemo/StatsDemo/Base.lproj/Main_iPad.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6246"/>

--- a/WordPressCom-Stats-iOS/StatsDateUtilities.h
+++ b/WordPressCom-Stats-iOS/StatsDateUtilities.h
@@ -6,5 +6,6 @@
 - (instancetype)initWithTimeZone:(NSTimeZone *)timeZone;
 
 - (NSDate *)calculateEndDateForPeriodUnit:(StatsPeriodUnit)unit withDateWithinPeriod:(NSDate *)date;
+- (NSString *)dateAgeForDate:(NSDate *)date;
 
 @end

--- a/WordPressCom-Stats-iOS/StatsDateUtilities.m
+++ b/WordPressCom-Stats-iOS/StatsDateUtilities.m
@@ -10,7 +10,7 @@
 
 - (instancetype)init
 {
-    self = [self initWithTimeZone:[NSTimeZone systemTimeZone]];
+    self = [self initWithTimeZone:[NSTimeZone localTimeZone]];
     if (self) {
         
     }
@@ -80,6 +80,49 @@
     
     return nil;
 }
+
+
+- (NSString *)dateAgeForDate:(NSDate *)date
+{
+    if (!date) {
+        return @"";
+    }
+    
+    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    calendar.timeZone = self.timeZone;
+    NSDate *now = [NSDate date];
+    
+    NSDateComponents *dateComponents = [calendar components:NSCalendarUnitMinute | NSCalendarUnitHour | NSCalendarUnitDay
+                                                   fromDate:date
+                                                     toDate:now
+                                                    options:0];
+    NSDateComponents *niceDateComponents = [calendar components:NSCalendarUnitMinute | NSCalendarUnitHour | NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear
+                                                       fromDate:date
+                                                         toDate:now
+                                                        options:0];
+    
+    if (dateComponents.day >= 548) {
+        return [NSString stringWithFormat:NSLocalizedString(@"%d years", @"Age between dates over one year."), niceDateComponents.year];
+    } else if (dateComponents.day >= 345) {
+        return NSLocalizedString(@"a year", @"Age between dates equaling one year.");
+    } else if (dateComponents.day >= 45) {
+        return [NSString stringWithFormat:NSLocalizedString(@"%d months", @"Age between dates over one month."), niceDateComponents.month];
+    } else if (dateComponents.day >= 25) {
+        return NSLocalizedString(@"a month", @"Age between dates equaling one month.");
+    } else if (dateComponents.day > 1 || (dateComponents.day == 1 && dateComponents.hour >= 12)) {
+        return [NSString stringWithFormat:NSLocalizedString(@"%d days", @"Age between dates over one day."), niceDateComponents.day];
+    } else if (dateComponents.hour >= 22) {
+        return NSLocalizedString(@"a day", @"Age between dates equaling one day.");
+    } else if (dateComponents.hour > 1 || (dateComponents.hour == 1 && dateComponents.minute >= 30)) {
+        return [NSString stringWithFormat:NSLocalizedString(@"%d hours", @"Age between dates over one hour."), niceDateComponents.hour];
+    } else if (dateComponents.minute >= 45) {
+        return NSLocalizedString(@"an hour", @"Age between dates equaling one hour.");
+    } else {
+        return NSLocalizedString(@"<1 hour", @"Age between dates less than one hour.");
+    }
+}
+
+
 
 
 @end

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -84,7 +84,8 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
     [self wipeDataAndSeedGroups];
     
     self.graphViewController = [WPStatsGraphViewController new];
-    self.selectedDate = [NSDate date];
+    
+    [self resetDateToTodayForSite];
     self.selectedPeriodUnit = StatsPeriodUnitDay;
     self.selectedSummaryType = StatsSummaryTypeViews;
     self.graphViewController.allowDeselection = NO;
@@ -425,7 +426,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
 
 - (IBAction)refreshCurrentStats:(UIRefreshControl *)sender
 {
-    self.selectedDate = [NSDate date];
+    [self resetDateToTodayForSite];
     [self.statsService expireAllItemsInCache];
     [self retrieveStatsSkipGraph:NO];
 }
@@ -435,7 +436,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
 {
     StatsPeriodUnit unit = (StatsPeriodUnit)control.selectedSegmentIndex;
     self.selectedPeriodUnit = unit;
-    self.selectedDate = [NSDate date];
+    [self resetDateToTodayForSite];
     NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:[self.sections indexOfObject:@(StatsSectionPeriodHeader)]];
     [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationFade];
 
@@ -1154,6 +1155,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
     return data;
 }
 
+
 - (void)wipeDataAndSeedGroups
 {
     if (self.sectionData) {
@@ -1192,5 +1194,21 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
     [refreshControl addTarget:self action:@selector(refreshCurrentStats:) forControlEvents:UIControlEventValueChanged];
     self.refreshControl = refreshControl;
 }
+
+
+// Resets self.selected date to an NSDate with device local timezone but representing what today is
+// for the site, not the device
+- (void)resetDateToTodayForSite
+{
+    NSCalendar *calendar = [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
+    calendar.timeZone = self.siteTimeZone;
+    
+    NSDateComponents *components = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:[NSDate date]];
+    
+    calendar.timeZone = [NSTimeZone localTimeZone];
+    NSDate *date = [calendar dateFromComponents:components];
+    self.selectedDate = date;
+}
+
 
 @end

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -44,7 +44,7 @@
     if (self) {
         _siteId = siteId;
         _oauth2Token = oauth2Token;
-        _siteTimeZone = timeZone ?: [NSTimeZone systemTimeZone];
+        _siteTimeZone = timeZone ?: [NSTimeZone localTimeZone];
         _ephemory = [[StatsEphemory alloc] initWithExpiryInterval:cacheExpirationInterval];
     }
 
@@ -354,7 +354,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
         cacheDictionary[@(statsSubSection)] = followersResult;
         
         for (StatsItem *item in items) {
-            NSString *age = [self dateAgeForDate:item.date];
+            NSString *age = [self.dateUtilities dateAgeForDate:item.date];
             item.value = age;
         }
         
@@ -368,54 +368,14 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
 #pragma mark - Private helper methods
 
 
-// TODO - Extract this into a separate class that's unit testable
-- (NSString *)dateAgeForDate:(NSDate *)date
-{
-    if (!date) {
-        return @"";
-    }
-    
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-    NSDate *now = [NSDate date];
-    
-    NSDateComponents *dateComponents = [calendar components:NSCalendarUnitMinute | NSCalendarUnitHour | NSCalendarUnitDay
-                                                   fromDate:date
-                                                     toDate:now
-                                                    options:0];
-    NSDateComponents *niceDateComponents = [calendar components:NSCalendarUnitMinute | NSCalendarUnitHour | NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear
-                                                       fromDate:date
-                                                         toDate:now
-                                                        options:0];
-    
-    if (dateComponents.day >= 548) {
-        return [NSString stringWithFormat:NSLocalizedString(@"%d years", @"Age between dates over one year."), niceDateComponents.year];
-    } else if (dateComponents.day >= 345) {
-        return NSLocalizedString(@"a year", @"Age between dates equaling one year.");
-    } else if (dateComponents.day >= 45) {
-        return [NSString stringWithFormat:NSLocalizedString(@"%d months", @"Age between dates over one month."), niceDateComponents.month];
-    } else if (dateComponents.day >= 25) {
-        return NSLocalizedString(@"a month", @"Age between dates equaling one month.");
-    } else if (dateComponents.day > 1 || (dateComponents.day == 1 && dateComponents.hour >= 12)) {
-        return [NSString stringWithFormat:NSLocalizedString(@"%d days", @"Age between dates over one day."), niceDateComponents.day];
-    } else if (dateComponents.hour >= 22) {
-        return NSLocalizedString(@"a day", @"Age between dates equaling one day.");
-    } else if (dateComponents.hour > 1 || (dateComponents.hour == 1 && dateComponents.minute >= 30)) {
-        return [NSString stringWithFormat:NSLocalizedString(@"%d hours", @"Age between dates over one hour."), niceDateComponents.hour];
-    } else if (dateComponents.minute >= 45) {
-        return NSLocalizedString(@"an hour", @"Age between dates equaling one hour.");
-    } else {
-        return NSLocalizedString(@"<1 hour", @"Age between dates less than one hour.");
-    }
-}
-
-
 - (StatsDateUtilities *)dateUtilities
 {
     if (!_dateUtilities) {
-        _dateUtilities = [[StatsDateUtilities alloc] initWithTimeZone:self.siteTimeZone];
+        _dateUtilities = [StatsDateUtilities new];
     }
     
     return _dateUtilities;
 }
+
 
 @end

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -44,7 +44,7 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
         _deviceDateFormatter = [NSDateFormatter new];
         _deviceDateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
         _deviceDateFormatter.dateFormat = @"yyyy-MM-dd";
-        _deviceDateFormatter.timeZone = timeZone;
+        _deviceDateFormatter.timeZone = [NSTimeZone localTimeZone];
         
         _deviceNumberFormatter = [NSNumberFormatter new];
         
@@ -1099,7 +1099,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
     formatter.dateFormat = @"yyyy-MM-dd";
-    formatter.timeZone = [NSTimeZone systemTimeZone];
+    formatter.timeZone = [NSTimeZone localTimeZone];
     
     NSString *todayString = [formatter stringFromDate:date];
     return todayString;

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
@@ -17,7 +17,7 @@
 - (void)setUp {
     [super setUp];
     
-    self.subject = [[WPStatsServiceRemote alloc] initWithOAuth2Token:@"token" siteId:@123456 andSiteTimeZone:[NSTimeZone systemTimeZone]];
+    self.subject = [[WPStatsServiceRemote alloc] initWithOAuth2Token:@"token" siteId:@123456 andSiteTimeZone:[NSTimeZone localTimeZone]];
 }
 
 - (void)tearDown {

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
@@ -20,7 +20,7 @@
 - (void)setUp {
     [super setUp];
     
-    self.subject = [[WPStatsService alloc] initWithSiteId:@123456 siteTimeZone:[NSTimeZone systemTimeZone] oauth2Token:@"token" andCacheExpirationInterval:50 * 6];
+    self.subject = [[WPStatsService alloc] initWithSiteId:@123456 siteTimeZone:[NSTimeZone localTimeZone] oauth2Token:@"token" andCacheExpirationInterval:50 * 6];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
Closes #195 

Site timezone is now only used for calculating what "today" is, as it did in the old version of stats. With this PR and the WPiOS blog timezone fix it should resolve any crazy dates and data that doesn't match.

cc: @daniloercoli for review (even after its merged)