### PR TITLE
Resolves the issue with the graph changing dates when put in background

### DIFF
--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -115,6 +115,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification
 {
+    [self resetDateToTodayForSite];
     [self retrieveStatsSkipGraph:NO];
 }
 


### PR DESCRIPTION
Fixes #186 

Reset the selected date to the most recent when the app returns from the background. This isn't the final solution but one that at least fixes the weird behavior with the graph going back in time.

cc: @daniloercoli 