### PR TITLE
Provide VoiceOver announcement when download completes

### DIFF
--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -291,6 +291,10 @@
          [self setupRefreshControl];
          [self.refreshControl endRefreshing];
          
+         if (cachedDataWasUsed == NO) {
+             UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, NSLocalizedString(@"Fetch of stats completed.", @"VoiceOver announcement of download finishing for stats."));
+         }
+
          if ([self.statsProgressViewDelegate respondsToSelector:@selector(statsViewControllerDidEndLoadingStats:)]) {
              [self.statsProgressViewDelegate statsViewControllerDidEndLoadingStats:self];
          }

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -255,7 +255,7 @@
              [self.statsProgressViewDelegate statsViewController:self loadingProgressPercentage:percentage];
          }
      }
-                                                  andOverallCompletionHandler:^
+                                                  andOverallCompletionHandler:^(BOOL cachedDataWasUsed)
      {
          // Set the colors to what they should be (previous color for unknown data)
          self.mostPopularDay.textColor = [WPStyleGuide greyDarken30];

--- a/WordPressCom-Stats-iOS/StatsPostDetailsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsPostDetailsTableViewController.m
@@ -339,6 +339,8 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionPostDetailsGraph)];
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:1 inSection:sectionNumber];
         [self.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+        
+        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, NSLocalizedString(@"Fetch of stats completed.", @"VoiceOver announcement of download finishing for stats."));
     }];
     
 }

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -778,6 +778,10 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
          [self setupRefreshControl];
          [self.refreshControl endRefreshing];
          
+         if (cachedDataWasUsed == NO) {
+             UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, NSLocalizedString(@"Fetch of stats completed.", @"VoiceOver announcement of download finishing for stats."));
+         }
+
          if ([self.statsProgressViewDelegate respondsToSelector:@selector(statsViewControllerDidEndLoadingStats:)]) {
              [self.statsProgressViewDelegate statsViewControllerDidEndLoadingStats:self];
          }

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -769,7 +769,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
             [self.statsProgressViewDelegate statsViewController:self loadingProgressPercentage:percentage];
         }
      }
-                   andOverallCompletionHandler:^
+                   andOverallCompletionHandler:^(BOOL cachedDataWasUsed)
      {
 #ifndef AF_APP_EXTENSIONS
          [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;

--- a/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
@@ -231,6 +231,8 @@ static NSString *const StatsTableLoadingIndicatorCellIdentifier = @"LoadingIndic
         [self.tableView deleteRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:1 inSection:0]] withRowAnimation:UITableViewRowAnimationTop];
         [self.tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationTop];
         [self.tableView endUpdates];
+        
+        UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, NSLocalizedString(@"Fetch of stats completed.", @"VoiceOver announcement of download finishing for stats."));
     };
     
     if (self.statsSection == StatsSectionPosts) {

--- a/WordPressCom-Stats-iOS/WPStatsService.h
+++ b/WordPressCom-Stats-iOS/WPStatsService.h
@@ -45,7 +45,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
  followersEmailCompletionHandler:(StatsGroupCompletion)followersEmailCompletion
      publicizeCompletionHandler:(StatsGroupCompletion)publicizeCompletion
                   progressBlock:(void (^)(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations)) progressBlock
-     andOverallCompletionHandler:(void (^)())completionHandler;
+     andOverallCompletionHandler:(void (^)(BOOL cachedDataWasUsed))completionHandler;
 
 - (void)retrievePostDetailsStatsForPostID:(NSNumber *)postID
                     withCompletionHandler:(StatsPostDetailsCompletion)completion;
@@ -87,7 +87,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                                      insightsCompletionHandler:(StatsInsightsCompletion)insightsCompletion
                                  todaySummaryCompletionHandler:(StatsSummaryCompletion)todaySummaryCompletion
                                                  progressBlock:(void (^)(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations)) progressBlock
-                                   andOverallCompletionHandler:(void (^)())completionHandler;
+                                   andOverallCompletionHandler:(void (^)(BOOL cachedDataWasUsed))completionHandler;
 
 - (void)retrieveTodayStatsWithCompletionHandler:(StatsSummaryCompletion)completion failureHandler:(void (^)(NSError *))failureHandler;
 

--- a/WordPressCom-Stats-iOS/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/WPStatsService.m
@@ -69,7 +69,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
  followersEmailCompletionHandler:(StatsGroupCompletion)followersEmailCompletion
       publicizeCompletionHandler:(StatsGroupCompletion)publicizeCompletion
                   progressBlock:(void (^)(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations)) progressBlock
-     andOverallCompletionHandler:(void (^)())completionHandler
+     andOverallCompletionHandler:(void (^)(BOOL cachedDataWasUsed))completionHandler
 {
     if (!completionHandler) {
         return;
@@ -171,7 +171,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
             publicizeCompletion(publicizeData, nil);
         }
         
-        completionHandler();
+        completionHandler(YES);
         
         return;
     } else {
@@ -199,7 +199,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                           progressBlock:progressBlock
             andOverallCompletionHandler:^
     {
-        completionHandler();
+        completionHandler(NO);
     }];
 }
 
