### PR TITLE
Implement authors and search terms sections

### DIFF
--- a/WordPressCom-Stats-iOS/StatsDateUtilities.m
+++ b/WordPressCom-Stats-iOS/StatsDateUtilities.m
@@ -37,11 +37,17 @@
     
     if (unit == StatsPeriodUnitDay) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
+        dateComponents.hour = 23;
+        dateComponents.minute = 59;
+        dateComponents.second = 59;
         date = [calendar dateFromComponents:dateComponents];
         
         return date;
     } else if (unit == StatsPeriodUnitMonth) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth fromDate:date];
+        dateComponents.hour = 23;
+        dateComponents.minute = 59;
+        dateComponents.second = 59;
         date = [calendar dateFromComponents:dateComponents];
         
         dateComponents = [NSDateComponents new];
@@ -61,13 +67,19 @@
             date = [calendar dateByAddingComponents:dateComponents toDate:date options:0];
         }
         
-        // Strip time
+        // Force time
         dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
+        dateComponents.hour = 23;
+        dateComponents.minute = 59;
+        dateComponents.second = 59;
         date = [calendar dateFromComponents:dateComponents];
         
         return date;
     } else if (unit == StatsPeriodUnitYear) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear fromDate:date];
+        dateComponents.hour = 23;
+        dateComponents.minute = 59;
+        dateComponents.second = 59;
         date = [calendar dateFromComponents:dateComponents];
         
         dateComponents = [NSDateComponents new];

--- a/WordPressCom-Stats-iOS/StatsGroup.m
+++ b/WordPressCom-Stats-iOS/StatsGroup.m
@@ -72,6 +72,11 @@
 - (void)setUpTitles
 {
     switch (self.statsSection) {
+        case StatsSectionAuthors:
+            self.groupTitle = NSLocalizedString(@"Authors", @"Title for stats section for Authors");
+            self.titlePrimary = NSLocalizedString(@"Author", @"");
+            self.titleSecondary = NSLocalizedString(@"Views", @"");
+            break;
         case StatsSectionClicks:
             self.groupTitle = NSLocalizedString(@"Clicks", @"Title for stats section for Clicks");
             self.titlePrimary = NSLocalizedString(@"Link", @"");
@@ -110,6 +115,11 @@
             self.titlePrimary = NSLocalizedString(@"Referrer", @"");
             self.titleSecondary = NSLocalizedString(@"Views", @"");
             break;
+        case StatsSectionSearchTerms:
+            self.groupTitle = NSLocalizedString(@"Search Terms", @"Title for stats section for Search Terms");
+            self.titlePrimary = NSLocalizedString(@"Search", @"");
+            self.titleSecondary = NSLocalizedString(@"Views", @"");
+            break;
         case StatsSectionTagsCategories:
             self.groupTitle = NSLocalizedString(@"Tags & Categories", @"Title for stats section for Tags & Categories");
             self.titlePrimary = NSLocalizedString(@"Topic", @"");
@@ -120,8 +130,10 @@
             self.titlePrimary = NSLocalizedString(@"Video", @"");
             self.titleSecondary = NSLocalizedString(@"Views", @"");
             break;
-            
-        default:
+
+        case StatsSectionGraph:
+        case StatsSectionPeriodHeader:
+        case StatsSectionWebVersion:
             break;
     }
 

--- a/WordPressCom-Stats-iOS/StatsSection.h
+++ b/WordPressCom-Stats-iOS/StatsSection.h
@@ -7,6 +7,8 @@ typedef NS_ENUM(NSInteger, StatsSection) {
     StatsSectionClicks,
     StatsSectionCountry,
     StatsSectionVideos,
+    StatsSectionAuthors,
+    StatsSectionSearchTerms,
     StatsSectionComments,
     StatsSectionTagsCategories,
     StatsSectionFollowers,

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -1155,7 +1155,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
                        selectable:(BOOL)selectable
                   forStatsSection:(StatsSection)statsSection
 {
-    BOOL showCircularIcon = (statsSection == StatsSectionComments || statsSection == StatsSectionFollowers);
+    BOOL showCircularIcon = (statsSection == StatsSectionComments || statsSection == StatsSectionFollowers || statsSection == StatsSectionAuthors);
 
     StatsTwoColumnTableViewCell *statsCell = (StatsTwoColumnTableViewCell *)cell;
     statsCell.leftText = leftText;

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -66,6 +66,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
     
     self.sections =     @[ @(StatsSectionGraph),
                            @(StatsSectionPeriodHeader),
+                           @(StatsSectionEvents),
                            @(StatsSectionPosts),
                            @(StatsSectionCountry),
                            @(StatsSectionReferrers),
@@ -517,7 +518,19 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
          NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(self.selectedSummaryType + 1) inSection:sectionNumber];
          [self.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
      }
-                        eventsCompletionHandler:nil
+                       eventsCompletionHandler:^(StatsGroup *group, NSError *error)
+     {
+         group.offsetRows = StatsTableRowDataOffsetWithoutGroupHeader;
+         self.sectionData[@(StatsSectionEvents)] = group;
+         
+         [self.tableView beginUpdates];
+         
+         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionEvents)];
+         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
+         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         
+         [self.tableView endUpdates];
+     }
                          postsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -596,6 +596,14 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
          
          [self.tableView endUpdates];
      }
