### PR TITLE
Deselect the View Web Version row after tapping

### DIFF
--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -352,6 +352,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
         }
     } else if ([[self cellIdentifierForIndexPath:indexPath] isEqualToString:StatsTableViewWebVersionCellIdentifier]) {
         [WPAnalytics track:WPAnalyticsStatStatsOpenedWebVersion];
+        [tableView deselectRowAtIndexPath:indexPath animated:YES];
 
         if ([self.statsDelegate respondsToSelector:@selector(statsViewController:didSelectViewWebStatsForSiteID:)]) {
             WPStatsViewController *statsViewController = (WPStatsViewController *)self.navigationController;


### PR DESCRIPTION
Fixes #210 

Deselects the row for "View Web Version" after the select action happens. 

Good catch @aerych!