### PR TITLE
Safely retrieve string for href in top-posts

### DIFF
--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		936B2254195CB2FE0058C828 /* WPStyleGuide+Stats.m in Sources */ = {isa = PBXBuildFile; fileRef = 936B2253195CB2FE0058C828 /* WPStyleGuide+Stats.m */; };
 		936E74A41A688E6F0048F552 /* StatsSelectableTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 936E74A31A688E6F0048F552 /* StatsSelectableTableViewCell.m */; };
 		936E74A71A69A8990048F552 /* StatsTableSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 936E74A61A69A8990048F552 /* StatsTableSectionHeaderView.m */; };
+		9387DB0A1A96311E00AB7662 /* stats-v1.1-top-posts-day-exception.json in Resources */ = {isa = PBXBuildFile; fileRef = 9387DB091A96311E00AB7662 /* stats-v1.1-top-posts-day-exception.json */; };
 		9389C94E197EBBAF0036D437 /* WPStatsGraphToastView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9389C94D197EBBAF0036D437 /* WPStatsGraphToastView.m */; };
 		9396CFB31921096A006A66D7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9396CFB21921096A006A66D7 /* Foundation.framework */; };
 		9396CFC11921096B006A66D7 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9396CFC01921096B006A66D7 /* XCTest.framework */; };
@@ -151,6 +152,7 @@
 		936E74A51A69A8990048F552 /* StatsTableSectionHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsTableSectionHeaderView.h; sourceTree = "<group>"; };
 		936E74A61A69A8990048F552 /* StatsTableSectionHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsTableSectionHeaderView.m; sourceTree = "<group>"; };
 		9383180E1994F701003B953A /* WordPressCom-Stats-iOSTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WordPressCom-Stats-iOSTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		9387DB091A96311E00AB7662 /* stats-v1.1-top-posts-day-exception.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-v1.1-top-posts-day-exception.json"; sourceTree = "<group>"; };
 		9389C94C197EBBAF0036D437 /* WPStatsGraphToastView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPStatsGraphToastView.h; sourceTree = "<group>"; };
 		9389C94D197EBBAF0036D437 /* WPStatsGraphToastView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPStatsGraphToastView.m; sourceTree = "<group>"; };
 		9396CFAF1921096A006A66D7 /* libWordPressCom-Stats-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libWordPressCom-Stats-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -378,22 +380,23 @@
 			isa = PBXGroup;
 			children = (
 				93E3679C1922B751000FB32A /* stats-batch.json */,
-				93652B7E19FFFC60006A4C47 /* stats-v1.1-summary.json */,
-				93274AE51A07CCE40017238F /* stats-v1.1-visits-day.json */,
-				931193EB1A0C09D60005BED2 /* stats-v1.1-visits-day-large.json */,
-				93274AE71A091E840017238F /* stats-v1.1-top-posts-day.json */,
-				931193ED1A0C0D050005BED2 /* stats-v1.1-top-posts-day-large.json */,
-				93274AE91A09B4FA0017238F /* stats-v1.1-referrers-day.json */,
-				931193EF1A0C12170005BED2 /* stats-v1.1-referrers-day-large.json */,
 				931193E71A0BAA660005BED2 /* stats-v1.1-clicks-day.json */,
 				931193F11A0C18C70005BED2 /* stats-v1.1-clicks-month-large.json */,
-				931193E91A0BBF7D0005BED2 /* stats-v1.1-country-views-day.json */,
 				933FF2251A40C7FD00336167 /* stats-v1.1-comments-day.json */,
-				933FF2211A407F2B00336167 /* stats-v1.1-followers-wpcom-day.json */,
+				931193E91A0BBF7D0005BED2 /* stats-v1.1-country-views-day.json */,
 				933FF2231A4085C300336167 /* stats-v1.1-followers-email-day.json */,
+				933FF2211A407F2B00336167 /* stats-v1.1-followers-wpcom-day.json */,
+				931193EF1A0C12170005BED2 /* stats-v1.1-referrers-day-large.json */,
+				93274AE91A09B4FA0017238F /* stats-v1.1-referrers-day.json */,
+				93652B7E19FFFC60006A4C47 /* stats-v1.1-summary.json */,
 				933FF21F1A40736D00336167 /* stats-v1.1-tags-categories-views-day.json */,
-				933FF21B1A406E0400336167 /* stats-v1.1-video-plays-day.json */,
+				931193ED1A0C0D050005BED2 /* stats-v1.1-top-posts-day-large.json */,
+				93274AE71A091E840017238F /* stats-v1.1-top-posts-day.json */,
+				9387DB091A96311E00AB7662 /* stats-v1.1-top-posts-day-exception.json */,
 				933FF21D1A406E1400336167 /* stats-v1.1-video-plays-day-no-data.json */,
+				933FF21B1A406E0400336167 /* stats-v1.1-video-plays-day.json */,
+				931193EB1A0C09D60005BED2 /* stats-v1.1-visits-day-large.json */,
+				93274AE51A07CCE40017238F /* stats-v1.1-visits-day.json */,
 			);
 			name = "Test Data";
 			sourceTree = "<group>";
@@ -492,6 +495,7 @@
 				93274AEA1A09B4FA0017238F /* stats-v1.1-referrers-day.json in Resources */,
 				933FF2201A40736D00336167 /* stats-v1.1-tags-categories-views-day.json in Resources */,
 				933FF2261A40C7FD00336167 /* stats-v1.1-comments-day.json in Resources */,