+                      authorsCompletionHandler:^(StatsGroup *group, NSError *error)
+     {
+         // TODO
+     }
+                  searchTermsCompletionHandler:^(StatsGroup *group, NSError *error)
+     {
+         // TODO
+     }
                 commentsAuthorCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetWithGroupSelector;

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -64,13 +64,16 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
     
     [self setupRefreshControl];
     
+    // Posts, Referrers, Clicks, Authors, Countries, Search Terms, Published, Videos, Comments, Tags, Followers, Publicize
     self.sections =     @[ @(StatsSectionGraph),
                            @(StatsSectionPeriodHeader),
-                           @(StatsSectionEvents),
                            @(StatsSectionPosts),
-                           @(StatsSectionCountry),
                            @(StatsSectionReferrers),
                            @(StatsSectionClicks),
+                           @(StatsSectionAuthors),
+                           @(StatsSectionCountry),
+                           @(StatsSectionSearchTerms),
+                           @(StatsSectionEvents),
                            @(StatsSectionVideos),
                            @(StatsSectionComments),
                            @(StatsSectionTagsCategories),
@@ -598,11 +601,29 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
      }
                       authorsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
-         // TODO
+         group.offsetRows = StatsTableRowDataOffsetStandard;
+         self.sectionData[@(StatsSectionAuthors)] = group;
+         
+         [self.tableView beginUpdates];
+         
+         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionAuthors)];
+         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
+         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         
+         [self.tableView endUpdates];
      }
                   searchTermsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