@@ -208,7 +208,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                                      insightsCompletionHandler:(StatsInsightsCompletion)insightsCompletion
                                  todaySummaryCompletionHandler:(StatsSummaryCompletion)todaySummaryCompletion
                                                  progressBlock:(void (^)(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations)) progressBlock
-                                   andOverallCompletionHandler:(void (^)())overallCompletionHandler
+                                   andOverallCompletionHandler:(void (^)(BOOL cachedDataWasUsed))overallCompletionHandler
 {
     NSString *cacheKey = @"BatchInsights";
     NSString *allTimeCacheKey = @"AllTime";
@@ -229,7 +229,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
         }
         
         if (overallCompletionHandler) {
-            overallCompletionHandler();
+            overallCompletionHandler(YES);
         }
         
         return;
@@ -282,7 +282,7 @@ followersDotComCompletionHandler:(StatsGroupCompletion)followersDotComCompletion
                                          andOverallCompletionHandler:^
     {
         if (overallCompletionHandler) {
-            overallCompletionHandler();
+            overallCompletionHandler(NO);
         }
     }];
 }

--- a/WordPressCom-Stats-iOS/WPStatsViewController.m
+++ b/WordPressCom-Stats-iOS/WPStatsViewController.m
@@ -94,12 +94,14 @@
                                                         cancelButtonTitle:NSLocalizedString(@"Cancel", @"Cancel button title")
                                                    destructiveButtonTitle:nil
                                                         otherButtonTitles:NSLocalizedString(@"Days", @"Title of Days segmented control"), NSLocalizedString(@"Weeks", @"Title of Weeks segmented control"), NSLocalizedString(@"Months", @"Title of Months segmented control"), NSLocalizedString(@"Years", @"Title of Years segmented control"), nil];
+#ifndef AF_APP_EXTENSIONS
         UIViewController *viewController = [[[UIApplication sharedApplication] windows].firstObject rootViewController];
         if ([viewController isKindOfClass:[UITabBarController class]]) {
             [actionSheet showFromTabBar:[(UITabBarController *)viewController tabBar]];
         } else {
             [actionSheet showInView:viewController.view];
         }
+#endif
         self.periodActionSheet = actionSheet;
     } else if (self.showingAbbreviatedSegments && control.selectedSegmentIndex == 1) {
         self.statsType = self.lastSelectedStatsType;

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
@@ -98,7 +98,7 @@
                    [publicizeExpectation fulfill];
                }
                             progressBlock:nil
-              andOverallCompletionHandler:^{
+              andOverallCompletionHandler:^(BOOL cachedDataWasUsed) {
                   [overallExpectation fulfill];
               }];
     
@@ -379,7 +379,7 @@
           followersEmailCompletionHandler:nil
                publicizeCompletionHandler:nil
                             progressBlock:nil
-               andOverallCompletionHandler:^{
+               andOverallCompletionHandler:^(BOOL cachedDataWasUsed) {
                    // Don't do anything
                }];
     


### PR DESCRIPTION
Closes #235 

Provides a VoiceOver announcement when the download of a screen completes. Does not provide the announcement if the screen is loaded via cached data, only if fetched remote.

Needs Review: @koke, @jleandroperez 