### PR TITLE
Do not fire the delegate method for the selected item after a rotate

### DIFF
--- a/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsGraphViewController.m
@@ -64,11 +64,6 @@ static NSInteger const RecommendedYAxisTicks = 2;
     [super didRotateFromInterfaceOrientation:fromInterfaceOrientation];
     
     [self.collectionView performBatchUpdates:nil completion:nil];
-    
-    if ([[self.collectionView indexPathsForSelectedItems] count] > 0) {
-        NSIndexPath *indexPath = [self.collectionView indexPathsForSelectedItems][0];
-        [self collectionView:self.collectionView didSelectItemAtIndexPath:indexPath];
-    }
 }
 
 #pragma mark - UICollectionViewDelegate methods


### PR DESCRIPTION
Fixes #123 

I removed the call in the graph view controller that manually hit the delegate method to indicate an item was selected. I'm not really certain why this was here in the first place, possibly as a workaround for a different bug that was solved.

Wil need to make sure we test this one with backgrounding the app, rotating, then foregrounding it. Also test on iPad and iPhone devices. Make sure to include iOS 7 with at least one device as application lifecycle is slightly different between the OSs.