-         // TODO
+         group.offsetRows = StatsTableRowDataOffsetStandard;
+         self.sectionData[@(StatsSectionSearchTerms)] = group;
+         
+         [self.tableView beginUpdates];
+         
+         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionSearchTerms)];
+         NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
+         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         
+         [self.tableView endUpdates];
      }
                 commentsAuthorCompletionHandler:^(StatsGroup *group, NSError *error)
      {
@@ -745,6 +766,8 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
         case StatsSectionClicks:
         case StatsSectionCountry:
         case StatsSectionVideos:
+        case StatsSectionAuthors:
+        case StatsSectionSearchTerms:
         case StatsSectionTagsCategories:
         case StatsSectionPublicize:
         {
@@ -1090,6 +1113,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
             case StatsSectionFollowers:
                 text = NSLocalizedString(@"No followers", @"");
                 break;
+            case StatsSectionAuthors:
             case StatsSectionPosts:
                 text = NSLocalizedString(@"No posts or pages viewed", @"");
                 break;
@@ -1098,6 +1122,9 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
                 break;
             case StatsSectionReferrers:
                 text = NSLocalizedString(@"No referrers recorded", @"");
+                break;
+            case StatsSectionSearchTerms:
+                text = NSLocalizedString(@"No search terms recorded", @"");
                 break;
             case StatsSectionTagsCategories:
                 text = NSLocalizedString(@"No tagged posts or pages viewed", @"");

--- a/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
@@ -238,6 +238,10 @@ static NSString *const StatsTableLoadingIndicatorCellIdentifier = @"LoadingIndic
         [self.statsService retrieveCountriesForDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];
     } else if (self.statsSection == StatsSectionVideos) {
         [self.statsService retrieveVideosForDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];
+    } else if (self.statsSection == StatsSectionAuthors) {
+        [self.statsService retrieveAuthorsForDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];
+    } else if (self.statsSection == StatsSectionSearchTerms) {
+        [self.statsService retrieveSearchTermsForDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];
     } else if (self.statsSection == StatsSectionFollowers) {
         StatsFollowerType followerType = self.statsSubSection == StatsSubSectionFollowersDotCom ? StatsFollowerTypeDotCom : StatsFollowerTypeEmail;
         [self.statsService retrieveFollowersOfType:followerType forDate:self.selectedDate andUnit:self.periodUnit withCompletionHandler:completion];

--- a/WordPressCom-Stats-iOS/WPStatsService.h
+++ b/WordPressCom-Stats-iOS/WPStatsService.h
@@ -29,6 +29,8 @@ typedef NS_ENUM(NSUInteger, StatsFollowerType) {
         clicksCompletionHandler:(StatsGroupCompletion)clicksCompletion
        countryCompletionHandler:(StatsGroupCompletion)countryCompletion
         videosCompletionHandler:(StatsGroupCompletion)videosCompletion
+       authorsCompletionHandler:(StatsGroupCompletion)authorsCompletion
+   searchTermsCompletionHandler:(StatsGroupCompletion)searchTermsCompletionHandler
 commentsAuthorCompletionHandler:(StatsGroupCompletion)commentsAuthorsCompletion
  commentsPostsCompletionHandler:(StatsGroupCompletion)commentsPostsCompletion
 tagsCategoriesCompletionHandler:(StatsGroupCompletion)tagsCategoriesCompletion

--- a/WordPressCom-Stats-iOS/WPStatsService.h
+++ b/WordPressCom-Stats-iOS/WPStatsService.h
@@ -59,6 +59,14 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                       andUnit:(StatsPeriodUnit)unit
         withCompletionHandler:(StatsGroupCompletion)completionHandler;
 
+- (void)retrieveAuthorsForDate:(NSDate *)date
+                       andUnit:(StatsPeriodUnit)unit
+         withCompletionHandler:(StatsGroupCompletion)completionHandler;
+
+- (void)retrieveSearchTermsForDate:(NSDate *)date
+                           andUnit:(StatsPeriodUnit)unit
+             withCompletionHandler:(StatsGroupCompletion)completionHandler;
+
 - (void)retrieveFollowersOfType:(StatsFollowerType)followersType
                         forDate:(NSDate *)date
                         andUnit:(StatsPeriodUnit)unit

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -232,6 +232,27 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
 }
 
 
+
+- (void)retrieveAuthorsForDate:(NSDate *)date
+                       andUnit:(StatsPeriodUnit)unit
+         withCompletionHandler:(StatsGroupCompletion)completionHandler
+{
+    NSDate *endDate = [self.dateUtilities calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
+    
+    [self.remote fetchAuthorsStatsForDate:endDate andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil forStatsSection:StatsSectionAuthors andCompletionHandler:completionHandler]];
+}
+
+
+- (void)retrieveSearchTermsForDate:(NSDate *)date
+                           andUnit:(StatsPeriodUnit)unit
+             withCompletionHandler:(StatsGroupCompletion)completionHandler
+{
+    NSDate *endDate = [self.dateUtilities calculateEndDateForPeriodUnit:unit withDateWithinPeriod:date];
+    
+    [self.remote fetchSearchTermsStatsForDate:endDate andUnit:unit withCompletionHandler:[self remoteItemCompletionWithCache:nil forStatsSection:StatsSectionSearchTerms andCompletionHandler:completionHandler]];
+}
+
+
 - (void)retrieveTodayStatsWithCompletionHandler:(StatsSummaryCompletion)completion failureHandler:(void (^)(NSError *))failureHandler
 {
     void (^failure)(NSError *error) = ^void (NSError *error) {

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -60,6 +60,8 @@
         clicksCompletionHandler:(StatsGroupCompletion)clicksCompletion
        countryCompletionHandler:(StatsGroupCompletion)countryCompletion
         videosCompletionHandler:(StatsGroupCompletion)videosCompletion
+       authorsCompletionHandler:(StatsGroupCompletion)authorsCompletion
+   searchTermsCompletionHandler:(StatsGroupCompletion)searchTermsCompletion
 commentsAuthorCompletionHandler:(StatsGroupCompletion)commentsAuthorsCompletion
  commentsPostsCompletionHandler:(StatsGroupCompletion)commentsPostsCompletion
 tagsCategoriesCompletionHandler:(StatsGroupCompletion)tagsCategoriesCompletion
@@ -105,6 +107,14 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
             videosCompletion(cacheDictionary[@(StatsSectionVideos)], nil);
         }
     
+        if (authorsCompletion) {
+            authorsCompletion(cacheDictionary[@(StatsSectionAuthors)], nil);
+        }
+        
+        if (searchTermsCompletion) {
+            searchTermsCompletion(cacheDictionary[@(StatsSectionSearchTerms)], nil);
+        }
+        
         if (commentsAuthorsCompletion) {
             commentsAuthorsCompletion(cacheDictionary[@(StatsSubSectionCommentsByAuthor)], nil);
         }

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -157,6 +157,8 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                 clicksCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionClicks andCompletionHandler:clicksCompletion]
                countryCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionCountry andCompletionHandler:countryCompletion]
                 videosCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionVideos andCompletionHandler:videosCompletion]
