### PR TITLE
Re-enable Events/Published section and fix weirdness

### DIFF
--- a/WordPressCom-Stats-iOS/StatsDateUtilities.m
+++ b/WordPressCom-Stats-iOS/StatsDateUtilities.m
@@ -37,11 +37,17 @@
     
     if (unit == StatsPeriodUnitDay) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
+        dateComponents.hour = 23;
+        dateComponents.minute = 59;
+        dateComponents.second = 59;
         date = [calendar dateFromComponents:dateComponents];
         
         return date;
     } else if (unit == StatsPeriodUnitMonth) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth fromDate:date];
+        dateComponents.hour = 23;
+        dateComponents.minute = 59;
+        dateComponents.second = 59;
         date = [calendar dateFromComponents:dateComponents];
         
         dateComponents = [NSDateComponents new];
@@ -61,13 +67,19 @@
             date = [calendar dateByAddingComponents:dateComponents toDate:date options:0];
         }
         
-        // Strip time
+        // Force time
         dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
+        dateComponents.hour = 23;
+        dateComponents.minute = 59;
+        dateComponents.second = 59;
         date = [calendar dateFromComponents:dateComponents];
         
         return date;
     } else if (unit == StatsPeriodUnitYear) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear fromDate:date];
+        dateComponents.hour = 23;
+        dateComponents.minute = 59;
+        dateComponents.second = 59;
         date = [calendar dateFromComponents:dateComponents];
         
         dateComponents = [NSDateComponents new];

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -66,6 +66,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
     
     self.sections =     @[ @(StatsSectionGraph),
                            @(StatsSectionPeriodHeader),
+                           @(StatsSectionEvents),
                            @(StatsSectionPosts),
                            @(StatsSectionCountry),
                            @(StatsSectionReferrers),
@@ -517,7 +518,19 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
          NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(self.selectedSummaryType + 1) inSection:sectionNumber];
          [self.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
      }
-                        eventsCompletionHandler:nil
+                       eventsCompletionHandler:^(StatsGroup *group, NSError *error)
+     {
+         group.offsetRows = StatsTableRowDataOffsetWithoutGroupHeader;
+         self.sectionData[@(StatsSectionEvents)] = group;
+         
+         [self.tableView beginUpdates];
+         
+         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionEvents)];
+         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
+         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         
+         [self.tableView endUpdates];
+     }
                          postsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -401,8 +401,8 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         }
     };
     
-    NSDictionary *parameters = @{@"after"   : [self deviceLocalStringForDate:[self calculateStartDateForPeriodUnit:unit withEndDate:date]],
-                                 @"before"  : [self deviceLocalStringForDate:date],
+    NSDictionary *parameters = @{@"after"   : [self deviceLocalISOStringForDate:[self calculateStartDateForPeriodUnit:unit withEndDate:date]],
+                                 @"before"  : [self deviceLocalISOStringForDate:date],
                                  @"number"  : @10,
                                  @"fields"  : @"ID, title, URL"};
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForPosts]
@@ -1109,6 +1109,18 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 }
 
 
+- (NSString *)deviceLocalISOStringForDate:(NSDate *)date
+{
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+    formatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss";
+    formatter.timeZone = [NSTimeZone localTimeZone];
+    
+    NSString *todayString = [formatter stringFromDate:date];
+    return todayString;
+}
+
+
 - (StatsPeriodUnit)periodUnitForString:(NSString *)unitString
 {
     if ([unitString isEqualToString:@"day"]) {
@@ -1188,13 +1200,14 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 
 - (NSDate *)calculateStartDateForPeriodUnit:(StatsPeriodUnit)unit withEndDate:(NSDate *)date
 {
-    if (unit == StatsPeriodUnitDay) {
-        return date;
-    }
-    
     NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     
-    if (unit == StatsPeriodUnitMonth) {
+    if (unit == StatsPeriodUnitDay) {
+        NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
+        date = [calendar dateFromComponents:dateComponents];
+        
+        return date;
+    } else if (unit == StatsPeriodUnitMonth) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth fromDate:date];
         date = [calendar dateFromComponents:dateComponents];
         

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -390,6 +390,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
             item.label = [[post stringForKey:@"title"] stringByDecodingXMLCharacters];
             
             StatsItemAction *itemAction = [StatsItemAction new];
+            itemAction.defaultAction = YES;
             itemAction.url = [NSURL URLWithString:[post stringForKey:@"URL"]];
             item.actions = @[itemAction];
             

--- a/WordPressCom-Stats-iOSTests/StatsDateUtilitiesTests.m
+++ b/WordPressCom-Stats-iOSTests/StatsDateUtilitiesTests.m
@@ -35,11 +35,15 @@
     
     NSDate *result = [self.subject calculateEndDateForPeriodUnit:StatsPeriodUnitDay withDateWithinPeriod:date];
     
-    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:result];
+    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond fromDate:result];
     
     XCTAssertEqual(dateComponents.year, 2014);
     XCTAssertEqual(dateComponents.month, 12);
     XCTAssertEqual(dateComponents.day, 30);
+    XCTAssertEqual(dateComponents.hour, 23);
+    XCTAssertEqual(dateComponents.minute, 59);
+    XCTAssertEqual(dateComponents.second, 59);
+    
 }
 
 
@@ -56,11 +60,14 @@
     
     NSDate *result = [self.subject calculateEndDateForPeriodUnit:StatsPeriodUnitWeek withDateWithinPeriod:date];
     
-    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:result];
+    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond fromDate:result];
     
     XCTAssertEqual(dateComponents.year, 2015);
     XCTAssertEqual(dateComponents.month, 1);
     XCTAssertEqual(dateComponents.day, 11);
+    XCTAssertEqual(dateComponents.hour, 23);
+    XCTAssertEqual(dateComponents.minute, 59);
+    XCTAssertEqual(dateComponents.second, 59);
 }
 
 
@@ -77,11 +84,14 @@
     
     NSDate *result = [self.subject calculateEndDateForPeriodUnit:StatsPeriodUnitMonth withDateWithinPeriod:date];
     
-    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:result];
+    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond fromDate:result];
     
     XCTAssertEqual(dateComponents.year, 2015);
     XCTAssertEqual(dateComponents.month, 1);
     XCTAssertEqual(dateComponents.day, 31);
+    XCTAssertEqual(dateComponents.hour, 23);
+    XCTAssertEqual(dateComponents.minute, 59);
+    XCTAssertEqual(dateComponents.second, 59);
 }
 
 
@@ -98,11 +108,14 @@
     
     NSDate *result = [self.subject calculateEndDateForPeriodUnit:StatsPeriodUnitYear withDateWithinPeriod:date];
     
-    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:result];
+    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond fromDate:result];
     
     XCTAssertEqual(dateComponents.year, 2015);
     XCTAssertEqual(dateComponents.month, 12);
     XCTAssertEqual(dateComponents.day, 31);
+    XCTAssertEqual(dateComponents.hour, 23);
+    XCTAssertEqual(dateComponents.minute, 59);
+    XCTAssertEqual(dateComponents.second, 59);
 }
 
 @end


### PR DESCRIPTION
Closes #129 

1. Re-enables events/published items section.
2. Fixes the date parameters sent to the /posts endpoint to include time in the ISO format we all love.
3. Internally establish 23:59:59 for the time on all calculated end dates.

cc: @nbradbury since you originally reported the strangeness