### PR TITLE
Add actions (URLs) to tags/categories

### DIFF
--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -1081,6 +1081,14 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
                 StatsItem *statsItem = [StatsItem new];
                 statsItem.label = [theTag stringForKey:@"name"];
                 statsItem.value = [self localizedStringForNumber:[tagGroup numberForKey:@"views"]];
+                NSString *linkURL = [theTag stringForKey:@"link"];
+                if (linkURL.length > 0) {
+                    StatsItemAction *itemAction = [StatsItemAction new];
+                    itemAction.url = [NSURL URLWithString:linkURL];
+                    itemAction.defaultAction = YES;
+                    statsItem.actions = @[itemAction];
+                }
+                
                 [items addObject:statsItem];
             } else {
                 NSMutableString *tagLabel = [NSMutableString new];
@@ -1090,7 +1098,14 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
                     
                     StatsItem *childItem = [StatsItem new];
                     childItem.label = [subTag stringForKey:@"name"];
-                    
+                    NSString *linkURL = [subTag stringForKey:@"link"];
+                    if (linkURL.length > 0) {
+                        StatsItemAction *itemAction = [StatsItemAction new];
+                        itemAction.url = [NSURL URLWithString:linkURL];
+                        itemAction.defaultAction = YES;
+                        childItem.actions = @[itemAction];
+                    }
+
                     [tagLabel appendFormat:@"%@ ", childItem.label];
                     
                     [statsItem addChildStatsItem:childItem];

--- a/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/WPStatsServiceRemote.m
@@ -1106,12 +1106,14 @@ followersEmailCompletionHandler:(StatsRemoteItemsCompletion)followersEmailComple
                         childItem.actions = @[itemAction];
                     }
 
-                    [tagLabel appendFormat:@"%@ ", childItem.label];
+                    [tagLabel appendFormat:@"%@, ", childItem.label];
                     
                     [statsItem addChildStatsItem:childItem];
                 }
                 
-                NSString *trimmedLabel = [tagLabel stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+                NSMutableCharacterSet *whitespaceCharacters = [NSMutableCharacterSet whitespaceCharacterSet];
+                [whitespaceCharacters addCharactersInString:@","];
+                NSString *trimmedLabel = [tagLabel stringByTrimmingCharactersInSet:whitespaceCharacters];
                 statsItem.label = trimmedLabel;
                 statsItem.value = [self localizedStringForNumber:[tagGroup numberForKey:@"views"]];
                 

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
@@ -662,8 +662,12 @@
          StatsItem *item1 = items.firstObject;
          XCTAssertTrue([@"Uncategorized" isEqualToString:item1.label]);
          XCTAssertTrue([@"461" isEqualToString:item1.value]);
-         XCTAssertEqual(0, item1.actions.count);
+         XCTAssertEqual(1, item1.actions.count);
          XCTAssertEqual(0, item1.children.count);
+         
+         StatsItemAction *itemAction = item1.actions[0];
+         XCTAssertNotNil(itemAction.url);
+         XCTAssertTrue(itemAction.defaultAction);
          
          StatsItem *item9 = items[8];
          XCTAssertTrue([@"unit test XCTest asynchronous testing" isEqualToString:item9.label]);

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
@@ -670,7 +670,7 @@
          XCTAssertTrue(itemAction.defaultAction);
          
          StatsItem *item9 = items[8];
-         XCTAssertTrue([@"unit test XCTest asynchronous testing" isEqualToString:item9.label]);
+         XCTAssertTrue([@"unit test, XCTest, asynchronous, testing" isEqualToString:item9.label]);
          XCTAssertTrue([@"43" isEqualToString:item9.value]);
          XCTAssertEqual(0, item9.actions.count);
          XCTAssertEqual(4, item9.children.count);


### PR DESCRIPTION
Fixes #212 

Adds `StatsAction`s to tags and categories so they're tappable/reviewable in the app.

props to @daniloercoli 