+               authorsCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionAuthors andCompletionHandler:authorsCompletion]
+           searchTermsCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionSearchTerms andCompletionHandler:searchTermsCompletion]
               commentsCompletionHandler:[self remoteCommentsCompletionWithCache:cacheDictionary andCommentsAuthorsCompletion:commentsAuthorsCompletion commentsPostsCompletion:commentsPostsCompletion]
         tagsCategoriesCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionTagsCategories andCompletionHandler:tagsCategoriesCompletion]
        followersDotComCompletionHandler:[self remoteFollowersCompletionWithCache:cacheDictionary followerType:StatsFollowerTypeDotCom andCompletionHandler:followersDotComCompletion]

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
@@ -76,6 +76,14 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
                         andUnit:(StatsPeriodUnit)unit
           withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
 
+- (void)fetchAuthorsStatsForDate:(NSDate *)date
+                         andUnit:(StatsPeriodUnit)unit
+           withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
+
+- (void)fetchSearchTermsStatsForDate:(NSDate *)date
+                             andUnit:(StatsPeriodUnit)unit
+               withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;
+
 - (void)fetchCommentsStatsForDate:(NSDate *)date
                           andUnit:(StatsPeriodUnit)unit
             withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler;

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.h
@@ -40,6 +40,8 @@ typedef void (^StatsRemoteItemsCompletion)(NSArray *items, NSString *totalViews,
        clicksCompletionHandler:(StatsRemoteItemsCompletion)clicksCompletion
       countryCompletionHandler:(StatsRemoteItemsCompletion)countryCompletion
        videosCompletionHandler:(StatsRemoteItemsCompletion)videosCompletion
+      authorsCompletionHandler:(StatsRemoteItemsCompletion)authorsCompletion
+  searchTermsCompletionHandler:(StatsRemoteItemsCompletion)searchTermsCompletion
      commentsCompletionHandler:(StatsRemoteItemsCompletion)commentsCompletion
 tagsCategoriesCompletionHandler:(StatsRemoteItemsCompletion)tagsCategoriesCompletion
 followersDotComCompletionHandler:(StatsRemoteItemsCompletion)followersDotComCompletion

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -229,6 +229,29 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 }
 
 
+
+- (void)fetchAuthorsStatsForDate:(NSDate *)date
+                         andUnit:(StatsPeriodUnit)unit
+           withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
+{
+    NSParameterAssert(date != nil);
+    
+    AFHTTPRequestOperation *operation = [self operationForAuthorsForDate:date andUnit:unit viewAll:YES withCompletionHandler:completionHandler];
+    [operation start];
+}
+
+
+- (void)fetchSearchTermsStatsForDate:(NSDate *)date
+                             andUnit:(StatsPeriodUnit)unit
+               withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
+{
+    NSParameterAssert(date != nil);
+    
+    AFHTTPRequestOperation *operation = [self operationForSearchTermsForDate:date andUnit:unit viewAll:YES withCompletionHandler:completionHandler];
+    [operation start];
+}
+
+
 - (void)fetchCommentsStatsForDate:(NSDate *)date
                           andUnit:(StatsPeriodUnit)unit
             withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -401,8 +401,8 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         }
     };
     