+				9387DB0A1A96311E00AB7662 /* stats-v1.1-top-posts-day-exception.json in Resources */,
 				93E3679D1922B751000FB32A /* stats-batch.json in Resources */,
 				931193EC1A0C09D60005BED2 /* stats-v1.1-visits-day-large.json in Resources */,
 				9396CFCD1921096B006A66D7 /* InfoPlist.strings in Resources */,

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -435,11 +435,14 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
             statsItem.value = [self localizedStringForNumber:[post numberForKey:@"views"]];
             statsItem.label = [post stringForKey:@"title"];
             
-            StatsItemAction *statsItemAction = [StatsItemAction new];
-            statsItemAction.url = [NSURL URLWithString:[post stringForKey:@"href"]];
-            statsItemAction.defaultAction = YES;
-            
-            statsItem.actions = @[statsItemAction];
+            id url = post[@"href"];
+            if ([url isKindOfClass:[NSString class]]) {
+                StatsItemAction *statsItemAction = [StatsItemAction new];
+                statsItemAction.url = [NSURL URLWithString:url];
+                statsItemAction.defaultAction = YES;
+
+                statsItem.actions = @[statsItemAction];
+            }
             
             [items addObject:statsItem];
         }

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -436,7 +436,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
             statsItem.label = [post stringForKey:@"title"];
             
             StatsItemAction *statsItemAction = [StatsItemAction new];
-            statsItemAction.url = [NSURL URLWithString:post[@"href"]];
+            statsItemAction.url = [NSURL URLWithString:[post stringForKey:@"href"]];
             statsItemAction.defaultAction = YES;
             
             statsItem.actions = @[statsItemAction];

--- a/WordPressCom-Stats-iOSTests/stats-v1.1-top-posts-day-exception.json
+++ b/WordPressCom-Stats-iOSTests/stats-v1.1-top-posts-day-exception.json
@@ -1,0 +1,91 @@
+{
+    "date": "2014-11-04",
+    "days": {
+        "2014-11-04": {
+            "postviews": [
+                          {
+                          "id": 750,
+                          "href": false,
+                          "date": "2014-08-06 14:52:11",
+                          "title": "Asynchronous unit testing Core Data with Xcode 6",
+                          "views": 7,
+                          "video_play": false
+                          },
+                          {
+                          "id": 200,
+                          "href": "http://astralbodi.es/2012/02/01/resizing-a-uitextview-automatically-with-the-keyboard/",
+                          "date": "2012-02-01 09:34:11",
+                          "title": "Resizing a UITextView automatically with the keyboard",
+                          "views": 4,
+                          "video_play": false
+                          },
+                          {
+                          "id": 120,
+                          "href": "http://astralbodi.es/2011/03/20/ios-basics-uinavigation-controller-back-button-text/",
+                          "date": "2011-03-20 10:16:09",
+                          "title": "iOS Basics - UINavigation Controller & Back Button Text",
+                          "views": 4,
+                          "video_play": false
+                          },
+                          {
+                          "id": 0,
+                          "href": "http://astralbodi.es/",
+                          "date": null,
+                          "title": "Home page / Archives",
+                          "views": 2,
+                          "video_play": false
+                          },
+                          {
+                          "id": 111,
+                          "href": "http://astralbodi.es/2011/02/04/mac-os-x-adding-a-loopback-alias/",
+                          "date": "2011-02-04 10:13:33",
+                          "title": "Mac OS X - Adding a loopback alias",
+                          "views": 2,
+                          "video_play": false
+                          },
+                          {
+                          "id": 802,
+                          "href": "http://astralbodi.es/2014/10/30/stabby/",
+                          "date": "2014-10-30 14:00:38",
+                          "title": "Stabby",
+                          "views": 2,
+                          "video_play": false
+                          },
+                          {
+                          "id": 151,
+                          "href": "http://astralbodi.es/2011/07/07/ios-pull-app-version-from-bundle-configuration/",
+                          "date": "2011-07-07 08:46:42",
+                          "title": "iOS - Pull App Version From Bundle Configuration",
+                          "views": 1,
+                          "video_play": false
+                          },
+                          {
+                          "id": 725,
+                          "href": "http://astralbodi.es/2014/06/05/mac-os-x-10-9-mavericks-calendar-google-sync-problems/",
+                          "date": "2014-06-05 10:23:24",
+                          "title": "Mac OS X 10.9 Mavericks Calendar + Google Sync Problems",
+                          "views": 1,
+                          "video_play": false
+                          },
+                          {
+                          "id": 59,
+                          "href": "http://astralbodi.es/2009/11/16/xcode-wtf-are-you-doing/",
+                          "date": "2009-11-16 09:36:02",
+                          "title": "Xcode WTF are you doing?!",
+                          "views": 1,
+                          "video_play": false
+                          },
+                          {
+                          "id": 149,
+                          "href": "http://astralbodi.es/2011/07/05/time-warner-cable-power-snr-acceptable-values/",
+                          "date": "2011-07-05 10:20:03",
+                          "title": "Time Warner Cable Power / SNR Acceptable Values",
+                          "views": 1,
+                          "video_play": false
+                          }
+                          ],
+            "total_views": 25
+        }
+    },
+    "period": "day"
+}


### PR DESCRIPTION
Closes #203 

Use the safe expectation method stringForKey to ensure a string is returned. Ideally the API call should be fixed.