### PR TITLE
Stop using WPTableViewCell

### DIFF
--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -136,7 +136,7 @@
                                     <outlet property="valueLabel" destination="xSH-fQ-AtQ" id="VCq-qK-HKI"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="PeriodHeader" id="uMq-k6-6FG" userLabel="PeriodHeader" customClass="WPTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="PeriodHeader" id="uMq-k6-6FG" userLabel="PeriodHeader">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uMq-k6-6FG" id="pML-ow-yKw">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -1069,7 +1069,7 @@
                         <color key="separatorColor" red="0.90980392160000001" green="0.94117647059999998" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="LoadingIndicator" id="SKa-Ti-lUJ" userLabel="LoadingIndicator" customClass="WPTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="LoadingIndicator" id="SKa-Ti-lUJ" userLabel="LoadingIndicator">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SKa-Ti-lUJ" id="Ox4-Hv-7ay">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -1166,7 +1166,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="PeriodHeader" id="cN5-eE-Q2Y" userLabel="PeriodHeader" customClass="WPTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="PeriodHeader" id="cN5-eE-Q2Y" userLabel="PeriodHeader">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cN5-eE-Q2Y" id="q1l-Cb-lUN">
                                     <autoresizingMask key="autoresizingMask"/>

--- a/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsSelectableTableViewCell.h
@@ -1,7 +1,6 @@
 #import <UIKit/UIKit.h>
-#import <WordPress-iOS-Shared/WPTableViewCell.h>
 
-@interface StatsSelectableTableViewCell : WPTableViewCell
+@interface StatsSelectableTableViewCell : UITableViewCell
 
 @property (nonatomic, weak) IBOutlet UILabel *categoryIconLabel;
 @property (nonatomic, weak) IBOutlet UILabel *categoryLabel;

--- a/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
+++ b/WordPressCom-Stats-iOS/StatsStandardBorderedTableViewCell.h
@@ -1,7 +1,6 @@
 #import <UIKit/UIKit.h>
-#import <WordPress-iOS-Shared/WPTableViewCell.h>
 
-@interface StatsStandardBorderedTableViewCell : WPTableViewCell
+@interface StatsStandardBorderedTableViewCell : UITableViewCell
 
 @property (nonatomic, assign) BOOL topBorderDarkEnabled;
 @property (nonatomic, assign) BOOL bottomBorderEnabled;

--- a/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
+++ b/WordPressCom-Stats-iOS/StatsTableSectionHeaderView.m
@@ -1,6 +1,5 @@
 #import "StatsTableSectionHeaderView.h"
 #import "WPStyleGuide+Stats.h"
-#import <WordPress-iOS-Shared/WPTableViewCell.h>
 
 @interface StatsTableSectionHeaderView ()
 
@@ -25,37 +24,11 @@
 }
 
 
-- (void)setFrame:(CGRect)frame {
-    CGFloat width = self.superview.frame.size.width;
-    // On iPad, add a margin around tables
-    if (IS_IPAD && width > WPTableViewFixedWidth) {
-        CGFloat x = (width - WPTableViewFixedWidth) / 2;
-        // If origin.x is not equal to x we add the value.
-        // This is a semi-fix / work around for an issue positioning cells on
-        // iOS 8 when editing a table view and the delete button is visible.
-        if (x != frame.origin.x) {
-            frame.origin.x += x;
-        } else {
-            frame.origin.x = x;
-        }
-        frame.size.width = WPTableViewFixedWidth;
-    }
-    [super setFrame:frame];
-}
-
-
 - (void)layoutSubviews
 {
     [super layoutSubviews];
     
     // Need to set the origin again on iPad (for margins)
-    CGFloat width = self.superview.frame.size.width;
-    if (IS_IPAD && width > WPTableViewFixedWidth) {
-        CGRect frame = self.frame;
-        frame.origin.x = (width - WPTableViewFixedWidth) / 2;
-        self.frame = frame;
-    }
-
     CGFloat borderSidePadding = StatsVCHorizontalOuterPadding - 1.0f; // Just to the left of the container
     self.theBoxView.frame = CGRectMake(borderSidePadding, self.isFooter ? -1.0f : 0.0f, CGRectGetWidth(self.frame) - 2.0 * borderSidePadding, 1.0f);
 }