-    NSDictionary *parameters = @{@"after"   : [self deviceLocalStringForDate:[self calculateStartDateForPeriodUnit:unit withEndDate:date]],
-                                 @"before"  : [self deviceLocalStringForDate:date],
+    NSDictionary *parameters = @{@"after"   : [self deviceLocalISOStringForDate:[self calculateStartDateForPeriodUnit:unit withEndDate:date]],
+                                 @"before"  : [self deviceLocalISOStringForDate:date],
                                  @"number"  : @10,
                                  @"fields"  : @"ID, title, URL"};
     AFHTTPRequestOperation *operation =  [self requestOperationForURLString:[self urlForPosts]
@@ -1109,6 +1109,18 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 }
 
 
+- (NSString *)deviceLocalISOStringForDate:(NSDate *)date
+{
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+    formatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+    formatter.dateFormat = @"yyyy'-'MM'-'dd'T'HH':'mm':'ss";
+    formatter.timeZone = [NSTimeZone localTimeZone];
+    
+    NSString *todayString = [formatter stringFromDate:date];
+    return todayString;
+}
+
+
 - (StatsPeriodUnit)periodUnitForString:(NSString *)unitString
 {
     if ([unitString isEqualToString:@"day"]) {
@@ -1188,13 +1200,14 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 
 - (NSDate *)calculateStartDateForPeriodUnit:(StatsPeriodUnit)unit withEndDate:(NSDate *)date
 {
-    if (unit == StatsPeriodUnitDay) {
-        return date;
-    }
-    
     NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
     
-    if (unit == StatsPeriodUnitMonth) {
+    if (unit == StatsPeriodUnitDay) {
+        NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
+        date = [calendar dateFromComponents:dateComponents];
+        
+        return date;
+    } else if (unit == StatsPeriodUnitMonth) {
         NSDateComponents *dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth fromDate:date];
         date = [calendar dateFromComponents:dateComponents];
         

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -734,6 +734,62 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
 }
 
 
+- (AFHTTPRequestOperation *)operationForAuthorsForDate:(NSDate *)date
+                                               andUnit:(StatsPeriodUnit)unit
+                                               viewAll:(BOOL)viewAll
+                                 withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
+{
+    id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
+    {
+        NSDictionary *responseDict = (NSDictionary *)responseObject;
+        
+        if (completionHandler) {
+            completionHandler(nil, nil, nil, nil);
+        }
+    };
+    
+    NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
+                                 @"date"   : [self deviceLocalStringForDate:date],
+                                 @"max"    : (viewAll ? @0 : @10) };
+    
+    AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForAuthors]
+                                                                parameters:parameters
+                                                                   success:handler
+                                                                   failure:[self failureForCompletionHandler:completionHandler]];
+    
+    return operation;
+}
+
+
+
+
+- (AFHTTPRequestOperation *)operationForSearchTermsForDate:(NSDate *)date
+                                                   andUnit:(StatsPeriodUnit)unit
+                                                   viewAll:(BOOL)viewAll
+                                     withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
+{
+    id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
+    {
+        NSDictionary *responseDict = (NSDictionary *)responseObject;
+        
+        if (completionHandler) {
+            completionHandler(nil, nil, nil, nil);
+        }
+    };
+    
+    NSDictionary *parameters = @{@"period" : [self stringForPeriodUnit:unit],
+                                 @"date"   : [self deviceLocalStringForDate:date],
+                                 @"max"    : (viewAll ? @0 : @10) };
+    
+    AFHTTPRequestOperation *operation = [self requestOperationForURLString:[self urlForSearchTerms]
+                                                                parameters:parameters
+                                                                   success:handler
+                                                                   failure:[self failureForCompletionHandler:completionHandler]];
+    
+    return operation;
+}
+
+
 - (AFHTTPRequestOperation *)operationForCommentsForDate:(NSDate *)date
                                                 andUnit:(StatsPeriodUnit)unit
                                   withCompletionHandler:(StatsRemoteItemsCompletion)completionHandler
@@ -1044,9 +1100,22 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     return [NSString stringWithFormat:@"%@/top-posts/", self.statsPathPrefix];
 }
 
+
 - (NSString *)urlForVideos
 {
     return [NSString stringWithFormat:@"%@/video-plays/", self.statsPathPrefix];
+}
+
+
+- (NSString *)urlForAuthors
+{
+    return [NSString stringWithFormat:@"%@/top-authors/", self.statsPathPrefix];
+}
+
+
+- (NSString *)urlForSearchTerms
+{
+    return [NSString stringWithFormat:@"%@/search-terms/", self.statsPathPrefix];
 }
 
 

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -390,6 +390,7 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
             item.label = [[post stringForKey:@"title"] stringByDecodingXMLCharacters];
             
             StatsItemAction *itemAction = [StatsItemAction new];
+            itemAction.defaultAction = YES;
             itemAction.url = [NSURL URLWithString:[post stringForKey:@"URL"]];
             item.actions = @[itemAction];
             

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -108,10 +108,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
         [mutableOperations addObject:[self operationForVideosForDate:date andUnit:unit viewAll:NO withCompletionHandler:videosCompletion]];
     }
     if (authorsCompletion) {
-        [mutableOperations addObject:nil];
+        [mutableOperations addObject:[self operationForAuthorsForDate:date andUnit:unit viewAll:NO withCompletionHandler:authorsCompletion]];
     }
     if (searchTermsCompletion) {
-        [mutableOperations addObject:nil];
+        [mutableOperations addObject:[self operationForSearchTermsForDate:date andUnit:unit viewAll:NO withCompletionHandler:searchTermsCompletion]];
     }
     if (commentsCompletion) {
         [mutableOperations addObject:[self operationForCommentsForDate:date andUnit:unit withCompletionHandler:commentsCompletion]];
@@ -742,9 +742,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
         NSDictionary *responseDict = (NSDictionary *)responseObject;
-        
+        NSMutableArray *items = [NSMutableArray new];
+
         if (completionHandler) {
-            completionHandler(nil, nil, nil, nil);
+            completionHandler(items, nil, nil, nil);
         }
     };
     
@@ -771,9 +772,10 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
     {
         NSDictionary *responseDict = (NSDictionary *)responseObject;
-        
+        NSMutableArray *items = [NSMutableArray new];
+
         if (completionHandler) {
-            completionHandler(nil, nil, nil, nil);
+            completionHandler(items, nil, nil, nil);
         }
     };
     

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -75,6 +75,8 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
        clicksCompletionHandler:(StatsRemoteItemsCompletion)clicksCompletion
       countryCompletionHandler:(StatsRemoteItemsCompletion)countryCompletion
        videosCompletionHandler:(StatsRemoteItemsCompletion)videosCompletion
+      authorsCompletionHandler:(StatsRemoteItemsCompletion)authorsCompletion
+  searchTermsCompletionHandler:(StatsRemoteItemsCompletion)searchTermsCompletion
      commentsCompletionHandler:(StatsRemoteItemsCompletion)commentsCompletion
 tagsCategoriesCompletionHandler:(StatsRemoteItemsCompletion)tagsCategoriesCompletion
 followersDotComCompletionHandler:(StatsRemoteItemsCompletion)followersDotComCompletion
@@ -104,6 +106,12 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     }
     if (videosCompletion) {
         [mutableOperations addObject:[self operationForVideosForDate:date andUnit:unit viewAll:NO withCompletionHandler:videosCompletion]];
+    }
+    if (authorsCompletion) {
+        [mutableOperations addObject:nil];
+    }
+    if (searchTermsCompletion) {
+        [mutableOperations addObject:nil];
     }
     if (commentsCompletion) {
         [mutableOperations addObject:[self operationForCommentsForDate:date andUnit:unit withCompletionHandler:commentsCompletion]];

--- a/WordPressCom-Stats-iOSTests/StatsDateUtilitiesTests.m
+++ b/WordPressCom-Stats-iOSTests/StatsDateUtilitiesTests.m
@@ -35,11 +35,15 @@
     
     NSDate *result = [self.subject calculateEndDateForPeriodUnit:StatsPeriodUnitDay withDateWithinPeriod:date];
     
-    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:result];
+    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond fromDate:result];
     
     XCTAssertEqual(dateComponents.year, 2014);
     XCTAssertEqual(dateComponents.month, 12);
     XCTAssertEqual(dateComponents.day, 30);