--- a/WordPressCom-Stats-iOS/WPStatsViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsViewController.m
@@ -94,12 +94,14 @@
                                                         cancelButtonTitle:NSLocalizedString(@"Cancel", @"Cancel button title")
                                                    destructiveButtonTitle:nil
                                                         otherButtonTitles:NSLocalizedString(@"Days", @"Title of Days segmented control"), NSLocalizedString(@"Weeks", @"Title of Weeks segmented control"), NSLocalizedString(@"Months", @"Title of Months segmented control"), NSLocalizedString(@"Years", @"Title of Years segmented control"), nil];
+#ifndef AF_APP_EXTENSIONS
         UIViewController *viewController = [[[UIApplication sharedApplication] windows].firstObject rootViewController];
         if ([viewController isKindOfClass:[UITabBarController class]]) {
             [actionSheet showFromTabBar:[(UITabBarController *)viewController tabBar]];
         } else {
             [actionSheet showInView:viewController.view];
         }
+#endif
         self.periodActionSheet = actionSheet;
     } else if (self.showingAbbreviatedSegments && control.selectedSegmentIndex == 1) {
         self.statsType = self.lastSelectedStatsType;

--- a/WordPressCom-Stats-iOS/WPStatsViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsViewController.m
@@ -101,8 +101,8 @@
         } else {
             [actionSheet showInView:viewController.view];
         }
-#endif
         self.periodActionSheet = actionSheet;
+#endif
     } else if (self.showingAbbreviatedSegments && control.selectedSegmentIndex == 1) {
         self.statsType = self.lastSelectedStatsType;
     } else {

--- a/WordPressCom-Stats-iOS/WPStatsViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsViewController.m
@@ -89,12 +89,12 @@
     self.statsContainerView.hidden = NO;
     
     if (self.showingAbbreviatedSegments && control.selectedSegmentIndex == 2) {
+#ifndef AF_APP_EXTENSIONS
         UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:@"Select Period Unit"
                                                                  delegate:self
                                                         cancelButtonTitle:NSLocalizedString(@"Cancel", @"Cancel button title")
                                                    destructiveButtonTitle:nil
                                                         otherButtonTitles:NSLocalizedString(@"Days", @"Title of Days segmented control"), NSLocalizedString(@"Weeks", @"Title of Weeks segmented control"), NSLocalizedString(@"Months", @"Title of Months segmented control"), NSLocalizedString(@"Years", @"Title of Years segmented control"), nil];
-#ifndef AF_APP_EXTENSIONS
         UIViewController *viewController = [[[UIApplication sharedApplication] windows].firstObject rootViewController];
         if ([viewController isKindOfClass:[UITabBarController class]]) {
             [actionSheet showFromTabBar:[(UITabBarController *)viewController tabBar]];

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
@@ -864,7 +864,7 @@
     }];
     
     [self.subject fetchInsightsWithCompletionHandler:^(NSString *highestHour, NSString *highestHourPercent, NSNumber *highestHourPercentValue, NSString *highestDayOfWeek, NSString *highestDayPercent, NSNumber *highestDayPercentValue, NSError *error) {
-         XCTAssertTrue([@"9 AM" isEqualToString:highestHour]);
+         XCTAssertTrue([@"9:00 AM" isEqualToString:highestHour]);
          XCTAssertTrue([@"Saturday" isEqualToString:highestDayOfWeek]);
          XCTAssertTrue([@"31%" isEqualToString:highestDayPercent]);
          XCTAssertNil(error);


### PR DESCRIPTION
Fixes #260 
Related: https://github.com/wordpress-mobile/WordPress-iOS/issues/2491

Eliminates the usage of WPTableViewCell which put margins around all the cells in a table view on an iPad.

![ios simulator screen shot jun 11 2015 12 36 36 pm](https://cloud.githubusercontent.com/assets/373903/8113978/2ba35c9c-1037-11e5-8f2e-3049b2491caa.png)

Needs Review: @aerych 