+    XCTAssertEqual(dateComponents.hour, 23);
+    XCTAssertEqual(dateComponents.minute, 59);
+    XCTAssertEqual(dateComponents.second, 59);
+    
 }
 
 
@@ -56,11 +60,14 @@
     
     NSDate *result = [self.subject calculateEndDateForPeriodUnit:StatsPeriodUnitWeek withDateWithinPeriod:date];
     
-    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:result];
+    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond fromDate:result];
     
     XCTAssertEqual(dateComponents.year, 2015);
     XCTAssertEqual(dateComponents.month, 1);
     XCTAssertEqual(dateComponents.day, 11);
+    XCTAssertEqual(dateComponents.hour, 23);
+    XCTAssertEqual(dateComponents.minute, 59);
+    XCTAssertEqual(dateComponents.second, 59);
 }
 
 
@@ -77,11 +84,14 @@
     
     NSDate *result = [self.subject calculateEndDateForPeriodUnit:StatsPeriodUnitMonth withDateWithinPeriod:date];
     
-    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:result];
+    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond fromDate:result];
     
     XCTAssertEqual(dateComponents.year, 2015);
     XCTAssertEqual(dateComponents.month, 1);
     XCTAssertEqual(dateComponents.day, 31);
+    XCTAssertEqual(dateComponents.hour, 23);
+    XCTAssertEqual(dateComponents.minute, 59);
+    XCTAssertEqual(dateComponents.second, 59);
 }
 
 
@@ -98,11 +108,14 @@
     
     NSDate *result = [self.subject calculateEndDateForPeriodUnit:StatsPeriodUnitYear withDateWithinPeriod:date];
     
-    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:result];
+    dateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond fromDate:result];
     
     XCTAssertEqual(dateComponents.year, 2015);
     XCTAssertEqual(dateComponents.month, 12);
     XCTAssertEqual(dateComponents.day, 31);
+    XCTAssertEqual(dateComponents.hour, 23);
+    XCTAssertEqual(dateComponents.minute, 59);
+    XCTAssertEqual(dateComponents.second, 59);
 }
 
 @end

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
@@ -41,6 +41,8 @@
     XCTestExpectation *countryExpectation = [self expectationWithDescription:@"countryExpectation"];
     XCTestExpectation *videosExpectation = [self expectationWithDescription:@"videosExpectation"];
     XCTestExpectation *commentsAuthorExpectation = [self expectationWithDescription:@"commentsAuthorExpectation"];
+    XCTestExpectation *authorsExpectation = [self expectationWithDescription:@"authorsExpectation"];
+    XCTestExpectation *searchTermsExpectation = [self expectationWithDescription:@"searchTermsExpectation"];
     XCTestExpectation *commentsPostsExpectation = [self expectationWithDescription:@"commentsPostsExpectation"];
     XCTestExpectation *tagsExpectation = [self expectationWithDescription:@"tagsExpectation"];
     XCTestExpectation *followersDotComExpectation = [self expectationWithDescription:@"followersDotComExpectation"];
@@ -71,6 +73,12 @@
                   videosCompletionHandler:^(StatsGroup *group, NSError *error) {
                       [videosExpectation fulfill];
                   }
+                 authorsCompletionHandler:^(StatsGroup *group, NSError *error) {
+                     [authorsExpectation fulfill];
+                 }
+             searchTermsCompletionHandler:^(StatsGroup *group, NSError *error) {
+                 [searchTermsExpectation fulfill];
+             }
           commentsAuthorCompletionHandler:^(StatsGroup *group, NSError *error) {
               [commentsAuthorExpectation fulfill];
           }
@@ -333,19 +341,21 @@
     
     OCMExpect([remote batchFetchStatsForDate:dateCheckBlock
                                      andUnit:unit
-                  withVisitsCompletionHandler:[OCMArg any]
-                      eventsCompletionHandler:[OCMArg any]
-                       postsCompletionHandler:[OCMArg any]
-                   referrersCompletionHandler:[OCMArg any]
-                      clicksCompletionHandler:[OCMArg any]
-                     countryCompletionHandler:[OCMArg any]
-                      videosCompletionHandler:[OCMArg any]
-                    commentsCompletionHandler:[OCMArg any]
-              tagsCategoriesCompletionHandler:[OCMArg any]
-             followersDotComCompletionHandler:[OCMArg any]
-              followersEmailCompletionHandler:[OCMArg any]
-                   publicizeCompletionHandler:[OCMArg any]
-                  andOverallCompletionHandler:[OCMArg any]]);
+                 withVisitsCompletionHandler:[OCMArg any]
+                     eventsCompletionHandler:[OCMArg any]
+                      postsCompletionHandler:[OCMArg any]
+                  referrersCompletionHandler:[OCMArg any]
+                     clicksCompletionHandler:[OCMArg any]
+                    countryCompletionHandler:[OCMArg any]
+                     videosCompletionHandler:[OCMArg any]
+                    authorsCompletionHandler:[OCMArg any]
+                searchTermsCompletionHandler:[OCMArg any]
+                   commentsCompletionHandler:[OCMArg any]
+             tagsCategoriesCompletionHandler:[OCMArg any]
+            followersDotComCompletionHandler:[OCMArg any]
+             followersEmailCompletionHandler:[OCMArg any]
+                  publicizeCompletionHandler:[OCMArg any]
+                 andOverallCompletionHandler:[OCMArg any]]);
     
     self.subject.remote = remote;
     
@@ -358,6 +368,8 @@
                   clicksCompletionHandler:nil
                  countryCompletionHandler:nil
                   videosCompletionHandler:nil
+                 authorsCompletionHandler:nil
+             searchTermsCompletionHandler:nil
           commentsAuthorCompletionHandler:nil
            commentsPostsCompletionHandler:nil
           tagsCategoriesCompletionHandler:nil
@@ -385,6 +397,8 @@
        clicksCompletionHandler:(StatsRemoteItemsCompletion)clicksCompletion
       countryCompletionHandler:(StatsRemoteItemsCompletion)countryCompletion
        videosCompletionHandler:(StatsRemoteItemsCompletion)videosCompletion
+      authorsCompletionHandler:(StatsRemoteItemsCompletion)authorsCompletion
+  searchTermsCompletionHandler:(StatsRemoteItemsCompletion)searchTermsCompletion
      commentsCompletionHandler:(StatsRemoteItemsCompletion)commentsCompletion
 tagsCategoriesCompletionHandler:(StatsRemoteItemsCompletion)tagsCategoriesCompletion
 followersDotComCompletionHandler:(StatsRemoteItemsCompletion)followersDotComCompletion
@@ -412,6 +426,12 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
     }
     if (videosCompletion) {
         videosCompletion(@[[StatsItem new]], nil, false, nil);
+    }
+    if (authorsCompletion) {
+        authorsCompletion(@[[StatsItem new]], nil, false, nil);
+    }
+    if (searchTermsCompletion) {
+        searchTermsCompletion(@[[StatsItem new]], nil, false, nil);
     }
     if (commentsCompletion) {
         commentsCompletion(@[[StatsItem new]], nil, false, nil);


### PR DESCRIPTION
Closes #154 #117 

Added sections for search terms and authors. Reordered all the sections to match the current order on single column mode in web stats.

cc: @daniloercoli 

![ios simulator screen shot feb 25 2015 2 30 05 pm](https://cloud.githubusercontent.com/assets/373903/6379849/e1fc4e94-bcfa-11e4-98ff-786d0c6e29d4.png)
![ios simulator screen shot feb 25 2015 2 30 15 pm](https://cloud.githubusercontent.com/assets/373903/6379853/e5c613ca-bcfa-11e4-9faf-8693ae615c27.png)
