### PR TITLE
Implement Insights 2x2 grid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ language: objective-c
 xcode_workspace: WordPressCom-Stats-iOS.xcworkspace
 xcode_scheme: WordPressCom-Stats-iOS
 xcode_sdk: iphonesimulator8.1
-
+install:
+- gem install cocoapods && pod install

--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -36,7 +36,7 @@ PODS:
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
   - WordPressCom-Analytics-iOS (0.0.34)
-  - WordPressCom-Stats-iOS (0.4.1):
+  - WordPressCom-Stats-iOS (0.4.2):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (= 0.0.2)
@@ -58,6 +58,6 @@ SPEC CHECKSUMS:
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   WordPress-iOS-Shared: 155109cd666b8416ce0d2bdb2b8f6f6f6ec2ac50
   WordPressCom-Analytics-iOS: 85c1609bbcdc2cec25dddc633568c8970811b9d2
-  WordPressCom-Stats-iOS: c7ec665c037a2bae50cf5971c4ee6dba27859269
+  WordPressCom-Stats-iOS: 53a6d3573f5e443458a6dca4ddb9bb09fd423920
 
 COCOAPODS: 0.37.2

--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -32,7 +32,7 @@ PODS:
     - HockeySDK/AllFeaturesLib (= 3.7.1)
   - HockeySDK/AllFeaturesLib (3.7.1)
   - NSObject-SafeExpectations (0.0.2)
-  - WordPress-iOS-Shared (0.3.5):
+  - WordPress-iOS-Shared (0.4.0):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
   - WordPressCom-Analytics-iOS (0.0.34)
@@ -56,8 +56,8 @@ SPEC CHECKSUMS:
   CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
   HockeySDK: 77bb90b6484a3b742ccf32bcae247c0a0051a962
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
-  WordPress-iOS-Shared: 155109cd666b8416ce0d2bdb2b8f6f6f6ec2ac50
+  WordPress-iOS-Shared: 19e63665b3c583e889620147097deb7d1932c706
   WordPressCom-Analytics-iOS: 85c1609bbcdc2cec25dddc633568c8970811b9d2
-  WordPressCom-Stats-iOS: 53a6d3573f5e443458a6dca4ddb9bb09fd423920
+  WordPressCom-Stats-iOS: 79ca18a2c35e6e15d0ea899b397c90455ad9aa10
 
 COCOAPODS: 0.37.2

--- a/WordPressCom-Stats-iOS.podspec
+++ b/WordPressCom-Stats-iOS.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.exclude_files = "WordPressCom-Stats-iOS/Exclude"
   s.prefix_header_file = "WordPressCom-Stats-iOS/WordPressCom-Stats-iOS-Prefix.pch"
 
-  s.resource_bundle = { 'WordPressCom-Stats-iOS' => ['WordPressCom-Stats-iOS/**/*.storyboard', 'WordPressCom-Stats-iOS/**/*.otf', 'WordPressCom-Stats-iOS/**/*.png'] }
+  s.resource_bundle = { 'WordPressCom-Stats-iOS' => ['WordPressCom-Stats-iOS/**/*.storyboard', 'WordPressCom-Stats-iOS/**/*.xib', 'WordPressCom-Stats-iOS/**/*.otf', 'WordPressCom-Stats-iOS/**/*.png'] }
   s.requires_arc = true
 
   s.dependency 'AFNetworking',	'~> 2.5'

--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		931193EE1A0C0D050005BED2 /* stats-v1.1-top-posts-day-large.json in Resources */ = {isa = PBXBuildFile; fileRef = 931193ED1A0C0D050005BED2 /* stats-v1.1-top-posts-day-large.json */; };
 		931193F01A0C12170005BED2 /* stats-v1.1-referrers-day-large.json in Resources */ = {isa = PBXBuildFile; fileRef = 931193EF1A0C12170005BED2 /* stats-v1.1-referrers-day-large.json */; };
 		931193F21A0C18C70005BED2 /* stats-v1.1-clicks-month-large.json in Resources */ = {isa = PBXBuildFile; fileRef = 931193F11A0C18C70005BED2 /* stats-v1.1-clicks-month-large.json */; };
+		9311AC271B581E5200BBC877 /* InsightsAllTimeTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9311AC251B581E5200BBC877 /* InsightsAllTimeTableViewCell.m */; };
+		9311AC2A1B5845FE00BBC877 /* InsightsMostPopularTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9311AC291B5845FE00BBC877 /* InsightsMostPopularTableViewCell.m */; };
+		9311AC2D1B58462C00BBC877 /* InsightsSectionHeaderTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9311AC2C1B58462C00BBC877 /* InsightsSectionHeaderTableViewCell.m */; };
+		9311AC301B58466900BBC877 /* InsightsTodaysStatsTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9311AC2F1B58466900BBC877 /* InsightsTodaysStatsTableViewCell.m */; };
 		93274AE41A07C7EA0017238F /* StatsVisits.m in Sources */ = {isa = PBXBuildFile; fileRef = 93274AE31A07C7EA0017238F /* StatsVisits.m */; };
 		93274AE61A07CCE40017238F /* stats-v1.1-visits-day.json in Resources */ = {isa = PBXBuildFile; fileRef = 93274AE51A07CCE40017238F /* stats-v1.1-visits-day.json */; };
 		93274AE81A091E840017238F /* stats-v1.1-top-posts-day.json in Resources */ = {isa = PBXBuildFile; fileRef = 93274AE71A091E840017238F /* stats-v1.1-top-posts-day.json */; };
@@ -118,6 +122,14 @@
 		931193ED1A0C0D050005BED2 /* stats-v1.1-top-posts-day-large.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-v1.1-top-posts-day-large.json"; sourceTree = "<group>"; };
 		931193EF1A0C12170005BED2 /* stats-v1.1-referrers-day-large.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-v1.1-referrers-day-large.json"; sourceTree = "<group>"; };
 		931193F11A0C18C70005BED2 /* stats-v1.1-clicks-month-large.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-v1.1-clicks-month-large.json"; sourceTree = "<group>"; };
+		9311AC241B581E5200BBC877 /* InsightsAllTimeTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InsightsAllTimeTableViewCell.h; sourceTree = "<group>"; };
+		9311AC251B581E5200BBC877 /* InsightsAllTimeTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InsightsAllTimeTableViewCell.m; sourceTree = "<group>"; };
+		9311AC281B5845FE00BBC877 /* InsightsMostPopularTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InsightsMostPopularTableViewCell.h; sourceTree = "<group>"; };
+		9311AC291B5845FE00BBC877 /* InsightsMostPopularTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InsightsMostPopularTableViewCell.m; sourceTree = "<group>"; };
+		9311AC2B1B58462C00BBC877 /* InsightsSectionHeaderTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InsightsSectionHeaderTableViewCell.h; sourceTree = "<group>"; };
+		9311AC2C1B58462C00BBC877 /* InsightsSectionHeaderTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InsightsSectionHeaderTableViewCell.m; sourceTree = "<group>"; };
+		9311AC2E1B58466900BBC877 /* InsightsTodaysStatsTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InsightsTodaysStatsTableViewCell.h; sourceTree = "<group>"; };
+		9311AC2F1B58466900BBC877 /* InsightsTodaysStatsTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InsightsTodaysStatsTableViewCell.m; sourceTree = "<group>"; };
 		93274AE21A07C7EA0017238F /* StatsVisits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsVisits.h; sourceTree = "<group>"; };
 		93274AE31A07C7EA0017238F /* StatsVisits.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsVisits.m; sourceTree = "<group>"; };
 		93274AE51A07CCE40017238F /* stats-v1.1-visits-day.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-v1.1-visits-day.json"; sourceTree = "<group>"; };
@@ -285,6 +297,14 @@
 				936E74A61A69A8990048F552 /* StatsTableSectionHeaderView.m */,
 				9367D9D61A6EB5A90033911A /* StatsTwoColumnTableViewCell.h */,
 				9367D9D71A6EB5A90033911A /* StatsTwoColumnTableViewCell.m */,
+				9311AC241B581E5200BBC877 /* InsightsAllTimeTableViewCell.h */,
+				9311AC251B581E5200BBC877 /* InsightsAllTimeTableViewCell.m */,
+				9311AC281B5845FE00BBC877 /* InsightsMostPopularTableViewCell.h */,
+				9311AC291B5845FE00BBC877 /* InsightsMostPopularTableViewCell.m */,
+				9311AC2B1B58462C00BBC877 /* InsightsSectionHeaderTableViewCell.h */,
+				9311AC2C1B58462C00BBC877 /* InsightsSectionHeaderTableViewCell.m */,
+				9311AC2E1B58466900BBC877 /* InsightsTodaysStatsTableViewCell.h */,
+				9311AC2F1B58466900BBC877 /* InsightsTodaysStatsTableViewCell.m */,
 			);
 			name = Cells;
 			sourceTree = "<group>";
@@ -718,15 +738,18 @@
 				9389C94E197EBBAF0036D437 /* WPStatsGraphToastView.m in Sources */,
 				93A379E119FEAB1C00415023 /* StatsItemAction.m in Sources */,
 				930C2EEB195DB4D300C6964D /* WPStatsGraphBackgroundView.m in Sources */,
+				9311AC2A1B5845FE00BBC877 /* InsightsMostPopularTableViewCell.m in Sources */,
 				93A379EA19FEDEE100415023 /* WPStatsServiceRemote.m in Sources */,
 				9340980D1A5C83A00005DF06 /* StatsEphemory.m in Sources */,
 				93035C3B1AE97B6300F6FF5C /* WPFontManager+Stats.m in Sources */,
 				9367D9D41A6EAEBB0033911A /* StatsViewAllTableViewController.m in Sources */,
 				936B2251195C48700058C828 /* WPStatsGraphBarCell.m in Sources */,
+				9311AC2D1B58462C00BBC877 /* InsightsSectionHeaderTableViewCell.m in Sources */,
 				9367D9DC1A7018350033911A /* StatsBorderedCellBackgroundView.m in Sources */,
 				936E74A71A69A8990048F552 /* StatsTableSectionHeaderView.m in Sources */,
 				938A61851B0CAC23007C5EE7 /* StatsAllTime.m in Sources */,
 				936E74A41A688E6F0048F552 /* StatsSelectableTableViewCell.m in Sources */,
+				9311AC271B581E5200BBC877 /* InsightsAllTimeTableViewCell.m in Sources */,
 				936E00211AA8A7E300DCFA65 /* StatsPostDetailsTableViewController.m in Sources */,
 				93302C521A1BD78300B49CFC /* WPStatsService.m in Sources */,
 				936B22481958C3840058C828 /* WPStatsGraphViewController.m in Sources */,
@@ -736,6 +759,7 @@
 				936B2254195CB2FE0058C828 /* WPStyleGuide+Stats.m in Sources */,
 				93554C7D1B03D18700B49657 /* InsightsTableViewController.m in Sources */,
 				936B224E195AFD380058C828 /* WPStatsGraphLegendView.m in Sources */,
+				9311AC301B58466900BBC877 /* InsightsTodaysStatsTableViewCell.m in Sources */,
 				939A830A1A6703E00041B68A /* WPStatsViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPressCom-Stats-iOS/InsightsAllTimeTableViewCell.h
+++ b/WordPressCom-Stats-iOS/InsightsAllTimeTableViewCell.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
+#import "StatsStandardBorderedTableViewCell.h"
 
-@interface InsightsAllTimeTableViewCell : UITableViewCell
+@interface InsightsAllTimeTableViewCell : StatsStandardBorderedTableViewCell
 
 @property (nonatomic, weak) IBOutlet NSLayoutConstraint *heightConstraint;
 

--- a/WordPressCom-Stats-iOS/InsightsAllTimeTableViewCell.h
+++ b/WordPressCom-Stats-iOS/InsightsAllTimeTableViewCell.h
@@ -1,0 +1,18 @@
+#import <UIKit/UIKit.h>
+
+@interface InsightsAllTimeTableViewCell : UITableViewCell
+
+@property (nonatomic, weak) IBOutlet NSLayoutConstraint *heightConstraint;
+
+@property (nonatomic, weak) IBOutlet UILabel *allTimePostsLabel;
+@property (nonatomic, weak) IBOutlet UILabel *allTimeViewsLabel;
+@property (nonatomic, weak) IBOutlet UILabel *allTimeVisitorsLabel;
+@property (nonatomic, weak) IBOutlet UILabel *allTimeBestViewsLabel;
+
+@property (nonatomic, weak) IBOutlet UILabel *allTimePostsValueLabel;
+@property (nonatomic, weak) IBOutlet UILabel *allTimeViewsValueLabel;
+@property (nonatomic, weak) IBOutlet UILabel *allTimeVisitorsValueLabel;
+@property (nonatomic, weak) IBOutlet UILabel *allTimeBestViewsValueLabel;
+@property (nonatomic, weak) IBOutlet UILabel *allTimeBestViewsOnValueLabel;
+
+@end

--- a/WordPressCom-Stats-iOS/InsightsAllTimeTableViewCell.m
+++ b/WordPressCom-Stats-iOS/InsightsAllTimeTableViewCell.m
@@ -2,14 +2,4 @@
 
 @implementation InsightsAllTimeTableViewCell
 
-- (void)awakeFromNib {
-    // Initialization code
-}
-
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
-    [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
-}
-
 @end

--- a/WordPressCom-Stats-iOS/InsightsAllTimeTableViewCell.m
+++ b/WordPressCom-Stats-iOS/InsightsAllTimeTableViewCell.m
@@ -1,0 +1,15 @@
+#import "InsightsAllTimeTableViewCell.h"
+
+@implementation InsightsAllTimeTableViewCell
+
+- (void)awakeFromNib {
+    // Initialization code
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+
+@end

--- a/WordPressCom-Stats-iOS/InsightsMostPopularTableViewCell.h
+++ b/WordPressCom-Stats-iOS/InsightsMostPopularTableViewCell.h
@@ -3,7 +3,6 @@
 
 @interface InsightsMostPopularTableViewCell : StatsStandardBorderedTableViewCell
 
-@property (nonatomic, weak) IBOutlet UILabel *popularSectionHeaderLabel;
 @property (nonatomic, weak) IBOutlet UILabel *mostPopularDayLabel;
 @property (nonatomic, weak) IBOutlet UILabel *mostPopularDayPercentWeeklyViews;
 @property (nonatomic, weak) IBOutlet UILabel *mostPopularHourLabel;

--- a/WordPressCom-Stats-iOS/InsightsMostPopularTableViewCell.h
+++ b/WordPressCom-Stats-iOS/InsightsMostPopularTableViewCell.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
+#import "StatsStandardBorderedTableViewCell.h"
 
-@interface InsightsMostPopularTableViewCell : UITableViewCell
+@interface InsightsMostPopularTableViewCell : StatsStandardBorderedTableViewCell
 
 @property (nonatomic, weak) IBOutlet UILabel *popularSectionHeaderLabel;
 @property (nonatomic, weak) IBOutlet UILabel *mostPopularDayLabel;

--- a/WordPressCom-Stats-iOS/InsightsMostPopularTableViewCell.h
+++ b/WordPressCom-Stats-iOS/InsightsMostPopularTableViewCell.h
@@ -1,0 +1,13 @@
+#import <UIKit/UIKit.h>
+
+@interface InsightsMostPopularTableViewCell : UITableViewCell
+
+@property (nonatomic, weak) IBOutlet UILabel *popularSectionHeaderLabel;
+@property (nonatomic, weak) IBOutlet UILabel *mostPopularDayLabel;
+@property (nonatomic, weak) IBOutlet UILabel *mostPopularDayPercentWeeklyViews;
+@property (nonatomic, weak) IBOutlet UILabel *mostPopularHourLabel;
+@property (nonatomic, weak) IBOutlet UILabel *mostPopularHourPercentDailyViews;
+@property (nonatomic, weak) IBOutlet UILabel *mostPopularDay;
+@property (nonatomic, weak) IBOutlet UILabel *mostPopularHour;
+
+@end

--- a/WordPressCom-Stats-iOS/InsightsMostPopularTableViewCell.m
+++ b/WordPressCom-Stats-iOS/InsightsMostPopularTableViewCell.m
@@ -1,0 +1,15 @@
+#import "InsightsMostPopularTableViewCell.h"
+
+@implementation InsightsMostPopularTableViewCell
+
+- (void)awakeFromNib {
+    // Initialization code
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+
+@end

--- a/WordPressCom-Stats-iOS/InsightsMostPopularTableViewCell.m
+++ b/WordPressCom-Stats-iOS/InsightsMostPopularTableViewCell.m
@@ -2,14 +2,4 @@
 
 @implementation InsightsMostPopularTableViewCell
 
-- (void)awakeFromNib {
-    // Initialization code
-}
-
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
-    [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
-}
-
 @end

--- a/WordPressCom-Stats-iOS/InsightsSectionHeaderTableViewCell.h
+++ b/WordPressCom-Stats-iOS/InsightsSectionHeaderTableViewCell.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
+#import "StatsStandardBorderedTableViewCell.h"
 
-@interface InsightsSectionHeaderTableViewCell : UITableViewCell
+@interface InsightsSectionHeaderTableViewCell : StatsStandardBorderedTableViewCell
 
 @property (nonatomic, weak) IBOutlet UILabel *sectionHeaderLabel;
 

--- a/WordPressCom-Stats-iOS/InsightsSectionHeaderTableViewCell.h
+++ b/WordPressCom-Stats-iOS/InsightsSectionHeaderTableViewCell.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface InsightsSectionHeaderTableViewCell : UITableViewCell
+
+@property (nonatomic, weak) IBOutlet UILabel *sectionHeaderLabel;
+
+@end

--- a/WordPressCom-Stats-iOS/InsightsSectionHeaderTableViewCell.m
+++ b/WordPressCom-Stats-iOS/InsightsSectionHeaderTableViewCell.m
@@ -2,14 +2,5 @@
 
 @implementation InsightsSectionHeaderTableViewCell
 
-- (void)awakeFromNib {
-    // Initialization code
-}
-
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
-    [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
-}
 
 @end

--- a/WordPressCom-Stats-iOS/InsightsSectionHeaderTableViewCell.m
+++ b/WordPressCom-Stats-iOS/InsightsSectionHeaderTableViewCell.m
@@ -1,0 +1,15 @@
+#import "InsightsSectionHeaderTableViewCell.h"
+
+@implementation InsightsSectionHeaderTableViewCell
+
+- (void)awakeFromNib {
+    // Initialization code
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+
+@end

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -3,6 +3,7 @@
 #import "WPStyleGuide+Stats.h"
 #import "StatsTableSectionHeaderView.h"
 #import "StatsGaugeView.h"
+#import "InsightsSectionHeaderTableViewCell.h"
 #import "InsightsAllTimeTableViewCell.h"
 #import "StatsTableSectionHeaderView.h"
 #import "StatsSection.h"
@@ -55,23 +56,17 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
 
     [self setupRefreshControl];
 
-//    self.popularSectionHeaderLabel.text = NSLocalizedString(@"Most popular day and hour", @"Insights popular section header");
-//    self.popularSectionHeaderLabel.textColor = [WPStyleGuide greyDarken10];
 //    self.mostPopularDayLabel.text = [NSLocalizedString(@"Most popular day", @"Insights most popular day section label") uppercaseStringWithLocale:[NSLocale currentLocale]];
 //    self.mostPopularDayLabel.textColor = [WPStyleGuide greyDarken10];
 //    self.mostPopularHourLabel.text = [NSLocalizedString(@"Most popular hour", @"Insights most popular hour section label") uppercaseStringWithLocale:[NSLocale currentLocale]];
 //    self.mostPopularHourLabel.textColor = [WPStyleGuide greyDarken10];
-//    self.allTimeSectionHeaderLabel.text = NSLocalizedString(@"All-time posts, views, and visitors", @"Insights all time section header");
-//    self.allTimeSectionHeaderLabel.textColor = [WPStyleGuide greyDarken10];
-//    
+//
 //    self.allTimePostsLabel.attributedText = [self postsAttributedString];
 //    self.allTimeViewsLabel.attributedText = [self viewsAttributedString];
 //    self.allTimeVisitorsLabel.attributedText = [self visitorsAttributedString];
 //    
 //    self.allTimeBestViewsLabel.attributedText = [self bestViewsAttributedString];
 //
-//    self.todaySectionHeaderLabel.text = NSLocalizedString(@"Today's Stats", @"Insights today section header");
-//    self.todaySectionHeaderLabel.textColor = [WPStyleGuide wordPressBlue];
 //
 //    [self.todayViewsButton setAttributedTitle:[self viewsAttributedString] forState:UIControlStateNormal];
 //    [self.todayVisitorsButton setAttributedTitle:[self visitorsAttributedString] forState:UIControlStateNormal];
@@ -118,27 +113,40 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
 }
 
 
+#pragma mark - UITableViewDataSource methods
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    NSString *identifier = [self cellIdentifierForIndexPath:indexPath];
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:identifier forIndexPath:indexPath];
+    
+    [self configureCell:cell forIndexPath:indexPath];
+    
+    return cell;
+}
+
+
 #pragma mark - UITableViewDelegate methods
 
-- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    if (indexPath.section == 1 && indexPath.row == 2) {
-        return 100;
-    }
-    
-    return tableView.rowHeight;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    if (indexPath.section == 1 && indexPath.row == 2) {
-        InsightsAllTimeTableViewCell *insightsCell = (InsightsAllTimeTableViewCell *)[tableView cellForRowAtIndexPath:indexPath];
-        
-        return insightsCell.heightConstraint.constant + 1.0;
-    }
-    
-    return [super tableView:tableView heightForRowAtIndexPath:indexPath];
-}
+//- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
+//{
+//    if (indexPath.section == 1 && indexPath.row == 2) {
+//        return 100;
+//    }
+//    
+//    return tableView.rowHeight;
+//}
+//
+//- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
+//{
+//    if (indexPath.section == 1 && indexPath.row == 2) {
+//        InsightsAllTimeTableViewCell *insightsCell = (InsightsAllTimeTableViewCell *)[tableView cellForRowAtIndexPath:indexPath];
+//        
+//        return insightsCell.heightConstraint.constant + 1.0;
+//    }
+//    
+//    return [super tableView:tableView heightForRowAtIndexPath:indexPath];
+//}
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
@@ -150,6 +158,102 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
         }
     }
 }
+
+
+#pragma mark - Private cell configuration methods
+
+- (NSString *)cellIdentifierForIndexPath:(NSIndexPath *)indexPath
+{
+    NSString *identifier = @"";
+    
+    StatsSection statsSection = [self statsSectionForTableViewSection:indexPath.section];
+    
+    switch (statsSection) {
+        case StatsSectionInsightsAllTime:
+            if (indexPath.row == 0) {
+                identifier = InsightsTableSectionHeaderCellIdentifier;
+            } else {
+                identifier = InsightsTableAllTimeDetailsCellIdentifier;
+            }
+            break;
+            
+        case StatsSectionInsightsMostPopular:
+            if (indexPath.row == 0) {
+                identifier = InsightsTableSectionHeaderCellIdentifier;
+            } else {
+                identifier = InsightsTableMostPopularDetailsCellIdentifier;
+            }
+            break;
+
+        case StatsSectionInsightsTodaysStats:
+            if (indexPath.row == 0) {
+                identifier = InsightsTableSectionHeaderCellIdentifier;
+            } else {
+                identifier = InsightsTableTodaysStatsDetailsCellIdentifier;
+            }
+            break;
+
+        case StatsSectionGraph:
+        case StatsSectionPeriodHeader:
+        case StatsSectionEvents:
+        case StatsSectionPosts:
+        case StatsSectionReferrers:
+        case StatsSectionClicks:
+        case StatsSectionCountry:
+        case StatsSectionVideos:
+        case StatsSectionAuthors:
+        case StatsSectionSearchTerms:
+        case StatsSectionTagsCategories:
+        case StatsSectionPublicize:
+        case StatsSectionFollowers:
+        case StatsSectionComments:
+        case StatsSectionWebVersion:
+        case StatsSectionPostDetailsAveragePerDay:
+        case StatsSectionPostDetailsGraph:
+        case StatsSectionPostDetailsLoadingIndicator:
+        case StatsSectionPostDetailsMonthsYears:
+        case StatsSectionPostDetailsRecentWeeks:
+            break;
+    }
+    
+    return identifier;
+}
+
+
+- (void)configureCell:(UITableViewCell *)cell forIndexPath:(NSIndexPath *)indexPath
+{
+    NSString *identifier = cell.reuseIdentifier;
+    
+    if ([identifier isEqualToString:InsightsTableSectionHeaderCellIdentifier]) {
+        [self configureSectionHeaderCell:(InsightsSectionHeaderTableViewCell *)cell forSection:indexPath.section];
+    }
+}
+
+
+- (void)configureSectionHeaderCell:(InsightsSectionHeaderTableViewCell *)cell forSection:(NSInteger)section
+{
+    StatsSection statsSection = [self statsSectionForTableViewSection:section];
+
+    cell.sectionHeaderLabel.textColor = [WPStyleGuide greyDarken10];
+    
+    switch (statsSection) {
+        case StatsSectionInsightsAllTime:
+            cell.sectionHeaderLabel.text = NSLocalizedString(@"All-time posts, views, and visitors", @"Insights all time section header");
+            break;
+        case StatsSectionInsightsMostPopular:
+            cell.sectionHeaderLabel.text = NSLocalizedString(@"Most popular day and hour", @"Insights popular section header");
+            break;
+        case StatsSectionInsightsTodaysStats:
+            cell.sectionHeaderLabel.text = NSLocalizedString(@"Today's Stats", @"Insights today section header");
+            break;
+        default:
+            break;
+    }
+}
+
+
+#pragma mark - Private methods
+
 
 - (IBAction)refreshCurrentStats:(UIRefreshControl *)sender
 {

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -660,14 +660,6 @@ static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"Tod
 }
 
 
-- (id)statsDataForStatsSection:(StatsSection)statsSection
-{
-    id data = self.sectionData[@(statsSection)];
-    
-    return data;
-}
-
-
 - (void)wipeDataAndSeedGroups
 {
     if (self.sectionData) {

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -241,6 +241,12 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
         [self configureSectionHeaderCell:(InsightsSectionHeaderTableViewCell *)cell forSection:indexPath.section];
     } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsCellIdentifier]) {
         [self configureAllTimeCell:(InsightsAllTimeTableViewCell *)cell];
+    } else if ([identifier isEqualToString:InsightsTableMostPopularDetailsCellIdentifier]) {
+        [self configureMostPopularCell:(InsightsMostPopularTableViewCell *)cell];
+    } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsCellIdentifier]) {
+        [self configureTodaysStatsCell:(InsightsTodaysStatsTableViewCell *)cell];
+    } else {
+        DDLogWarn(@"ConfigureCell called with unknown cell identifier: %@", identifier);
     }
 }
 

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -5,6 +5,8 @@
 #import "StatsGaugeView.h"
 #import "InsightsSectionHeaderTableViewCell.h"
 #import "InsightsAllTimeTableViewCell.h"
+#import "InsightsMostPopularTableViewCell.h"
+#import "InsightsTodaysStatsTableViewCell.h"
 #import "StatsTableSectionHeaderView.h"
 #import "StatsSection.h"
 #import <WordPressCom-Analytics-iOS/WPAnalytics.h>
@@ -56,51 +58,6 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
 
     [self setupRefreshControl];
 
-//    self.mostPopularDayLabel.text = [NSLocalizedString(@"Most popular day", @"Insights most popular day section label") uppercaseStringWithLocale:[NSLocale currentLocale]];
-//    self.mostPopularDayLabel.textColor = [WPStyleGuide greyDarken10];
-//    self.mostPopularHourLabel.text = [NSLocalizedString(@"Most popular hour", @"Insights most popular hour section label") uppercaseStringWithLocale:[NSLocale currentLocale]];
-//    self.mostPopularHourLabel.textColor = [WPStyleGuide greyDarken10];
-//
-//    self.allTimePostsLabel.attributedText = [self postsAttributedString];
-//    self.allTimeViewsLabel.attributedText = [self viewsAttributedString];
-//    self.allTimeVisitorsLabel.attributedText = [self visitorsAttributedString];
-//    
-//    self.allTimeBestViewsLabel.attributedText = [self bestViewsAttributedString];
-//
-//
-//    [self.todayViewsButton setAttributedTitle:[self viewsAttributedString] forState:UIControlStateNormal];
-//    [self.todayVisitorsButton setAttributedTitle:[self visitorsAttributedString] forState:UIControlStateNormal];
-//    [self.todayLikesButton setAttributedTitle:[self likesAttributedString] forState:UIControlStateNormal];
-//    [self.todayCommentsButton setAttributedTitle:[self commentsAttributedString] forState:UIControlStateNormal];
-//    
-//    // Default values for no data
-//    self.mostPopularDay.text = @"-";
-//    self.mostPopularDay.textColor = [WPStyleGuide greyLighten20];
-//    self.mostPopularDayPercentWeeklyViews.text = [NSString stringWithFormat:NSLocalizedString(@"%@ of views", @"Insights Percent of views label with value"), @"-"];
-//    self.mostPopularDayPercentWeeklyViews.textColor = [WPStyleGuide greyDarken10];
-//    self.mostPopularHour.text = @"-";
-//    self.mostPopularHour.textColor = [WPStyleGuide greyLighten20];
-//    self.mostPopularHourPercentDailyViews.text = [NSString stringWithFormat:NSLocalizedString(@"%@ of views", @"Insights Percent of views label with value"), @"-"];
-//    self.mostPopularHourPercentDailyViews.textColor = [WPStyleGuide greyDarken10];
-//    self.allTimePostsValueLabel.text = @"-";
-//    self.allTimePostsValueLabel.textColor = [WPStyleGuide greyLighten20];
-//    self.allTimeViewsValueLabel.text = @"-";
-//    self.allTimeViewsValueLabel.textColor = [WPStyleGuide greyLighten20];
-//    self.allTimeVisitorsValueLabel.text = @"-";
-//    self.allTimeVisitorsValueLabel.textColor = [WPStyleGuide greyLighten20];
-//    self.allTimeBestViewsValueLabel.text = @"-";
-//    self.allTimeBestViewsValueLabel.textColor = [WPStyleGuide greyLighten20];
-//    self.allTimeBestViewsOnValueLabel.text = NSLocalizedString(@"Unknown", @"Unknown data in value label");
-//    self.allTimeBestViewsOnValueLabel.textColor = [WPStyleGuide greyLighten20];
-//    [self.todayViewsValueButton setTitle:@"-" forState:UIControlStateNormal];
-//    [self.todayViewsValueButton setTitleColor:[WPStyleGuide greyLighten20] forState:UIControlStateNormal];
-//    [self.todayVisitorsValueButton setTitle:@"-" forState:UIControlStateNormal];
-//    [self.todayVisitorsValueButton setTitleColor:[WPStyleGuide greyLighten20] forState:UIControlStateNormal];
-//    [self.todayLikesValueButton setTitle:@"-" forState:UIControlStateNormal];
-//    [self.todayLikesValueButton setTitleColor:[WPStyleGuide greyLighten20] forState:UIControlStateNormal];
-//    [self.todayCommentsValueButton setTitle:@"-" forState:UIControlStateNormal];
-//    [self.todayCommentsValueButton setTitleColor:[WPStyleGuide greyLighten20] forState:UIControlStateNormal];
-
     [self retrieveStats];
 }
 
@@ -115,6 +72,16 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
 
 #pragma mark - UITableViewDataSource methods
 
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
+{
+    return (NSInteger)self.sections.count;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
+{
+    return 2;
+}
+
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     NSString *identifier = [self cellIdentifierForIndexPath:indexPath];
@@ -128,6 +95,40 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
 
 #pragma mark - UITableViewDelegate methods
 
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
+{
+    if ([self statsSectionForTableViewSection:section] != StatsSectionPeriodHeader) {
+        StatsTableSectionHeaderView *headerView = [tableView dequeueReusableHeaderFooterViewWithIdentifier:StatsTableSectionHeaderSimpleBorder];
+        
+        return headerView;
+    }
+    
+    return nil;
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+{
+    if ([self statsSectionForTableViewSection:section] != StatsSectionPeriodHeader) {
+        StatsTableSectionHeaderView *footerView = [tableView dequeueReusableHeaderFooterViewWithIdentifier:StatsTableSectionHeaderSimpleBorder];
+        footerView.footer = YES;
+        
+        return footerView;
+    }
+    
+    return nil;
+}
+
+
+- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
+{
+    return 1.0f;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
+{
+    return 10.0f;
+}
+
 //- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
 //{
 //    if (indexPath.section == 1 && indexPath.row == 2) {
@@ -137,16 +138,28 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
 //    return tableView.rowHeight;
 //}
 //
-//- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
-//{
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    NSString *identifier = [self cellIdentifierForIndexPath:indexPath];
+    
+    if ([identifier isEqualToString:InsightsTableSectionHeaderCellIdentifier]) {
+        return 44.0f;
+    } else if ([identifier isEqualToString:InsightsTableMostPopularDetailsCellIdentifier]) {
+        return 150.0f;
+    } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsCellIdentifier]) {
+        return 100.0f;
+    } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsCellIdentifier]) {
+        return 66.0f;
+    }
+    
 //    if (indexPath.section == 1 && indexPath.row == 2) {
 //        InsightsAllTimeTableViewCell *insightsCell = (InsightsAllTimeTableViewCell *)[tableView cellForRowAtIndexPath:indexPath];
 //        
 //        return insightsCell.heightConstraint.constant + 1.0;
 //    }
 //    
-//    return [super tableView:tableView heightForRowAtIndexPath:indexPath];
-//}
+    return [super tableView:tableView heightForRowAtIndexPath:indexPath];
+}
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
@@ -226,6 +239,8 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
     
     if ([identifier isEqualToString:InsightsTableSectionHeaderCellIdentifier]) {
         [self configureSectionHeaderCell:(InsightsSectionHeaderTableViewCell *)cell forSection:indexPath.section];
+    } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsCellIdentifier]) {
+        [self configureAllTimeCell:(InsightsAllTimeTableViewCell *)cell];
     }
 }
 
@@ -252,6 +267,105 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
 }
 
 
+- (void)configureAllTimeCell:(InsightsAllTimeTableViewCell *)cell
+{
+    cell.allTimePostsLabel.attributedText = [self postsAttributedStringWithFont:cell.allTimePostsLabel.font];
+    cell.allTimeViewsLabel.attributedText = [self viewsAttributedStringWithFont:cell.allTimeViewsLabel.font];
+    cell.allTimeVisitorsLabel.attributedText = [self visitorsAttributedStringWithFont:cell.allTimeVisitorsLabel.font];
+    cell.allTimeBestViewsLabel.attributedText = [self bestViewsAttributedStringWithFont:cell.allTimeBestViewsLabel.font];
+
+    StatsAllTime *statsAllTime = self.sectionData[@(StatsSectionInsightsAllTime)];
+    
+    if (!statsAllTime) {
+        cell.allTimePostsValueLabel.text = @"-";
+        cell.allTimePostsValueLabel.textColor = [WPStyleGuide greyLighten20];
+        cell.allTimeViewsValueLabel.text = @"-";
+        cell.allTimeViewsValueLabel.textColor = [WPStyleGuide greyLighten20];
+        cell.allTimeVisitorsValueLabel.text = @"-";
+        cell.allTimeVisitorsValueLabel.textColor = [WPStyleGuide greyLighten20];
+        cell.allTimeBestViewsValueLabel.text = @"-";
+        cell.allTimeBestViewsValueLabel.textColor = [WPStyleGuide greyLighten20];
+        cell.allTimeBestViewsOnValueLabel.text = NSLocalizedString(@"Unknown", @"Unknown data in value label");
+        cell.allTimeBestViewsOnValueLabel.textColor = [WPStyleGuide greyLighten20];
+    } else {
+        cell.allTimePostsValueLabel.textColor = [WPStyleGuide greyDarken30];
+        cell.allTimePostsValueLabel.text = statsAllTime.numberOfPosts;
+        cell.allTimeViewsValueLabel.textColor = [WPStyleGuide greyDarken30];
+        cell.allTimeViewsValueLabel.text = statsAllTime.numberOfViews;
+        cell.allTimeVisitorsValueLabel.textColor = [WPStyleGuide greyDarken30];
+        cell.allTimeVisitorsValueLabel.text = statsAllTime.numberOfVisitors;
+        cell.allTimeBestViewsValueLabel.textColor = [WPStyleGuide greyDarken30];
+        cell.allTimeBestViewsValueLabel.text = statsAllTime.bestNumberOfViews;
+        cell.allTimeBestViewsOnValueLabel.textColor = [WPStyleGuide greyDarken10];
+        cell.allTimeBestViewsOnValueLabel.text = statsAllTime.bestViewsOn;
+    }
+}
+
+
+- (void)configureMostPopularCell:(InsightsMostPopularTableViewCell *)cell
+{
+    cell.mostPopularDayLabel.text = [NSLocalizedString(@"Most popular day", @"Insights most popular day section label") uppercaseStringWithLocale:[NSLocale currentLocale]];
+    cell.mostPopularDayLabel.textColor = [WPStyleGuide greyDarken10];
+    cell.mostPopularHourLabel.text = [NSLocalizedString(@"Most popular hour", @"Insights most popular hour section label") uppercaseStringWithLocale:[NSLocale currentLocale]];
+    cell.mostPopularHourLabel.textColor = [WPStyleGuide greyDarken10];
+
+    StatsInsights *statsInsights = self.sectionData[@(StatsSectionInsightsMostPopular)];
+    
+    cell.mostPopularDayPercentWeeklyViews.textColor = [WPStyleGuide greyDarken10];
+    cell.mostPopularHourPercentDailyViews.textColor = [WPStyleGuide greyDarken10];
+
+    if (!statsInsights) {
+        cell.mostPopularDay.text = @"-";
+        cell.mostPopularDay.textColor = [WPStyleGuide greyLighten20];
+        cell.mostPopularDayPercentWeeklyViews.text = [NSString stringWithFormat:NSLocalizedString(@"%@ of views", @"Insights Percent of views label with value"), @"-"];
+        cell.mostPopularHour.text = @"-";
+        cell.mostPopularHour.textColor = [WPStyleGuide greyLighten20];
+        cell.mostPopularHourPercentDailyViews.text = [NSString stringWithFormat:NSLocalizedString(@"%@ of views", @"Insights Percent of views label with value"), @"-"];
+    } else {
+        cell.mostPopularDay.text = statsInsights.highestDayOfWeek;
+        cell.mostPopularDay.textColor = [WPStyleGuide greyDarken30];
+        cell.mostPopularHour.text = statsInsights.highestHour;
+        cell.mostPopularHour.textColor = [WPStyleGuide greyDarken30];
+        cell.mostPopularDayPercentWeeklyViews.text = [NSString stringWithFormat:NSLocalizedString(@"%@ of views", @"Insights Percent of views label with value"), statsInsights.highestDayPercent];
+        cell.mostPopularHourPercentDailyViews.text = [NSString stringWithFormat:NSLocalizedString(@"%@ of views", @"Insights Percent of views label with value"), statsInsights.highestHourPercent];
+    }
+    
+}
+
+
+- (void)configureTodaysStatsCell:(InsightsTodaysStatsTableViewCell *)cell
+{
+    [cell.todayViewsButton setAttributedTitle:[self viewsAttributedStringWithFont:cell.todayViewsButton.titleLabel.font] forState:UIControlStateNormal];
+    [cell.todayVisitorsButton setAttributedTitle:[self visitorsAttributedStringWithFont:cell.todayVisitorsButton.titleLabel.font] forState:UIControlStateNormal];
+    [cell.todayLikesButton setAttributedTitle:[self likesAttributedStringWithFont:cell.todayLikesButton.titleLabel.font] forState:UIControlStateNormal];
+    [cell.todayCommentsButton setAttributedTitle:[self commentsAttributedStringWithFont:cell.todayCommentsButton.titleLabel.font] forState:UIControlStateNormal];
+    
+    StatsSummary *todaySummary = self.sectionData[@(StatsSectionInsightsTodaysStats)];
+    
+    if (!todaySummary) {
+        // Default values for no data
+        [cell.todayViewsValueButton setTitle:@"-" forState:UIControlStateNormal];
+        [cell.todayViewsValueButton setTitleColor:[WPStyleGuide greyLighten20] forState:UIControlStateNormal];
+        [cell.todayVisitorsValueButton setTitle:@"-" forState:UIControlStateNormal];
+        [cell.todayVisitorsValueButton setTitleColor:[WPStyleGuide greyLighten20] forState:UIControlStateNormal];
+        [cell.todayLikesValueButton setTitle:@"-" forState:UIControlStateNormal];
+        [cell.todayLikesValueButton setTitleColor:[WPStyleGuide greyLighten20] forState:UIControlStateNormal];
+        [cell.todayCommentsValueButton setTitle:@"-" forState:UIControlStateNormal];
+        [cell.todayCommentsValueButton setTitleColor:[WPStyleGuide greyLighten20] forState:UIControlStateNormal];
+    } else {
+        [cell.todayViewsValueButton setTitle:todaySummary.views forState:UIControlStateNormal];
+        [cell.todayViewsValueButton setTitleColor:todaySummary.viewsValue.integerValue == 0 ? [WPStyleGuide grey] : [WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
+        [cell.todayVisitorsValueButton setTitle:todaySummary.visitors forState:UIControlStateNormal];
+        [cell.todayVisitorsValueButton setTitleColor:todaySummary.visitorsValue.integerValue == 0 ? [WPStyleGuide grey] : [WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
+        [cell.todayLikesValueButton setTitle:todaySummary.likes forState:UIControlStateNormal];
+        [cell.todayLikesValueButton setTitleColor:todaySummary.likesValue.integerValue == 0 ? [WPStyleGuide grey] : [WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
+        [cell.todayCommentsValueButton setTitle:todaySummary.comments forState:UIControlStateNormal];
+        [cell.todayCommentsValueButton setTitleColor:todaySummary.commentsValue.integerValue == 0 ? [WPStyleGuide grey] : [WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
+    }
+
+}
+
+
 #pragma mark - Private methods
 
 
@@ -269,20 +383,23 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
         self.refreshControl = nil;
     }
     
-    __block StatsAllTime *statsAllTime;
-    __block StatsInsights *statsInsights;
-    __block StatsSummary *todaySummary;
     [self.statsService retrieveInsightsStatsWithAllTimeStatsCompletionHandler:^(StatsAllTime *allTime, NSError *error)
      {
-         statsAllTime = allTime;
+         if (allTime) {
+             self.sectionData[@(StatsSectionInsightsAllTime)] = allTime;
+         }
      }
                                                     insightsCompletionHandler:^(StatsInsights *insights, NSError *error)
      {
-         statsInsights = insights;
+         if (insights) {
+             self.sectionData[@(StatsSectionInsightsMostPopular)] = insights;
+         }
      }
                                                 todaySummaryCompletionHandler:^(StatsSummary *summary, NSError *error)
      {
-         todaySummary = summary;
+         if (summary) {
+             self.sectionData[@(StatsSectionInsightsTodaysStats)] = summary;
+         }
      }
                                                                 progressBlock:^(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations)
      {
@@ -298,34 +415,13 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
                                                   andOverallCompletionHandler:^
      {
          // Set the colors to what they should be (previous color for unknown data)
-//         self.mostPopularDay.textColor = [WPStyleGuide greyDarken30];
-//         self.mostPopularHour.textColor = [WPStyleGuide greyDarken30];
-//         self.allTimePostsValueLabel.textColor = [WPStyleGuide greyDarken30];
-//         self.allTimeViewsValueLabel.textColor = [WPStyleGuide greyDarken30];
-//         self.allTimeVisitorsValueLabel.textColor = [WPStyleGuide greyDarken30];
-//         self.allTimeBestViewsValueLabel.textColor = [WPStyleGuide greyDarken30];
-//         self.allTimeBestViewsOnValueLabel.textColor = [WPStyleGuide greyDarken10];
-//
-//         self.mostPopularDay.text = statsInsights.highestDayOfWeek;
-//         self.mostPopularDayPercentWeeklyViews.text = [NSString stringWithFormat:NSLocalizedString(@"%@ of views", @"Insights Percent of views label with value"), statsInsights.highestDayPercent];
-//         self.mostPopularHour.text = statsInsights.highestHour;
-//         self.mostPopularHourPercentDailyViews.text = [NSString stringWithFormat:NSLocalizedString(@"%@ of views", @"Insights Percent of views label with value"), statsInsights.highestHourPercent];
-//         self.allTimePostsValueLabel.text = statsAllTime.numberOfPosts;
-//         self.allTimeViewsValueLabel.text = statsAllTime.numberOfViews;
-//         self.allTimeVisitorsValueLabel.text = statsAllTime.numberOfVisitors;
-//         self.allTimeBestViewsValueLabel.text = statsAllTime.bestNumberOfViews;
-//         self.allTimeBestViewsOnValueLabel.text = statsAllTime.bestViewsOn;
-//         [self.todayViewsValueButton setTitle:todaySummary.views forState:UIControlStateNormal];
-//         [self.todayViewsValueButton setTitleColor:todaySummary.viewsValue.integerValue == 0 ? [WPStyleGuide grey] : [WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
-//         [self.todayVisitorsValueButton setTitle:todaySummary.visitors forState:UIControlStateNormal];
-//         [self.todayVisitorsValueButton setTitleColor:todaySummary.visitorsValue.integerValue == 0 ? [WPStyleGuide grey] : [WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
-//         [self.todayLikesValueButton setTitle:todaySummary.likes forState:UIControlStateNormal];
-//         [self.todayLikesValueButton setTitleColor:todaySummary.likesValue.integerValue == 0 ? [WPStyleGuide grey] : [WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
-//         [self.todayCommentsValueButton setTitle:todaySummary.comments forState:UIControlStateNormal];
-//         [self.todayCommentsValueButton setTitleColor:todaySummary.commentsValue.integerValue == 0 ? [WPStyleGuide grey] : [WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
          
          [self setupRefreshControl];
          [self.refreshControl endRefreshing];
+         
+         
+         // FIXME - Do something elegant possibly
+         [self.tableView reloadData];
          
          if ([self.statsProgressViewDelegate respondsToSelector:@selector(statsViewControllerDidEndLoadingStats:)]) {
              [self.statsProgressViewDelegate statsViewControllerDidEndLoadingStats:self];
@@ -379,11 +475,11 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
 
 #pragma mark - Attributed String generation methods
 
-- (NSMutableAttributedString *)postsAttributedString
+- (NSMutableAttributedString *)postsAttributedStringWithFont:(UIFont *)font
 {
     NSMutableAttributedString *postsText = [[NSMutableAttributedString alloc] initWithString:[NSLocalizedString(@"Posts", @"Stats Posts label") uppercaseStringWithLocale:[NSLocale currentLocale]]];
     InlineTextAttachment *postsTextAttachment = [InlineTextAttachment new];
-//    postsTextAttachment.fontDescender = self.allTimeViewsLabel.font.descender;
+    postsTextAttachment.fontDescender = font.descender;
     postsTextAttachment.image = [self postsImage];
     [postsText insertAttributedString:[NSAttributedString attributedStringWithAttachment:postsTextAttachment] atIndex:0];
     [postsText insertAttributedString:[[NSAttributedString alloc] initWithString:@" "] atIndex:1];
@@ -393,11 +489,11 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
     return postsText;
 }
 
-- (NSMutableAttributedString *)viewsAttributedString
+- (NSMutableAttributedString *)viewsAttributedStringWithFont:(UIFont *)font
 {
     NSMutableAttributedString *viewsText = [[NSMutableAttributedString alloc] initWithString:[NSLocalizedString(@"Views", @"Stats Views label") uppercaseStringWithLocale:[NSLocale currentLocale]]];
     InlineTextAttachment *viewsTextAttachment = [InlineTextAttachment new];
-//    viewsTextAttachment.fontDescender = self.allTimeViewsLabel.font.descender;
+    viewsTextAttachment.fontDescender = font.descender;
     viewsTextAttachment.image = [self viewsImage];
     [viewsText insertAttributedString:[NSAttributedString attributedStringWithAttachment:viewsTextAttachment] atIndex:0];
     [viewsText insertAttributedString:[[NSAttributedString alloc] initWithString:@" "] atIndex:1];
@@ -407,11 +503,11 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
     return viewsText;
 }
 
-- (NSMutableAttributedString *)visitorsAttributedString
+- (NSMutableAttributedString *)visitorsAttributedStringWithFont:(UIFont *)font
 {
     NSMutableAttributedString *visitorsText = [[NSMutableAttributedString alloc] initWithString:[NSLocalizedString(@"Visitors", @"Stats Visitors label") uppercaseStringWithLocale:[NSLocale currentLocale]]];
     InlineTextAttachment *visitorsTextAttachment = [InlineTextAttachment new];
-//    visitorsTextAttachment.fontDescender = self.allTimeVisitorsLabel.font.descender;
+    visitorsTextAttachment.fontDescender = font.descender;
     visitorsTextAttachment.image = [self visitorsImage];
     [visitorsText insertAttributedString:[NSAttributedString attributedStringWithAttachment:visitorsTextAttachment] atIndex:0];
     [visitorsText insertAttributedString:[[NSAttributedString alloc] initWithString:@" "] atIndex:1];
@@ -421,11 +517,11 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
     return visitorsText;
 }
 
-- (NSMutableAttributedString *)bestViewsAttributedString
+- (NSMutableAttributedString *)bestViewsAttributedStringWithFont:(UIFont *)font
 {
     NSMutableAttributedString *bestViewsText = [[NSMutableAttributedString alloc] initWithString:[NSLocalizedString(@"Best Views Ever", @"Stats Best Views label") uppercaseStringWithLocale:[NSLocale currentLocale]]];
     InlineTextAttachment *bestViewsTextAttachment = [InlineTextAttachment new];
-//    bestViewsTextAttachment.fontDescender = self.allTimeBestViewsLabel.font.descender;
+    bestViewsTextAttachment.fontDescender = font.descender;
     bestViewsTextAttachment.image = [self bestViewsImage];
     [bestViewsText insertAttributedString:[NSAttributedString attributedStringWithAttachment:bestViewsTextAttachment] atIndex:0];
     [bestViewsText insertAttributedString:[[NSAttributedString alloc] initWithString:@" "] atIndex:1];
@@ -434,11 +530,11 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
     return bestViewsText;
 }
 
-- (NSMutableAttributedString *)likesAttributedString
+- (NSMutableAttributedString *)likesAttributedStringWithFont:(UIFont *)font
 {
     NSMutableAttributedString *likesText = [[NSMutableAttributedString alloc] initWithString:[NSLocalizedString(@"Likes", @"Stats Likes label") uppercaseStringWithLocale:[NSLocale currentLocale]]];
     InlineTextAttachment *likesTextAttachment = [InlineTextAttachment new];
-//    likesTextAttachment.fontDescender = self.todayLikesButton.titleLabel.font.descender;
+    likesTextAttachment.fontDescender = font.descender;
     likesTextAttachment.image = [self likesImage];
     [likesText insertAttributedString:[NSAttributedString attributedStringWithAttachment:likesTextAttachment] atIndex:0];
     [likesText insertAttributedString:[[NSAttributedString alloc] initWithString:@" "] atIndex:1];
@@ -448,11 +544,11 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
     return likesText;
 }
 
-- (NSMutableAttributedString *)commentsAttributedString
+- (NSMutableAttributedString *)commentsAttributedStringWithFont:(UIFont *)font
 {
     NSMutableAttributedString *commentsText = [[NSMutableAttributedString alloc] initWithString:[NSLocalizedString(@"Comments", @"Stats Comments label") uppercaseStringWithLocale:[NSLocale currentLocale]]];
     InlineTextAttachment *commentsTextAttachment = [InlineTextAttachment new];
-//    commentsTextAttachment.fontDescender = self.todayCommentsButton.titleLabel.font.descender;
+    commentsTextAttachment.fontDescender = font.descender;
     commentsTextAttachment.image = [self commentsImage];
     [commentsText insertAttributedString:[NSAttributedString attributedStringWithAttachment:commentsTextAttachment] atIndex:0];
     [commentsText insertAttributedString:[[NSAttributedString alloc] initWithString:@" "] atIndex:1];

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -203,7 +203,7 @@ static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"Tod
             if (indexPath.row == 0) {
                 identifier = InsightsTableSectionHeaderCellIdentifier;
             } else {
-                identifier = IS_IPAD ? InsightsTableAllTimeDetailsiPadCellIdentifier : InsightsTableAllTimeDetailsCellIdentifier;
+                identifier = self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad ? InsightsTableAllTimeDetailsiPadCellIdentifier : InsightsTableAllTimeDetailsCellIdentifier;
             }
             break;
     
@@ -219,7 +219,7 @@ static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"Tod
             if (indexPath.row == 0) {
                 identifier = InsightsTableSectionHeaderCellIdentifier;
             } else {
-                identifier = IS_IPAD ? InsightsTableTodaysStatsDetailsiPadCellIdentifier : InsightsTableTodaysStatsDetailsCellIdentifier;
+                identifier = self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad ? InsightsTableTodaysStatsDetailsiPadCellIdentifier : InsightsTableTodaysStatsDetailsCellIdentifier;
             }
             break;
 

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -143,7 +143,7 @@ static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"Tod
     } else if ([identifier isEqualToString:InsightsTableMostPopularDetailsCellIdentifier]) {
         return 150.0f;
     } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsCellIdentifier]) {
-        return 200.0f;
+        return 185.0f;
     } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsiPadCellIdentifier]) {
         return 100.0f;
     } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsiPadCellIdentifier]) {

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -32,6 +32,8 @@ static NSString *const InsightsTableSectionHeaderCellIdentifier = @"HeaderRow";
 static NSString *const InsightsTableMostPopularDetailsCellIdentifier = @"MostPopularDetails";
 static NSString *const InsightsTableAllTimeDetailsCellIdentifier = @"AllTimeDetails";
 static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysStatsDetails";
+static NSString *const InsightsTableAllTimeDetailsiPadCellIdentifier = @"AllTimeDetailsPad";
+static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"TodaysStatsDetailsPad";
 
 @interface InsightsTableViewController ()
 
@@ -48,8 +50,9 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
     self.tableView.tableHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 20.0f)];
     self.tableView.backgroundColor = [WPStyleGuide itsEverywhereGrey];
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
-    [self.tableView registerClass:[StatsTableSectionHeaderView class] forHeaderFooterViewReuseIdentifier:StatsTableSectionHeaderSimpleBorder];
 
+    [self.tableView registerClass:[StatsTableSectionHeaderView class] forHeaderFooterViewReuseIdentifier:StatsTableSectionHeaderSimpleBorder];
+    
     self.sections = @[@(StatsSectionInsightsMostPopular),
                       @(StatsSectionInsightsAllTime),
                       @(StatsSectionInsightsTodaysStats)];
@@ -124,20 +127,35 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
     return 1.0f;
 }
 
+
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
 {
     return 10.0f;
 }
 
-//- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
-//{
-//    if (indexPath.section == 1 && indexPath.row == 2) {
-//        return 100;
-//    }
-//    
-//    return tableView.rowHeight;
-//}
-//
+
+- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    NSString *identifier = [self cellIdentifierForIndexPath:indexPath];
+    
+    if ([identifier isEqualToString:InsightsTableSectionHeaderCellIdentifier]) {
+        return 44.0f;
+    } else if ([identifier isEqualToString:InsightsTableMostPopularDetailsCellIdentifier]) {
+        return 150.0f;
+    } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsCellIdentifier]) {
+      return 200.0f;
+    } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsiPadCellIdentifier]) {
+      return 100.0f;
+    } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsiPadCellIdentifier]) {
+        return 66.0f;
+    } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsCellIdentifier]) {
+        return 132.0f;
+    }
+  
+    return tableView.rowHeight;
+}
+
+
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     NSString *identifier = [self cellIdentifierForIndexPath:indexPath];
@@ -147,19 +165,18 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
     } else if ([identifier isEqualToString:InsightsTableMostPopularDetailsCellIdentifier]) {
         return 150.0f;
     } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsCellIdentifier]) {
+        return 200.0f;
+    } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsiPadCellIdentifier]) {
         return 100.0f;
-    } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsCellIdentifier]) {
+    } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsiPadCellIdentifier]) {
         return 66.0f;
+    } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsCellIdentifier]) {
+        return 132.0f;
     }
-    
-//    if (indexPath.section == 1 && indexPath.row == 2) {
-//        InsightsAllTimeTableViewCell *insightsCell = (InsightsAllTimeTableViewCell *)[tableView cellForRowAtIndexPath:indexPath];
-//        
-//        return insightsCell.heightConstraint.constant + 1.0;
-//    }
-//    
+
     return [super tableView:tableView heightForRowAtIndexPath:indexPath];
 }
+
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
@@ -186,10 +203,10 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
             if (indexPath.row == 0) {
                 identifier = InsightsTableSectionHeaderCellIdentifier;
             } else {
-                identifier = InsightsTableAllTimeDetailsCellIdentifier;
+                identifier = IS_IPAD ? InsightsTableAllTimeDetailsiPadCellIdentifier : InsightsTableAllTimeDetailsCellIdentifier;
             }
             break;
-            
+    
         case StatsSectionInsightsMostPopular:
             if (indexPath.row == 0) {
                 identifier = InsightsTableSectionHeaderCellIdentifier;
@@ -202,7 +219,7 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
             if (indexPath.row == 0) {
                 identifier = InsightsTableSectionHeaderCellIdentifier;
             } else {
-                identifier = InsightsTableTodaysStatsDetailsCellIdentifier;
+                identifier = IS_IPAD ? InsightsTableTodaysStatsDetailsiPadCellIdentifier : InsightsTableTodaysStatsDetailsCellIdentifier;
             }
             break;
 
@@ -239,11 +256,11 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
     
     if ([identifier isEqualToString:InsightsTableSectionHeaderCellIdentifier]) {
         [self configureSectionHeaderCell:(InsightsSectionHeaderTableViewCell *)cell forSection:indexPath.section];
-    } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsCellIdentifier]) {
+    } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsCellIdentifier] || [identifier isEqualToString:InsightsTableAllTimeDetailsiPadCellIdentifier]) {
         [self configureAllTimeCell:(InsightsAllTimeTableViewCell *)cell];
     } else if ([identifier isEqualToString:InsightsTableMostPopularDetailsCellIdentifier]) {
         [self configureMostPopularCell:(InsightsMostPopularTableViewCell *)cell];
-    } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsCellIdentifier]) {
+    } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsCellIdentifier] || [identifier isEqualToString:InsightsTableTodaysStatsDetailsiPadCellIdentifier]) {
         [self configureTodaysStatsCell:(InsightsTodaysStatsTableViewCell *)cell];
     } else {
         DDLogWarn(@"ConfigureCell called with unknown cell identifier: %@", identifier);

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -497,7 +497,7 @@ static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"Tod
     viewsTextAttachment.fontDescender = font.descender;
     viewsTextAttachment.image = [self viewsImage];
     [viewsText insertAttributedString:[NSAttributedString attributedStringWithAttachment:viewsTextAttachment] atIndex:0];
-    [viewsText insertAttributedString:[[NSAttributedString alloc] initWithString:@" "] atIndex:1];
+    [viewsText insertAttributedString:[[NSAttributedString alloc] initWithString:@"  "] atIndex:1];
     [viewsText appendAttributedString:[[NSAttributedString alloc] initWithString:@"  "]];
     [viewsText addAttribute:NSForegroundColorAttributeName value:[WPStyleGuide greyDarken20] range:NSMakeRange(0, viewsText.length)];
 

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -134,28 +134,6 @@ static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"Tod
 }
 
 
-- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    NSString *identifier = [self cellIdentifierForIndexPath:indexPath];
-    
-    if ([identifier isEqualToString:InsightsTableSectionHeaderCellIdentifier]) {
-        return 44.0f;
-    } else if ([identifier isEqualToString:InsightsTableMostPopularDetailsCellIdentifier]) {
-        return 150.0f;
-    } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsCellIdentifier]) {
-      return 200.0f;
-    } else if ([identifier isEqualToString:InsightsTableAllTimeDetailsiPadCellIdentifier]) {
-      return 100.0f;
-    } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsiPadCellIdentifier]) {
-        return 66.0f;
-    } else if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsCellIdentifier]) {
-        return 132.0f;
-    }
-  
-    return tableView.rowHeight;
-}
-
-
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     NSString *identifier = [self cellIdentifierForIndexPath:indexPath];

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -181,7 +181,7 @@ static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"Tod
             if (indexPath.row == 0) {
                 identifier = InsightsTableSectionHeaderCellIdentifier;
             } else {
-                identifier = self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad ? InsightsTableAllTimeDetailsiPadCellIdentifier : InsightsTableAllTimeDetailsCellIdentifier;
+                identifier = IS_IPAD ? InsightsTableAllTimeDetailsiPadCellIdentifier : InsightsTableAllTimeDetailsCellIdentifier;
             }
             break;
     
@@ -197,7 +197,7 @@ static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"Tod
             if (indexPath.row == 0) {
                 identifier = InsightsTableSectionHeaderCellIdentifier;
             } else {
-                identifier = self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad ? InsightsTableTodaysStatsDetailsiPadCellIdentifier : InsightsTableTodaysStatsDetailsCellIdentifier;
+                identifier = IS_IPAD ? InsightsTableTodaysStatsDetailsiPadCellIdentifier : InsightsTableTodaysStatsDetailsCellIdentifier;
             }
             break;
 

--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -35,6 +35,9 @@ static NSString *const InsightsTableTodaysStatsDetailsCellIdentifier = @"TodaysS
 static NSString *const InsightsTableAllTimeDetailsiPadCellIdentifier = @"AllTimeDetailsPad";
 static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"TodaysStatsDetailsPad";
 
+static CGFloat const InsightsTableSectionHeaderHeight = 1.0f;
+static CGFloat const InsightsTableSectionFooterHeight = 10.0f;
+
 @interface InsightsTableViewController ()
 
 @property (nonatomic, strong) NSArray *sections;
@@ -124,13 +127,13 @@ static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"Tod
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
-    return 1.0f;
+    return InsightsTableSectionHeaderHeight;
 }
 
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
 {
-    return 10.0f;
+    return InsightsTableSectionFooterHeight;
 }
 
 
@@ -160,7 +163,9 @@ static NSString *const InsightsTableTodaysStatsDetailsiPadCellIdentifier = @"Tod
 {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
     
-    if (indexPath.section == 2 && indexPath.row == 0) {
+    NSString *identifier = [self cellIdentifierForIndexPath:indexPath];
+    
+    if ([identifier isEqualToString:InsightsTableTodaysStatsDetailsCellIdentifier] || [identifier isEqualToString:InsightsTableTodaysStatsDetailsiPadCellIdentifier]) {
         if ([self.statsTypeSelectionDelegate conformsToProtocol:@protocol(WPStatsSummaryTypeSelectionDelegate)]) {
             [self.statsTypeSelectionDelegate viewController:self changeStatsSummaryTypeSelection:StatsSummaryTypeViews];
         }

--- a/WordPressCom-Stats-iOS/InsightsTodaysStatsTableViewCell.h
+++ b/WordPressCom-Stats-iOS/InsightsTodaysStatsTableViewCell.h
@@ -1,0 +1,15 @@
+#import <UIKit/UIKit.h>
+
+@interface InsightsTodaysStatsTableViewCell : UITableViewCell
+
+@property (nonatomic, weak) IBOutlet UIButton *todayViewsButton;
+@property (nonatomic, weak) IBOutlet UIButton *todayVisitorsButton;
+@property (nonatomic, weak) IBOutlet UIButton *todayLikesButton;
+@property (nonatomic, weak) IBOutlet UIButton *todayCommentsButton;
+
+@property (nonatomic, weak) IBOutlet UIButton *todayViewsValueButton;
+@property (nonatomic, weak) IBOutlet UIButton *todayVisitorsValueButton;
+@property (nonatomic, weak) IBOutlet UIButton *todayLikesValueButton;
+@property (nonatomic, weak) IBOutlet UIButton *todayCommentsValueButton;
+
+@end

--- a/WordPressCom-Stats-iOS/InsightsTodaysStatsTableViewCell.h
+++ b/WordPressCom-Stats-iOS/InsightsTodaysStatsTableViewCell.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
+#import "StatsStandardBorderedTableViewCell.h"
 
-@interface InsightsTodaysStatsTableViewCell : UITableViewCell
+@interface InsightsTodaysStatsTableViewCell : StatsStandardBorderedTableViewCell
 
 @property (nonatomic, weak) IBOutlet UIButton *todayViewsButton;
 @property (nonatomic, weak) IBOutlet UIButton *todayVisitorsButton;

--- a/WordPressCom-Stats-iOS/InsightsTodaysStatsTableViewCell.m
+++ b/WordPressCom-Stats-iOS/InsightsTodaysStatsTableViewCell.m
@@ -1,0 +1,15 @@
+#import "InsightsTodaysStatsTableViewCell.h"
+
+@implementation InsightsTodaysStatsTableViewCell
+
+- (void)awakeFromNib {
+    // Initialization code
+}
+
+- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
+    [super setSelected:selected animated:animated];
+
+    // Configure the view for the selected state
+}
+
+@end

--- a/WordPressCom-Stats-iOS/InsightsTodaysStatsTableViewCell.m
+++ b/WordPressCom-Stats-iOS/InsightsTodaysStatsTableViewCell.m
@@ -2,14 +2,4 @@
 
 @implementation InsightsTodaysStatsTableViewCell
 
-- (void)awakeFromNib {
-    // Initialization code
-}
-
-- (void)setSelected:(BOOL)selected animated:(BOOL)animated {
-    [super setSelected:selected animated:animated];
-
-    // Configure the view for the selected state
-}
-
 @end

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -407,6 +407,9 @@
                                         <constraint firstAttribute="centerY" secondItem="U94-Ix-7EC" secondAttribute="centerY" id="yxW-O8-hnK"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="sectionHeaderLabel" destination="U94-Ix-7EC" id="p7k-5V-KrH"/>
+                                </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="MostPopularDetails" rowHeight="150" id="qq2-Vb-czH" userLabel="Most Popular Details" customClass="InsightsMostPopularTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
@@ -491,6 +494,14 @@
                                         <constraint firstItem="voB-PG-oGO" firstAttribute="leading" secondItem="csy-iV-Ucm" secondAttribute="trailing" id="oEx-Lh-kER"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="mostPopularDay" destination="dPU-t1-atl" id="xgs-Zq-cPF"/>
+                                    <outlet property="mostPopularDayLabel" destination="LqR-Vc-rtl" id="VQY-ID-neR"/>
+                                    <outlet property="mostPopularDayPercentWeeklyViews" destination="yKD-YK-Mra" id="SFC-T6-nVW"/>
+                                    <outlet property="mostPopularHour" destination="xx2-Ii-OSN" id="Gya-lV-1Fc"/>
+                                    <outlet property="mostPopularHourLabel" destination="owa-7G-DL9" id="EfF-83-rjc"/>
+                                    <outlet property="mostPopularHourPercentDailyViews" destination="txh-pI-huu" id="WYQ-lm-j1c"/>
+                                </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AllTimeDetails" rowHeight="100" id="3Mz-H6-0pu" userLabel="All Time Details" customClass="InsightsAllTimeTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
@@ -665,6 +676,17 @@
                                         <constraint firstAttribute="bottomMargin" secondItem="cPN-KE-hdr" secondAttribute="bottom" constant="-8" id="sun-Ek-hFD"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="allTimeBestViewsLabel" destination="Ml6-Iu-wKc" id="YFc-nz-OAu"/>
+                                    <outlet property="allTimeBestViewsOnValueLabel" destination="p0T-y9-dQS" id="AYH-l7-dvy"/>
+                                    <outlet property="allTimeBestViewsValueLabel" destination="bhJ-yf-eeg" id="5FG-93-8On"/>
+                                    <outlet property="allTimePostsLabel" destination="qTg-V3-QrG" id="t5s-jm-luq"/>
+                                    <outlet property="allTimePostsValueLabel" destination="kyf-cc-9Pz" id="43E-YK-fx6"/>
+                                    <outlet property="allTimeViewsLabel" destination="SnZ-To-N2p" id="ztA-C7-hUE"/>
+                                    <outlet property="allTimeViewsValueLabel" destination="qJ0-wu-bhs" id="aMi-ko-LQz"/>
+                                    <outlet property="allTimeVisitorsLabel" destination="Ixp-TF-kKn" id="WHS-wX-1SJ"/>
+                                    <outlet property="allTimeVisitorsValueLabel" destination="RsC-iV-YWj" id="6G5-A0-BNc"/>
+                                </connections>
                             </tableViewCell>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TodaysStatsDetails" rowHeight="66" id="dRE-rs-NGi" userLabel="Today's Stats Details" customClass="InsightsTodaysStatsTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
@@ -867,6 +889,16 @@
                                         <constraint firstAttribute="bottomMargin" secondItem="iwI-u2-AsI" secondAttribute="bottom" constant="-8" id="xGZ-oC-qDY"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="todayCommentsButton" destination="nUZ-Tg-WTV" id="60h-3p-XDh"/>
+                                    <outlet property="todayCommentsValueButton" destination="5Xj-XK-eQ8" id="5oJ-RS-bRZ"/>
+                                    <outlet property="todayLikesButton" destination="ab2-8S-y1h" id="Zgk-G4-bDj"/>
+                                    <outlet property="todayLikesValueButton" destination="6H5-sV-soQ" id="YHx-y4-zcu"/>
+                                    <outlet property="todayViewsButton" destination="4Zp-vE-uY4" id="Shf-ZI-AQQ"/>
+                                    <outlet property="todayViewsValueButton" destination="nWH-aO-4eO" id="VYR-Xl-FjA"/>
+                                    <outlet property="todayVisitorsButton" destination="g9y-bc-4NQ" id="4JU-4J-3cM"/>
+                                    <outlet property="todayVisitorsValueButton" destination="g6C-KQ-1fr" id="4NS-Qd-PKg"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <sections/>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -926,19 +926,19 @@
                                             <rect key="frame" x="8" y="0.0" width="292" height="100"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="128" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="vE2-2f-R5G">
-                                                    <rect key="frame" x="125" y="33" width="43" height="35"/>
+                                                    <rect key="frame" x="125" y="43" width="43" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POSTS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nii-wq-jD8">
-                                                    <rect key="frame" x="131" y="18" width="31" height="14"/>
+                                                    <rect key="frame" x="131" y="28" width="31" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nLg-Ao-MTu" userLabel="Divider View">
-                                                    <rect key="frame" x="291" y="16" width="1" height="68"/>
+                                                    <rect key="frame" x="291" y="18" width="1" height="64"/>
                                                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="1" id="LBj-qK-bqG"/>
@@ -948,33 +948,33 @@
                                             </subviews>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
-                                                <constraint firstItem="nLg-Ao-MTu" firstAttribute="top" secondItem="gv6-zf-XEx" secondAttribute="top" constant="16" id="4Nr-OR-K1r"/>
+                                                <constraint firstItem="nLg-Ao-MTu" firstAttribute="top" secondItem="gv6-zf-XEx" secondAttribute="top" constant="18" id="4Nr-OR-K1r"/>
                                                 <constraint firstAttribute="trailing" secondItem="nLg-Ao-MTu" secondAttribute="trailing" id="4yD-9v-tly"/>
                                                 <constraint firstAttribute="centerX" secondItem="vE2-2f-R5G" secondAttribute="centerX" id="6bu-cT-lfS"/>
                                                 <constraint firstItem="vE2-2f-R5G" firstAttribute="top" secondItem="Nii-wq-jD8" secondAttribute="baseline" constant="4" id="OR0-50-f9k"/>
                                                 <constraint firstAttribute="centerX" secondItem="Nii-wq-jD8" secondAttribute="centerX" id="Odw-0T-tLP"/>
                                                 <constraint firstAttribute="height" constant="100" id="VTl-Wv-Rya"/>
-                                                <constraint firstAttribute="bottom" secondItem="nLg-Ao-MTu" secondAttribute="bottom" constant="16" id="aOW-Ok-atu"/>
-                                                <constraint firstAttribute="centerY" secondItem="vE2-2f-R5G" secondAttribute="centerY" id="aUB-WG-IX7"/>
+                                                <constraint firstAttribute="bottom" secondItem="nLg-Ao-MTu" secondAttribute="bottom" constant="18" id="aOW-Ok-atu"/>
+                                                <constraint firstAttribute="centerY" secondItem="vE2-2f-R5G" secondAttribute="centerY" constant="-10" id="aUB-WG-IX7"/>
                                             </constraints>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VVz-ur-nje" userLabel="Best Views">
                                             <rect key="frame" x="300" y="100" width="292" height="99"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3,485" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="KsA-er-QuV">
-                                                    <rect key="frame" x="114" y="37" width="64" height="35"/>
+                                                    <rect key="frame" x="114" y="32" width="64" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BEST VIEWS EVER" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="TpN-dY-IW4">
-                                                    <rect key="frame" x="106" y="22" width="81" height="14"/>
+                                                    <rect key="frame" x="106" y="17" width="81" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="APRIL 4, 2015" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Upc-GK-XKb">
-                                                    <rect key="frame" x="115" y="73" width="63" height="14"/>
+                                                    <rect key="frame" x="115" y="71" width="63" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -987,8 +987,8 @@
                                                 <constraint firstItem="KsA-er-QuV" firstAttribute="top" secondItem="TpN-dY-IW4" secondAttribute="bottom" constant="4" id="SXr-4O-uVP"/>
                                                 <constraint firstItem="KsA-er-QuV" firstAttribute="top" secondItem="TpN-dY-IW4" secondAttribute="baseline" constant="4" id="c7M-t8-2xB"/>
                                                 <constraint firstAttribute="centerX" secondItem="Upc-GK-XKb" secondAttribute="centerX" id="rVl-tp-XBT"/>
-                                                <constraint firstAttribute="bottom" secondItem="Upc-GK-XKb" secondAttribute="bottom" constant="12" id="uCN-F8-c2F"/>
-                                                <constraint firstAttribute="centerY" secondItem="KsA-er-QuV" secondAttribute="centerY" constant="-5" id="uxt-qC-oKT"/>
+                                                <constraint firstAttribute="bottom" secondItem="Upc-GK-XKb" secondAttribute="bottom" constant="14" id="uCN-F8-c2F"/>
+                                                <constraint firstAttribute="centerY" secondItem="KsA-er-QuV" secondAttribute="centerY" id="uxt-qC-oKT"/>
                                             </constraints>
                                             <variation key="default">
                                                 <mask key="constraints">
@@ -1000,13 +1000,13 @@
                                             <rect key="frame" x="8" y="100" width="292" height="99"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="42,837" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="E8k-cd-ojU">
-                                                    <rect key="frame" x="107" y="37" width="78" height="35"/>
+                                                    <rect key="frame" x="107" y="42" width="78" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VISITORS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EfI-IH-BWM">
-                                                    <rect key="frame" x="125" y="22" width="43" height="14"/>
+                                                    <rect key="frame" x="125" y="27" width="43" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -1029,7 +1029,7 @@
                                                 <constraint firstAttribute="trailing" secondItem="VBS-Y1-4M2" secondAttribute="trailing" id="K02-KQ-ZCj"/>
                                                 <constraint firstAttribute="centerX" secondItem="E8k-cd-ojU" secondAttribute="centerX" id="ZJN-m8-qrM"/>
                                                 <constraint firstItem="VBS-Y1-4M2" firstAttribute="top" secondItem="4wd-n6-Mh0" secondAttribute="top" constant="16" id="qSE-ey-1X1"/>
-                                                <constraint firstAttribute="centerY" secondItem="E8k-cd-ojU" secondAttribute="centerY" constant="-5" id="ukO-ik-qGz"/>
+                                                <constraint firstAttribute="centerY" secondItem="E8k-cd-ojU" secondAttribute="centerY" constant="-10" id="ukO-ik-qGz"/>
                                             </constraints>
                                             <variation key="default">
                                                 <mask key="constraints">
@@ -1041,13 +1041,13 @@
                                             <rect key="frame" x="300" y="0.0" width="292" height="100"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="56,613" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ubr-tF-ZJH">
-                                                    <rect key="frame" x="107" y="33" width="78" height="35"/>
+                                                    <rect key="frame" x="107" y="43" width="78" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgE-C0-FH2">
-                                                    <rect key="frame" x="131" y="18" width="30" height="14"/>
+                                                    <rect key="frame" x="131" y="28" width="30" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -1056,7 +1056,7 @@
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstAttribute="centerX" secondItem="xgE-C0-FH2" secondAttribute="centerX" id="SCT-hW-jsQ"/>
-                                                <constraint firstAttribute="centerY" secondItem="ubr-tF-ZJH" secondAttribute="centerY" id="Wqa-gi-zUw"/>
+                                                <constraint firstAttribute="centerY" secondItem="ubr-tF-ZJH" secondAttribute="centerY" constant="-10" id="Wqa-gi-zUw"/>
                                                 <constraint firstAttribute="centerX" secondItem="ubr-tF-ZJH" secondAttribute="centerX" id="wBA-oZ-qcD"/>
                                                 <constraint firstItem="ubr-tF-ZJH" firstAttribute="top" secondItem="xgE-C0-FH2" secondAttribute="baseline" constant="4" id="ypR-lp-Kkw"/>
                                             </constraints>
@@ -1111,7 +1111,7 @@
                                                     </constraints>
                                                 </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jsj-wA-qH3" userLabel="Horizontal Divider View">
-                                                    <rect key="frame" x="8" y="65" width="284" height="1"/>
+                                                    <rect key="frame" x="-8" y="65" width="300" height="1"/>
                                                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="6Ig-k2-UjH"/>
@@ -1140,7 +1140,7 @@
                                             </subviews>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
-                                                <constraint firstItem="jsj-wA-qH3" firstAttribute="leading" secondItem="Nex-6V-DVP" secondAttribute="leadingMargin" id="2bq-i9-PF8"/>
+                                                <constraint firstItem="jsj-wA-qH3" firstAttribute="leading" secondItem="Nex-6V-DVP" secondAttribute="leading" constant="-8" id="2bq-i9-PF8"/>
                                                 <constraint firstItem="LLy-Md-Bib" firstAttribute="top" secondItem="Nex-6V-DVP" secondAttribute="top" constant="2" id="4Y5-1E-GWK"/>
                                                 <constraint firstAttribute="trailing" secondItem="MAq-BP-G8l" secondAttribute="trailing" id="4ZS-QK-Z9x"/>
                                                 <constraint firstAttribute="trailing" secondItem="jsj-wA-qH3" secondAttribute="trailing" id="AkG-Wx-CiN"/>
@@ -1232,7 +1232,7 @@
                                             <rect key="frame" x="300" y="0.0" width="292" height="66"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rto-Xl-3ts" userLabel="Horizontal Divider View">
-                                                    <rect key="frame" x="0.0" y="65" width="292" height="1"/>
+                                                    <rect key="frame" x="0.0" y="65" width="300" height="1"/>
                                                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="1" id="HmC-y0-zDt"/>
@@ -1267,7 +1267,7 @@
                                                 <constraint firstItem="nsE-Pg-YZQ" firstAttribute="top" secondItem="BcG-A8-ztZ" secondAttribute="top" constant="2" id="FsM-fH-MhU"/>
                                                 <constraint firstAttribute="centerX" secondItem="nsE-Pg-YZQ" secondAttribute="centerX" id="Hy7-d0-sTn"/>
                                                 <constraint firstAttribute="centerY" secondItem="pgb-E0-bmm" secondAttribute="centerY" constant="-5" id="dRE-bU-Oat"/>
-                                                <constraint firstAttribute="trailing" secondItem="rto-Xl-3ts" secondAttribute="trailing" id="r5b-5S-fMJ"/>
+                                                <constraint firstAttribute="trailing" secondItem="rto-Xl-3ts" secondAttribute="trailing" constant="-8" id="r5b-5S-fMJ"/>
                                                 <constraint firstItem="rto-Xl-3ts" firstAttribute="leading" secondItem="BcG-A8-ztZ" secondAttribute="leading" id="z1g-My-ZEb"/>
                                             </constraints>
                                         </view>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -24,8 +24,6 @@
             <string>OpenSans-Bold</string>
             <string>OpenSans-Bold</string>
             <string>OpenSans-Bold</string>
-            <string>OpenSans-Bold</string>
-            <string>OpenSans-Bold</string>
         </mutableArray>
         <mutableArray key="OpenSans-Regular.ttf">
             <string>OpenSans</string>
@@ -386,572 +384,497 @@
         <scene sceneID="5i3-b5-Lrb">
             <objects>
                 <tableViewController id="Pq6-gc-ScC" userLabel="Insights Table View Controller" customClass="InsightsTableViewController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="4oy-Og-Ww9">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="4oy-Og-Ww9">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="492"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490196078431" green="0.93725490196078431" blue="0.95686274509803926" alpha="1" colorSpace="calibratedRGB"/>
-                        <sections>
-                            <tableViewSection id="2LJ-18-NK2">
-                                <cells>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="ZVK-0y-VvO" customClass="StatsStandardBorderedTableViewCell">
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ZVK-0y-VvO" id="edL-Mo-vo7">
-                                            <autoresizingMask key="autoresizingMask"/>
+                        <prototypes>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="HeaderRow" id="ZVK-0y-VvO" userLabel="Header Row" customClass="InsightsSectionHeaderTableViewCell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="ZVK-0y-VvO" id="edL-Mo-vo7">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Most popular day and hour" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U94-Ix-7EC">
+                                            <rect key="frame" x="16" y="11" width="203" height="21"/>
+                                            <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="15"/>
+                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="U94-Ix-7EC" firstAttribute="leading" secondItem="edL-Mo-vo7" secondAttribute="leadingMargin" constant="8" id="AR7-lj-Sdb"/>
+                                        <constraint firstAttribute="centerY" secondItem="U94-Ix-7EC" secondAttribute="centerY" id="bd4-tT-Uyc"/>
+                                        <constraint firstAttribute="centerY" secondItem="U94-Ix-7EC" secondAttribute="centerY" id="yxW-O8-hnK"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="MostPopularDetails" rowHeight="150" id="qq2-Vb-czH" userLabel="Most Popular Details" customClass="InsightsMostPopularTableViewCell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="qq2-Vb-czH" id="UXn-1E-rBv">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="voB-PG-oGO">
+                                            <rect key="frame" x="300" y="0.0" width="292" height="149"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Most popular day and hour" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U94-Ix-7EC">
-                                                    <rect key="frame" x="16" y="11" width="203" height="21"/>
-                                                    <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="15"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8% of Daily Views" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="txh-pI-huu">
+                                                    <rect key="frame" x="94" y="107" width="105" height="18"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="13"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="9 AM" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xx2-Ii-OSN">
+                                                    <rect key="frame" x="108" y="53" width="76" height="44"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="32"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MOST POPULAR HOUR" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="owa-7G-DL9">
+                                                    <rect key="frame" x="77" y="24" width="139" height="18"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="13"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="U94-Ix-7EC" firstAttribute="leading" secondItem="edL-Mo-vo7" secondAttribute="leadingMargin" constant="8" id="AR7-lj-Sdb"/>
-                                                <constraint firstAttribute="centerY" secondItem="U94-Ix-7EC" secondAttribute="centerY" id="bd4-tT-Uyc"/>
-                                                <constraint firstAttribute="centerY" secondItem="U94-Ix-7EC" secondAttribute="centerY" id="yxW-O8-hnK"/>
+                                                <constraint firstItem="owa-7G-DL9" firstAttribute="top" secondItem="voB-PG-oGO" secondAttribute="top" constant="24" id="37A-zt-rpu"/>
+                                                <constraint firstAttribute="centerY" secondItem="xx2-Ii-OSN" secondAttribute="centerY" id="4CI-Bt-hhp"/>
+                                                <constraint firstItem="xx2-Ii-OSN" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="voB-PG-oGO" secondAttribute="leading" constant="8" id="B4c-jZ-Pfy"/>
+                                                <constraint firstAttribute="centerX" secondItem="xx2-Ii-OSN" secondAttribute="centerX" id="HQd-KW-3hY"/>
+                                                <constraint firstAttribute="centerX" secondItem="txh-pI-huu" secondAttribute="centerX" id="IUk-cX-Yd5"/>
+                                                <constraint firstAttribute="bottom" secondItem="txh-pI-huu" secondAttribute="bottom" constant="24" id="cIs-6l-p9A"/>
+                                                <constraint firstAttribute="centerX" secondItem="owa-7G-DL9" secondAttribute="centerX" id="iay-6G-WoS"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xx2-Ii-OSN" secondAttribute="trailing" constant="8" id="mam-0i-kkd"/>
                                             </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="150" id="qq2-Vb-czH" customClass="StatsStandardBorderedTableViewCell">
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="qq2-Vb-czH" id="UXn-1E-rBv">
-                                            <autoresizingMask key="autoresizingMask"/>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="csy-iV-Ucm">
+                                            <rect key="frame" x="8" y="0.0" width="292" height="149"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="voB-PG-oGO">
-                                                    <rect key="frame" x="300" y="0.0" width="292" height="149"/>
-                                                    <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="8% of Daily Views" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="txh-pI-huu">
-                                                            <rect key="frame" x="94" y="107" width="105" height="18"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="13"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="9 AM" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xx2-Ii-OSN">
-                                                            <rect key="frame" x="108" y="53" width="76" height="44"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="32"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MOST POPULAR HOUR" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="owa-7G-DL9">
-                                                            <rect key="frame" x="77" y="24" width="139" height="18"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="13"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstItem="owa-7G-DL9" firstAttribute="top" secondItem="voB-PG-oGO" secondAttribute="top" constant="24" id="37A-zt-rpu"/>
-                                                        <constraint firstAttribute="centerY" secondItem="xx2-Ii-OSN" secondAttribute="centerY" id="4CI-Bt-hhp"/>
-                                                        <constraint firstItem="xx2-Ii-OSN" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="voB-PG-oGO" secondAttribute="leading" constant="8" id="B4c-jZ-Pfy"/>
-                                                        <constraint firstAttribute="centerX" secondItem="xx2-Ii-OSN" secondAttribute="centerX" id="HQd-KW-3hY"/>
-                                                        <constraint firstAttribute="centerX" secondItem="txh-pI-huu" secondAttribute="centerX" id="IUk-cX-Yd5"/>
-                                                        <constraint firstAttribute="bottom" secondItem="txh-pI-huu" secondAttribute="bottom" constant="24" id="cIs-6l-p9A"/>
-                                                        <constraint firstAttribute="centerX" secondItem="owa-7G-DL9" secondAttribute="centerX" id="iay-6G-WoS"/>
-                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xx2-Ii-OSN" secondAttribute="trailing" constant="8" id="mam-0i-kkd"/>
-                                                    </constraints>
-                                                </view>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="csy-iV-Ucm">
-                                                    <rect key="frame" x="8" y="0.0" width="292" height="149"/>
-                                                    <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="31% of Weekly Views" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yKD-YK-Mra">
-                                                            <rect key="frame" x="83" y="107" width="126" height="18"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="13"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wednesday" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dPU-t1-atl">
-                                                            <rect key="frame" x="59" y="53" width="174" height="44"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="32"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MOST POPULAR DAY" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LqR-Vc-rtl">
-                                                            <rect key="frame" x="83" y="24" width="127" height="18"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="13"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstItem="dPU-t1-atl" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="csy-iV-Ucm" secondAttribute="leading" constant="8" id="K0Z-Ad-MXx"/>
-                                                        <constraint firstAttribute="centerY" secondItem="dPU-t1-atl" secondAttribute="centerY" id="QNp-Jv-nqR"/>
-                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dPU-t1-atl" secondAttribute="trailing" constant="8" id="Ur8-JD-cSM"/>
-                                                        <constraint firstAttribute="bottom" secondItem="yKD-YK-Mra" secondAttribute="bottom" constant="24" id="cAv-5w-Qdq"/>
-                                                        <constraint firstItem="LqR-Vc-rtl" firstAttribute="top" secondItem="csy-iV-Ucm" secondAttribute="top" constant="24" id="goK-qU-22u"/>
-                                                        <constraint firstAttribute="centerX" secondItem="dPU-t1-atl" secondAttribute="centerX" id="pTv-hu-BaW"/>
-                                                        <constraint firstAttribute="centerX" secondItem="yKD-YK-Mra" secondAttribute="centerX" id="yHd-Oh-E3K"/>
-                                                        <constraint firstAttribute="centerX" secondItem="LqR-Vc-rtl" secondAttribute="centerX" id="yzq-6H-kYH"/>
-                                                    </constraints>
-                                                </view>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="csy-iV-Ucm" secondAttribute="bottom" id="69K-aX-UO7"/>
-                                                <constraint firstItem="voB-PG-oGO" firstAttribute="width" secondItem="csy-iV-Ucm" secondAttribute="width" id="AUB-Se-HlE"/>
-                                                <constraint firstItem="voB-PG-oGO" firstAttribute="top" secondItem="UXn-1E-rBv" secondAttribute="top" id="Qsr-4m-hkK"/>
-                                                <constraint firstItem="csy-iV-Ucm" firstAttribute="top" secondItem="UXn-1E-rBv" secondAttribute="top" id="Vbp-A9-nK2"/>
-                                                <constraint firstItem="csy-iV-Ucm" firstAttribute="leading" secondItem="UXn-1E-rBv" secondAttribute="leading" constant="8" id="hKR-R8-ddr"/>
-                                                <constraint firstAttribute="trailing" secondItem="voB-PG-oGO" secondAttribute="trailing" constant="8" id="k5a-N4-Q9a"/>
-                                                <constraint firstAttribute="bottom" secondItem="voB-PG-oGO" secondAttribute="bottom" id="n8E-Ll-xml"/>
-                                                <constraint firstItem="voB-PG-oGO" firstAttribute="leading" secondItem="csy-iV-Ucm" secondAttribute="trailing" id="oEx-Lh-kER"/>
-                                            </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection id="dIL-dV-nrd">
-                                <cells>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" id="i1h-1J-qpN" customClass="StatsStandardBorderedTableViewCell">
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="i1h-1J-qpN" id="2k5-0G-j9V">
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="All-time posts, views, and visitors" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5F3-oE-jzA">
-                                                    <rect key="frame" x="16" y="11" width="250" height="21"/>
-                                                    <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="15"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="31% of Weekly Views" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yKD-YK-Mra">
+                                                    <rect key="frame" x="83" y="107" width="126" height="18"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="13"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wednesday" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dPU-t1-atl">
+                                                    <rect key="frame" x="59" y="53" width="174" height="44"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="32"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MOST POPULAR DAY" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LqR-Vc-rtl">
+                                                    <rect key="frame" x="83" y="24" width="127" height="18"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="13"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="5F3-oE-jzA" firstAttribute="leading" secondItem="2k5-0G-j9V" secondAttribute="leadingMargin" constant="8" id="IrY-8n-Jbk"/>
-                                                <constraint firstAttribute="centerY" secondItem="5F3-oE-jzA" secondAttribute="centerY" id="TEn-Ov-gh7"/>
+                                                <constraint firstItem="dPU-t1-atl" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="csy-iV-Ucm" secondAttribute="leading" constant="8" id="K0Z-Ad-MXx"/>
+                                                <constraint firstAttribute="centerY" secondItem="dPU-t1-atl" secondAttribute="centerY" id="QNp-Jv-nqR"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dPU-t1-atl" secondAttribute="trailing" constant="8" id="Ur8-JD-cSM"/>
+                                                <constraint firstAttribute="bottom" secondItem="yKD-YK-Mra" secondAttribute="bottom" constant="24" id="cAv-5w-Qdq"/>
+                                                <constraint firstItem="LqR-Vc-rtl" firstAttribute="top" secondItem="csy-iV-Ucm" secondAttribute="top" constant="24" id="goK-qU-22u"/>
+                                                <constraint firstAttribute="centerX" secondItem="dPU-t1-atl" secondAttribute="centerX" id="pTv-hu-BaW"/>
+                                                <constraint firstAttribute="centerX" secondItem="yKD-YK-Mra" secondAttribute="centerX" id="yHd-Oh-E3K"/>
+                                                <constraint firstAttribute="centerX" secondItem="LqR-Vc-rtl" secondAttribute="centerX" id="yzq-6H-kYH"/>
                                             </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="100" id="3Mz-H6-0pu" customClass="StatsStandardBorderedTableViewCell">
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3Mz-H6-0pu" id="tND-dE-Btv">
-                                            <autoresizingMask key="autoresizingMask"/>
+                                        </view>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="csy-iV-Ucm" secondAttribute="bottom" id="69K-aX-UO7"/>
+                                        <constraint firstItem="voB-PG-oGO" firstAttribute="width" secondItem="csy-iV-Ucm" secondAttribute="width" id="AUB-Se-HlE"/>
+                                        <constraint firstItem="voB-PG-oGO" firstAttribute="top" secondItem="UXn-1E-rBv" secondAttribute="top" id="Qsr-4m-hkK"/>
+                                        <constraint firstItem="csy-iV-Ucm" firstAttribute="top" secondItem="UXn-1E-rBv" secondAttribute="top" id="Vbp-A9-nK2"/>
+                                        <constraint firstItem="csy-iV-Ucm" firstAttribute="leading" secondItem="UXn-1E-rBv" secondAttribute="leading" constant="8" id="hKR-R8-ddr"/>
+                                        <constraint firstAttribute="trailing" secondItem="voB-PG-oGO" secondAttribute="trailing" constant="8" id="k5a-N4-Q9a"/>
+                                        <constraint firstAttribute="bottom" secondItem="voB-PG-oGO" secondAttribute="bottom" id="n8E-Ll-xml"/>
+                                        <constraint firstItem="voB-PG-oGO" firstAttribute="leading" secondItem="csy-iV-Ucm" secondAttribute="trailing" id="oEx-Lh-kER"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AllTimeDetails" rowHeight="100" id="3Mz-H6-0pu" userLabel="All Time Details" customClass="InsightsAllTimeTableViewCell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3Mz-H6-0pu" id="tND-dE-Btv">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cPN-KE-hdr">
+                                            <rect key="frame" x="8" y="0.0" width="146" height="99"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cPN-KE-hdr">
-                                                    <rect key="frame" x="8" y="0.0" width="146" height="99"/>
-                                                    <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="128" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kyf-cc-9Pz">
-                                                            <rect key="frame" x="52" y="42" width="43" height="35"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POSTS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qTg-V3-QrG">
-                                                            <rect key="frame" x="58" y="27" width="31" height="14"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PUF-YG-InB" userLabel="Divider View">
-                                                            <rect key="frame" x="145" y="16" width="1" height="67"/>
-                                                            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="1" id="vqB-sa-51J"/>
-                                                            </constraints>
-                                                        </view>
-                                                    </subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="128" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kyf-cc-9Pz">
+                                                    <rect key="frame" x="52" y="42" width="43" height="35"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POSTS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qTg-V3-QrG">
+                                                    <rect key="frame" x="58" y="27" width="31" height="14"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PUF-YG-InB" userLabel="Divider View">
+                                                    <rect key="frame" x="145" y="16" width="1" height="67"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                                                     <constraints>
-                                                        <constraint firstItem="PUF-YG-InB" firstAttribute="top" secondItem="cPN-KE-hdr" secondAttribute="top" constant="16" id="0jy-Qu-MCM"/>
-                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kyf-cc-9Pz" secondAttribute="trailing" constant="8" id="7ZE-R0-YlR"/>
-                                                        <constraint firstItem="qTg-V3-QrG" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="cPN-KE-hdr" secondAttribute="leading" constant="4" id="Kbw-tA-dub"/>
-                                                        <constraint firstAttribute="centerX" secondItem="kyf-cc-9Pz" secondAttribute="centerX" id="OcQ-Hd-fKy"/>
-                                                        <constraint firstAttribute="centerX" secondItem="qTg-V3-QrG" secondAttribute="centerX" id="OtF-0g-um5"/>
-                                                        <constraint firstItem="kyf-cc-9Pz" firstAttribute="top" secondItem="qTg-V3-QrG" secondAttribute="baseline" constant="4" id="QO6-x7-uck"/>
-                                                        <constraint firstAttribute="trailing" secondItem="PUF-YG-InB" secondAttribute="trailing" id="Snq-2U-n55"/>
-                                                        <constraint firstAttribute="bottom" secondItem="PUF-YG-InB" secondAttribute="bottom" constant="16" id="UNd-Dn-DGe"/>
-                                                        <constraint firstAttribute="centerY" secondItem="kyf-cc-9Pz" secondAttribute="centerY" constant="-10" id="WPq-Kq-LbB"/>
-                                                        <constraint firstItem="kyf-cc-9Pz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="cPN-KE-hdr" secondAttribute="leading" constant="8" id="bJ0-aX-Ax5"/>
-                                                        <constraint firstItem="PUF-YG-InB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="qTg-V3-QrG" secondAttribute="trailing" constant="4" id="exk-OG-SRH"/>
-                                                    </constraints>
-                                                </view>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="M8I-iH-ljE">
-                                                    <rect key="frame" x="300" y="0.0" width="146" height="99"/>
-                                                    <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="42,837" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="RsC-iV-YWj">
-                                                            <rect key="frame" x="34" y="42" width="78" height="35"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VISITORS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ixp-TF-kKn">
-                                                            <rect key="frame" x="52" y="27" width="43" height="14"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ivs-sp-86o" userLabel="Divider View">
-                                                            <rect key="frame" x="145" y="16" width="1" height="67"/>
-                                                            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="1" id="6MY-sk-Hkv"/>
-                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="OjC-OG-14l"/>
-                                                            </constraints>
-                                                        </view>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstItem="RsC-iV-YWj" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="M8I-iH-ljE" secondAttribute="leading" constant="8" id="HXD-18-Amr"/>
-                                                        <constraint firstAttribute="centerY" secondItem="RsC-iV-YWj" secondAttribute="centerY" constant="-10" id="HZ1-Sj-KwE"/>
-                                                        <constraint firstAttribute="trailing" secondItem="Ivs-sp-86o" secondAttribute="trailing" id="RRe-Ng-fX8"/>
-                                                        <constraint firstAttribute="centerX" secondItem="RsC-iV-YWj" secondAttribute="centerX" id="RnX-5H-bvV"/>
-                                                        <constraint firstItem="Ivs-sp-86o" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Ixp-TF-kKn" secondAttribute="trailing" constant="4" id="S9G-0o-cRR"/>
-                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="RsC-iV-YWj" secondAttribute="trailing" constant="8" id="Wl6-3G-6lG"/>
-                                                        <constraint firstAttribute="centerX" secondItem="Ixp-TF-kKn" secondAttribute="centerX" id="Xtq-TV-vri"/>
-                                                        <constraint firstItem="Ixp-TF-kKn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="M8I-iH-ljE" secondAttribute="leading" constant="4" id="aeR-jN-dQG"/>
-                                                        <constraint firstItem="Ivs-sp-86o" firstAttribute="top" secondItem="M8I-iH-ljE" secondAttribute="top" constant="16" id="uf2-0a-OGv"/>
-                                                        <constraint firstAttribute="bottom" secondItem="Ivs-sp-86o" secondAttribute="bottom" constant="16" id="vcO-TQ-U6C"/>
-                                                        <constraint firstItem="RsC-iV-YWj" firstAttribute="top" secondItem="Ixp-TF-kKn" secondAttribute="baseline" constant="4" id="xNd-4M-1Cm"/>
-                                                    </constraints>
-                                                </view>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HV6-Cx-Ceh">
-                                                    <rect key="frame" x="446" y="0.0" width="146" height="99"/>
-                                                    <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3,485" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bhJ-yf-eeg">
-                                                            <rect key="frame" x="41" y="42" width="64" height="35"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BEST VIEWS EVER" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Ml6-Iu-wKc">
-                                                            <rect key="frame" x="33" y="27" width="81" height="14"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="APRIL 4, 2015" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p0T-y9-dQS">
-                                                            <rect key="frame" x="42" y="77" width="63" height="14"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstAttribute="centerX" secondItem="p0T-y9-dQS" secondAttribute="centerX" id="7BY-d3-qHL"/>
-                                                        <constraint firstItem="bhJ-yf-eeg" firstAttribute="top" secondItem="Ml6-Iu-wKc" secondAttribute="baseline" constant="4" id="7oe-du-RhP"/>
-                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ml6-Iu-wKc" secondAttribute="trailing" constant="4" id="EPy-f0-OFa"/>
-                                                        <constraint firstItem="bhJ-yf-eeg" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HV6-Cx-Ceh" secondAttribute="leading" constant="8" id="EnY-AB-i8L"/>
-                                                        <constraint firstAttribute="centerY" secondItem="bhJ-yf-eeg" secondAttribute="centerY" constant="-10" id="MsL-TP-Tcu"/>
-                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bhJ-yf-eeg" secondAttribute="trailing" constant="8" id="OAK-77-sJl"/>
-                                                        <constraint firstAttribute="bottom" secondItem="p0T-y9-dQS" secondAttribute="bottom" constant="8" id="OEI-1U-kyY"/>
-                                                        <constraint firstAttribute="centerX" secondItem="Ml6-Iu-wKc" secondAttribute="centerX" id="Vms-tu-r8l"/>
-                                                        <constraint firstItem="Ml6-Iu-wKc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HV6-Cx-Ceh" secondAttribute="leading" constant="4" id="a2a-HS-wm7"/>
-                                                        <constraint firstAttribute="centerX" secondItem="bhJ-yf-eeg" secondAttribute="centerX" id="k0v-Iw-UvW"/>
-                                                    </constraints>
-                                                </view>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EjH-b5-iye">
-                                                    <rect key="frame" x="154" y="0.0" width="146" height="99"/>
-                                                    <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="56,613" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="qJ0-wu-bhs">
-                                                            <rect key="frame" x="34" y="42" width="78" height="35"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SnZ-To-N2p">
-                                                            <rect key="frame" x="58" y="27" width="30" height="14"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
-                                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2hi-jg-tAu" userLabel="Divider View">
-                                                            <rect key="frame" x="145" y="16" width="1" height="67"/>
-                                                            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="1" id="D6P-Mf-BF2"/>
-                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="l2Q-Yx-j14"/>
-                                                            </constraints>
-                                                        </view>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstItem="qJ0-wu-bhs" firstAttribute="top" secondItem="SnZ-To-N2p" secondAttribute="baseline" constant="4" id="05o-9U-N1M"/>
-                                                        <constraint firstAttribute="centerX" secondItem="qJ0-wu-bhs" secondAttribute="centerX" id="3nN-pK-3qh"/>
-                                                        <constraint firstItem="2hi-jg-tAu" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="SnZ-To-N2p" secondAttribute="trailing" constant="4" id="5on-de-1E6"/>
-                                                        <constraint firstItem="SnZ-To-N2p" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="EjH-b5-iye" secondAttribute="leading" constant="4" id="7Yr-UL-JZX"/>
-                                                        <constraint firstAttribute="trailing" secondItem="2hi-jg-tAu" secondAttribute="trailing" id="WdE-ku-Rt0"/>
-                                                        <constraint firstAttribute="centerX" secondItem="SnZ-To-N2p" secondAttribute="centerX" id="X18-zZ-WsS"/>
-                                                        <constraint firstItem="2hi-jg-tAu" firstAttribute="top" secondItem="EjH-b5-iye" secondAttribute="top" constant="16" id="bE1-1l-Tlz"/>
-                                                        <constraint firstAttribute="bottom" secondItem="2hi-jg-tAu" secondAttribute="bottom" constant="16" id="jfU-bG-Wxi"/>
-                                                        <constraint firstItem="qJ0-wu-bhs" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="EjH-b5-iye" secondAttribute="leading" constant="8" id="k4d-4i-7pg"/>
-                                                        <constraint firstItem="2hi-jg-tAu" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="qJ0-wu-bhs" secondAttribute="trailing" constant="8" id="mUK-Kp-S9T"/>
-                                                        <constraint firstAttribute="centerY" secondItem="qJ0-wu-bhs" secondAttribute="centerY" constant="-10" id="wKk-z9-4dd"/>
+                                                        <constraint firstAttribute="width" constant="1" id="vqB-sa-51J"/>
                                                     </constraints>
                                                 </view>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="cPN-KE-hdr" firstAttribute="top" secondItem="tND-dE-Btv" secondAttribute="topMargin" constant="-8" id="0Ns-hB-RaH"/>
-                                                <constraint firstItem="HV6-Cx-Ceh" firstAttribute="leading" secondItem="M8I-iH-ljE" secondAttribute="trailing" id="1mA-nd-3VV"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="M8I-iH-ljE" secondAttribute="bottom" constant="-8" id="4vP-6g-SBD"/>
-                                                <constraint firstItem="M8I-iH-ljE" firstAttribute="width" secondItem="HV6-Cx-Ceh" secondAttribute="width" id="5uE-BQ-pMn"/>
-                                                <constraint firstAttribute="trailing" secondItem="HV6-Cx-Ceh" secondAttribute="trailing" constant="8" id="AaH-xr-qOs"/>
-                                                <constraint firstItem="M8I-iH-ljE" firstAttribute="top" secondItem="tND-dE-Btv" secondAttribute="topMargin" constant="-8" id="DoO-Wf-NL0"/>
-                                                <constraint firstItem="M8I-iH-ljE" firstAttribute="width" secondItem="cPN-KE-hdr" secondAttribute="width" id="Jd3-xt-5BT"/>
-                                                <constraint firstItem="M8I-iH-ljE" firstAttribute="width" secondItem="EjH-b5-iye" secondAttribute="width" id="Jj2-lx-scT"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="EjH-b5-iye" secondAttribute="bottom" constant="-8" id="KkU-MA-2Qf"/>
-                                                <constraint firstItem="cPN-KE-hdr" firstAttribute="leading" secondItem="tND-dE-Btv" secondAttribute="leading" constant="8" id="V1o-Tw-coq"/>
-                                                <constraint firstItem="EjH-b5-iye" firstAttribute="top" secondItem="tND-dE-Btv" secondAttribute="topMargin" constant="-8" id="bzc-Rd-Z2B"/>
-                                                <constraint firstItem="EjH-b5-iye" firstAttribute="leading" secondItem="cPN-KE-hdr" secondAttribute="trailing" id="dNr-RP-GCN"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="HV6-Cx-Ceh" secondAttribute="bottom" constant="-8" id="hY5-xp-HfI"/>
-                                                <constraint firstItem="M8I-iH-ljE" firstAttribute="leading" secondItem="EjH-b5-iye" secondAttribute="trailing" id="kPt-Z6-iqL"/>
-                                                <constraint firstItem="HV6-Cx-Ceh" firstAttribute="top" secondItem="tND-dE-Btv" secondAttribute="topMargin" constant="-8" id="nbZ-fv-6OF"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="cPN-KE-hdr" secondAttribute="bottom" constant="-8" id="sun-Ek-hFD"/>
+                                                <constraint firstItem="PUF-YG-InB" firstAttribute="top" secondItem="cPN-KE-hdr" secondAttribute="top" constant="16" id="0jy-Qu-MCM"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kyf-cc-9Pz" secondAttribute="trailing" constant="8" id="7ZE-R0-YlR"/>
+                                                <constraint firstItem="qTg-V3-QrG" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="cPN-KE-hdr" secondAttribute="leading" constant="4" id="Kbw-tA-dub"/>
+                                                <constraint firstAttribute="centerX" secondItem="kyf-cc-9Pz" secondAttribute="centerX" id="OcQ-Hd-fKy"/>
+                                                <constraint firstAttribute="centerX" secondItem="qTg-V3-QrG" secondAttribute="centerX" id="OtF-0g-um5"/>
+                                                <constraint firstItem="kyf-cc-9Pz" firstAttribute="top" secondItem="qTg-V3-QrG" secondAttribute="baseline" constant="4" id="QO6-x7-uck"/>
+                                                <constraint firstAttribute="trailing" secondItem="PUF-YG-InB" secondAttribute="trailing" id="Snq-2U-n55"/>
+                                                <constraint firstAttribute="bottom" secondItem="PUF-YG-InB" secondAttribute="bottom" constant="16" id="UNd-Dn-DGe"/>
+                                                <constraint firstAttribute="centerY" secondItem="kyf-cc-9Pz" secondAttribute="centerY" constant="-10" id="WPq-Kq-LbB"/>
+                                                <constraint firstItem="kyf-cc-9Pz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="cPN-KE-hdr" secondAttribute="leading" constant="8" id="bJ0-aX-Ax5"/>
+                                                <constraint firstItem="PUF-YG-InB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="qTg-V3-QrG" secondAttribute="trailing" constant="4" id="exk-OG-SRH"/>
                                             </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection id="HRF-1A-qLk">
-                                <cells>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="8Pa-qA-6le" customClass="StatsStandardBorderedTableViewCell">
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="8Pa-qA-6le" id="Cho-Tr-KXc">
-                                            <autoresizingMask key="autoresizingMask"/>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="M8I-iH-ljE">
+                                            <rect key="frame" x="300" y="0.0" width="146" height="99"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Today's Stats" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FV4-Ej-Neu">
-                                                    <rect key="frame" x="16" y="11" width="98" height="21"/>
-                                                    <fontDescription key="fontDescription" name="OpenSans-Bold" family="Open Sans" pointSize="15"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="42,837" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="RsC-iV-YWj">
+                                                    <rect key="frame" x="34" y="42" width="78" height="35"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VISITORS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ixp-TF-kKn">
+                                                    <rect key="frame" x="52" y="27" width="43" height="14"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ivs-sp-86o" userLabel="Divider View">
+                                                    <rect key="frame" x="145" y="16" width="1" height="67"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="1" id="6MY-sk-Hkv"/>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="OjC-OG-14l"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="RsC-iV-YWj" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="M8I-iH-ljE" secondAttribute="leading" constant="8" id="HXD-18-Amr"/>
+                                                <constraint firstAttribute="centerY" secondItem="RsC-iV-YWj" secondAttribute="centerY" constant="-10" id="HZ1-Sj-KwE"/>
+                                                <constraint firstAttribute="trailing" secondItem="Ivs-sp-86o" secondAttribute="trailing" id="RRe-Ng-fX8"/>
+                                                <constraint firstAttribute="centerX" secondItem="RsC-iV-YWj" secondAttribute="centerX" id="RnX-5H-bvV"/>
+                                                <constraint firstItem="Ivs-sp-86o" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Ixp-TF-kKn" secondAttribute="trailing" constant="4" id="S9G-0o-cRR"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="RsC-iV-YWj" secondAttribute="trailing" constant="8" id="Wl6-3G-6lG"/>
+                                                <constraint firstAttribute="centerX" secondItem="Ixp-TF-kKn" secondAttribute="centerX" id="Xtq-TV-vri"/>
+                                                <constraint firstItem="Ixp-TF-kKn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="M8I-iH-ljE" secondAttribute="leading" constant="4" id="aeR-jN-dQG"/>
+                                                <constraint firstItem="Ivs-sp-86o" firstAttribute="top" secondItem="M8I-iH-ljE" secondAttribute="top" constant="16" id="uf2-0a-OGv"/>
+                                                <constraint firstAttribute="bottom" secondItem="Ivs-sp-86o" secondAttribute="bottom" constant="16" id="vcO-TQ-U6C"/>
+                                                <constraint firstItem="RsC-iV-YWj" firstAttribute="top" secondItem="Ixp-TF-kKn" secondAttribute="baseline" constant="4" id="xNd-4M-1Cm"/>
+                                            </constraints>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HV6-Cx-Ceh">
+                                            <rect key="frame" x="446" y="0.0" width="146" height="99"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3,485" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bhJ-yf-eeg">
+                                                    <rect key="frame" x="41" y="42" width="64" height="35"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BEST VIEWS EVER" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Ml6-Iu-wKc">
+                                                    <rect key="frame" x="33" y="27" width="81" height="14"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="APRIL 4, 2015" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p0T-y9-dQS">
+                                                    <rect key="frame" x="42" y="77" width="63" height="14"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="FV4-Ej-Neu" firstAttribute="leading" secondItem="Cho-Tr-KXc" secondAttribute="leadingMargin" constant="8" id="TR3-F3-DM8"/>
-                                                <constraint firstAttribute="centerY" secondItem="FV4-Ej-Neu" secondAttribute="centerY" id="uPp-t5-dyE"/>
+                                                <constraint firstAttribute="centerX" secondItem="p0T-y9-dQS" secondAttribute="centerX" id="7BY-d3-qHL"/>
+                                                <constraint firstItem="bhJ-yf-eeg" firstAttribute="top" secondItem="Ml6-Iu-wKc" secondAttribute="baseline" constant="4" id="7oe-du-RhP"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ml6-Iu-wKc" secondAttribute="trailing" constant="4" id="EPy-f0-OFa"/>
+                                                <constraint firstItem="bhJ-yf-eeg" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HV6-Cx-Ceh" secondAttribute="leading" constant="8" id="EnY-AB-i8L"/>
+                                                <constraint firstAttribute="centerY" secondItem="bhJ-yf-eeg" secondAttribute="centerY" constant="-10" id="MsL-TP-Tcu"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bhJ-yf-eeg" secondAttribute="trailing" constant="8" id="OAK-77-sJl"/>
+                                                <constraint firstAttribute="bottom" secondItem="p0T-y9-dQS" secondAttribute="bottom" constant="8" id="OEI-1U-kyY"/>
+                                                <constraint firstAttribute="centerX" secondItem="Ml6-Iu-wKc" secondAttribute="centerX" id="Vms-tu-r8l"/>
+                                                <constraint firstItem="Ml6-Iu-wKc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HV6-Cx-Ceh" secondAttribute="leading" constant="4" id="a2a-HS-wm7"/>
+                                                <constraint firstAttribute="centerX" secondItem="bhJ-yf-eeg" secondAttribute="centerX" id="k0v-Iw-UvW"/>
                                             </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="66" id="dRE-rs-NGi" customClass="StatsStandardBorderedTableViewCell">
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dRE-rs-NGi" id="hTu-9f-WBB">
-                                            <autoresizingMask key="autoresizingMask"/>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EjH-b5-iye">
+                                            <rect key="frame" x="154" y="0.0" width="146" height="99"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iwI-u2-AsI">
-                                                    <rect key="frame" x="300" y="0.0" width="146" height="65"/>
-                                                    <subviews>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AgS-4W-V5O" userLabel="Divider View">
-                                                            <rect key="frame" x="145" y="0.0" width="1" height="65"/>
-                                                            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="1" id="Qbv-PO-urv"/>
-                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="cb8-Pp-7FM"/>
-                                                            </constraints>
-                                                        </view>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ab2-8S-y1h">
-                                                            <rect key="frame" x="58" y="2" width="30" height="26"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
-                                                            <state key="normal" title="LIKES">
-                                                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </state>
-                                                            <connections>
-                                                                <action selector="switchToTodayLikes:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="kHf-gG-cP6"/>
-                                                            </connections>
-                                                        </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6H5-sV-soQ">
-                                                            <rect key="frame" x="8" y="21" width="130" height="34"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
-                                                            <state key="normal" title="0">
-                                                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </state>
-                                                            <connections>
-                                                                <action selector="switchToTodayLikes:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="4Qm-FM-g9S"/>
-                                                            </connections>
-                                                        </button>
-                                                    </subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="56,613" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="qJ0-wu-bhs">
+                                                    <rect key="frame" x="34" y="42" width="78" height="35"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SnZ-To-N2p">
+                                                    <rect key="frame" x="58" y="27" width="30" height="14"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2hi-jg-tAu" userLabel="Divider View">
+                                                    <rect key="frame" x="145" y="16" width="1" height="67"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                                                     <constraints>
-                                                        <constraint firstItem="ab2-8S-y1h" firstAttribute="top" secondItem="iwI-u2-AsI" secondAttribute="top" constant="2" id="A0d-Sf-gsB"/>
-                                                        <constraint firstAttribute="centerX" secondItem="ab2-8S-y1h" secondAttribute="centerX" id="GrT-pM-NhK"/>
-                                                        <constraint firstItem="AgS-4W-V5O" firstAttribute="top" secondItem="iwI-u2-AsI" secondAttribute="top" id="Hft-uX-HKa"/>
-                                                        <constraint firstAttribute="centerX" secondItem="6H5-sV-soQ" secondAttribute="centerX" id="JV4-3c-wB6"/>
-                                                        <constraint firstAttribute="bottom" secondItem="AgS-4W-V5O" secondAttribute="bottom" id="Pju-s6-nXU"/>
-                                                        <constraint firstAttribute="centerY" secondItem="6H5-sV-soQ" secondAttribute="centerY" constant="-5" id="Q8y-zS-ddH"/>
-                                                        <constraint firstItem="ab2-8S-y1h" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iwI-u2-AsI" secondAttribute="leading" constant="4" id="g8M-9i-KZk"/>
-                                                        <constraint firstItem="6H5-sV-soQ" firstAttribute="leading" secondItem="iwI-u2-AsI" secondAttribute="leading" constant="8" id="mw9-2n-KVJ"/>
-                                                        <constraint firstAttribute="trailing" secondItem="AgS-4W-V5O" secondAttribute="trailing" id="qqG-8p-P8C"/>
-                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ab2-8S-y1h" secondAttribute="trailing" constant="4" id="rFK-Ev-xJK"/>
-                                                        <constraint firstAttribute="trailing" secondItem="6H5-sV-soQ" secondAttribute="trailing" constant="8" id="sbJ-Up-jeE"/>
-                                                    </constraints>
-                                                </view>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vap-Tr-7k3">
-                                                    <rect key="frame" x="446" y="0.0" width="146" height="65"/>
-                                                    <subviews>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Xj-XK-eQ8">
-                                                            <rect key="frame" x="8" y="21" width="130" height="34"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
-                                                            <state key="normal" title="0">
-                                                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </state>
-                                                            <connections>
-                                                                <action selector="switchToTodayComments:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="KlF-nP-CW5"/>
-                                                            </connections>
-                                                        </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nUZ-Tg-WTV">
-                                                            <rect key="frame" x="45" y="2" width="57" height="26"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
-                                                            <state key="normal" title="COMMENTS">
-                                                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </state>
-                                                            <connections>
-                                                                <action selector="switchToTodayComments:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="LCB-GE-g5n"/>
-                                                            </connections>
-                                                        </button>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstItem="nUZ-Tg-WTV" firstAttribute="top" secondItem="vap-Tr-7k3" secondAttribute="top" constant="2" id="3ek-PM-QQy"/>
-                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="nUZ-Tg-WTV" secondAttribute="trailing" constant="4" id="CuI-Rq-qY5"/>
-                                                        <constraint firstAttribute="centerX" secondItem="nUZ-Tg-WTV" secondAttribute="centerX" id="Odz-dI-8CP"/>
-                                                        <constraint firstAttribute="centerX" secondItem="5Xj-XK-eQ8" secondAttribute="centerX" id="Oed-Ik-zRZ"/>
-                                                        <constraint firstAttribute="trailing" secondItem="5Xj-XK-eQ8" secondAttribute="trailing" constant="8" id="ZHI-eP-snC"/>
-                                                        <constraint firstAttribute="centerY" secondItem="5Xj-XK-eQ8" secondAttribute="centerY" constant="-5" id="mUv-gV-ozN"/>
-                                                        <constraint firstItem="5Xj-XK-eQ8" firstAttribute="leading" secondItem="vap-Tr-7k3" secondAttribute="leading" constant="8" id="qMK-bL-D0m"/>
-                                                        <constraint firstItem="nUZ-Tg-WTV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="vap-Tr-7k3" secondAttribute="leading" constant="4" id="vu7-k6-pBa"/>
-                                                    </constraints>
-                                                </view>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9TN-0u-X0e">
-                                                    <rect key="frame" x="154" y="0.0" width="146" height="65"/>
-                                                    <subviews>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZxX-Mc-USG" userLabel="Divider View">
-                                                            <rect key="frame" x="145" y="0.0" width="1" height="65"/>
-                                                            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="Z6a-z8-trh"/>
-                                                                <constraint firstAttribute="width" constant="1" id="apn-Vx-Jr3"/>
-                                                            </constraints>
-                                                        </view>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g6C-KQ-1fr">
-                                                            <rect key="frame" x="8" y="21" width="130" height="34"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
-                                                            <state key="normal" title="32">
-                                                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </state>
-                                                            <connections>
-                                                                <action selector="switchToTodayVisitors:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="tId-3p-i1R"/>
-                                                            </connections>
-                                                        </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g9y-bc-4NQ">
-                                                            <rect key="frame" x="52" y="2" width="43" height="26"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
-                                                            <state key="normal" title="VISITORS">
-                                                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </state>
-                                                            <connections>
-                                                                <action selector="switchToTodayVisitors:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="q2f-xD-KRm"/>
-                                                            </connections>
-                                                        </button>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstAttribute="bottom" secondItem="ZxX-Mc-USG" secondAttribute="bottom" id="5qc-Cv-4Ik"/>
-                                                        <constraint firstAttribute="centerY" secondItem="g6C-KQ-1fr" secondAttribute="centerY" constant="-5" id="Blp-e5-I6u"/>
-                                                        <constraint firstAttribute="trailing" secondItem="g6C-KQ-1fr" secondAttribute="trailing" constant="8" id="Bvc-yi-zCT"/>
-                                                        <constraint firstItem="g9y-bc-4NQ" firstAttribute="top" secondItem="9TN-0u-X0e" secondAttribute="top" constant="2" id="NeH-Vq-YXv"/>
-                                                        <constraint firstItem="g9y-bc-4NQ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="9TN-0u-X0e" secondAttribute="leading" constant="4" id="aIQ-9R-nN1"/>
-                                                        <constraint firstItem="g6C-KQ-1fr" firstAttribute="leading" secondItem="9TN-0u-X0e" secondAttribute="leading" constant="8" id="bN7-53-jhR"/>
-                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="g9y-bc-4NQ" secondAttribute="trailing" constant="4" id="bPV-Ha-wEo"/>
-                                                        <constraint firstAttribute="centerX" secondItem="g9y-bc-4NQ" secondAttribute="centerX" id="dv8-zC-3Gl"/>
-                                                        <constraint firstAttribute="centerX" secondItem="g6C-KQ-1fr" secondAttribute="centerX" id="k2A-eI-5bc"/>
-                                                        <constraint firstAttribute="trailing" secondItem="ZxX-Mc-USG" secondAttribute="trailing" id="nh0-lt-MLy"/>
-                                                        <constraint firstItem="ZxX-Mc-USG" firstAttribute="top" secondItem="9TN-0u-X0e" secondAttribute="top" id="zG1-hw-tEd"/>
-                                                    </constraints>
-                                                </view>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IwY-dz-TSD">
-                                                    <rect key="frame" x="8" y="0.0" width="146" height="65"/>
-                                                    <subviews>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gaP-FE-Uu4" userLabel="Divider View">
-                                                            <rect key="frame" x="145" y="0.0" width="1" height="65"/>
-                                                            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="1" id="GV0-JN-SmU"/>
-                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="KFA-Qw-kna"/>
-                                                            </constraints>
-                                                        </view>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nWH-aO-4eO">
-                                                            <rect key="frame" x="8" y="21" width="130" height="34"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
-                                                            <state key="normal" title="24">
-                                                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </state>
-                                                            <connections>
-                                                                <action selector="switchToTodayViews:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="38w-UC-aGe"/>
-                                                            </connections>
-                                                        </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Zp-vE-uY4">
-                                                            <rect key="frame" x="58" y="2" width="30" height="26"/>
-                                                            <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
-                                                            <state key="normal" title="VIEWS">
-                                                                <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                                            </state>
-                                                            <connections>
-                                                                <action selector="switchToTodayViews:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="NKu-zg-YtZ"/>
-                                                            </connections>
-                                                        </button>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="4Zp-vE-uY4" secondAttribute="trailing" constant="8" id="3cw-a4-bxo"/>
-                                                        <constraint firstAttribute="trailing" secondItem="nWH-aO-4eO" secondAttribute="trailing" constant="8" id="40X-oh-MUy"/>
-                                                        <constraint firstAttribute="bottom" secondItem="gaP-FE-Uu4" secondAttribute="bottom" id="Axi-gZ-Awi"/>
-                                                        <constraint firstAttribute="trailing" secondItem="gaP-FE-Uu4" secondAttribute="trailing" id="EkH-7F-gau"/>
-                                                        <constraint firstItem="gaP-FE-Uu4" firstAttribute="top" secondItem="IwY-dz-TSD" secondAttribute="top" id="GVr-LV-PG9"/>
-                                                        <constraint firstItem="4Zp-vE-uY4" firstAttribute="top" secondItem="IwY-dz-TSD" secondAttribute="top" constant="2" id="Lxc-JK-fz0"/>
-                                                        <constraint firstAttribute="centerX" secondItem="nWH-aO-4eO" secondAttribute="centerX" id="OIA-DZ-VXa"/>
-                                                        <constraint firstItem="4Zp-vE-uY4" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="IwY-dz-TSD" secondAttribute="leading" constant="8" id="TLQ-tw-3n3"/>
-                                                        <constraint firstItem="nWH-aO-4eO" firstAttribute="leading" secondItem="IwY-dz-TSD" secondAttribute="leading" constant="8" id="o8y-pA-k9z"/>
-                                                        <constraint firstAttribute="centerY" secondItem="nWH-aO-4eO" secondAttribute="centerY" constant="-5" id="oFU-Eg-zla"/>
-                                                        <constraint firstAttribute="centerX" secondItem="4Zp-vE-uY4" secondAttribute="centerX" id="oXs-bi-1ay"/>
+                                                        <constraint firstAttribute="width" constant="1" id="D6P-Mf-BF2"/>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="l2Q-Yx-j14"/>
                                                     </constraints>
                                                 </view>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="9TN-0u-X0e" firstAttribute="leading" secondItem="IwY-dz-TSD" secondAttribute="trailing" id="3KS-h0-4eW"/>
-                                                <constraint firstItem="vap-Tr-7k3" firstAttribute="leading" secondItem="iwI-u2-AsI" secondAttribute="trailing" id="5Ia-58-d9Y"/>
-                                                <constraint firstItem="IwY-dz-TSD" firstAttribute="leading" secondItem="hTu-9f-WBB" secondAttribute="leading" constant="8" id="73L-Nj-zNE"/>
-                                                <constraint firstItem="vap-Tr-7k3" firstAttribute="width" secondItem="IwY-dz-TSD" secondAttribute="width" id="776-Xz-gW1"/>
-                                                <constraint firstItem="vap-Tr-7k3" firstAttribute="height" secondItem="IwY-dz-TSD" secondAttribute="height" id="CQ0-2h-Rbn"/>
-                                                <constraint firstItem="vap-Tr-7k3" firstAttribute="width" secondItem="9TN-0u-X0e" secondAttribute="width" id="DPt-hA-MV2"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="9TN-0u-X0e" secondAttribute="bottom" constant="-8" id="Dte-jh-ayr"/>
-                                                <constraint firstItem="vap-Tr-7k3" firstAttribute="height" secondItem="9TN-0u-X0e" secondAttribute="height" id="Lml-1y-HFh"/>
-                                                <constraint firstItem="vap-Tr-7k3" firstAttribute="top" secondItem="hTu-9f-WBB" secondAttribute="topMargin" constant="-8" id="PVh-7i-STk"/>
-                                                <constraint firstItem="iwI-u2-AsI" firstAttribute="top" secondItem="hTu-9f-WBB" secondAttribute="topMargin" constant="-8" id="VOb-er-OA7"/>
-                                                <constraint firstItem="vap-Tr-7k3" firstAttribute="width" secondItem="iwI-u2-AsI" secondAttribute="width" id="Vp9-LB-y8H"/>
-                                                <constraint firstItem="IwY-dz-TSD" firstAttribute="top" secondItem="hTu-9f-WBB" secondAttribute="topMargin" constant="-8" id="bv5-Eq-P3j"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="vap-Tr-7k3" secondAttribute="bottom" constant="-8" id="co7-Fc-fhq"/>
-                                                <constraint firstItem="9TN-0u-X0e" firstAttribute="top" secondItem="hTu-9f-WBB" secondAttribute="topMargin" constant="-8" id="fKI-E9-F0O"/>
-                                                <constraint firstItem="vap-Tr-7k3" firstAttribute="height" secondItem="iwI-u2-AsI" secondAttribute="height" id="ijO-pt-Joh"/>
-                                                <constraint firstAttribute="trailing" secondItem="vap-Tr-7k3" secondAttribute="trailing" constant="8" id="ksp-CF-oxT"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="IwY-dz-TSD" secondAttribute="bottom" constant="-8" id="toQ-lz-mBi"/>
-                                                <constraint firstItem="iwI-u2-AsI" firstAttribute="leading" secondItem="9TN-0u-X0e" secondAttribute="trailing" id="vXJ-6j-BSo"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="iwI-u2-AsI" secondAttribute="bottom" constant="-8" id="xGZ-oC-qDY"/>
+                                                <constraint firstItem="qJ0-wu-bhs" firstAttribute="top" secondItem="SnZ-To-N2p" secondAttribute="baseline" constant="4" id="05o-9U-N1M"/>
+                                                <constraint firstAttribute="centerX" secondItem="qJ0-wu-bhs" secondAttribute="centerX" id="3nN-pK-3qh"/>
+                                                <constraint firstItem="2hi-jg-tAu" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="SnZ-To-N2p" secondAttribute="trailing" constant="4" id="5on-de-1E6"/>
+                                                <constraint firstItem="SnZ-To-N2p" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="EjH-b5-iye" secondAttribute="leading" constant="4" id="7Yr-UL-JZX"/>
+                                                <constraint firstAttribute="trailing" secondItem="2hi-jg-tAu" secondAttribute="trailing" id="WdE-ku-Rt0"/>
+                                                <constraint firstAttribute="centerX" secondItem="SnZ-To-N2p" secondAttribute="centerX" id="X18-zZ-WsS"/>
+                                                <constraint firstItem="2hi-jg-tAu" firstAttribute="top" secondItem="EjH-b5-iye" secondAttribute="top" constant="16" id="bE1-1l-Tlz"/>
+                                                <constraint firstAttribute="bottom" secondItem="2hi-jg-tAu" secondAttribute="bottom" constant="16" id="jfU-bG-Wxi"/>
+                                                <constraint firstItem="qJ0-wu-bhs" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="EjH-b5-iye" secondAttribute="leading" constant="8" id="k4d-4i-7pg"/>
+                                                <constraint firstItem="2hi-jg-tAu" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="qJ0-wu-bhs" secondAttribute="trailing" constant="8" id="mUK-Kp-S9T"/>
+                                                <constraint firstAttribute="centerY" secondItem="qJ0-wu-bhs" secondAttribute="centerY" constant="-10" id="wKk-z9-4dd"/>
                                             </constraints>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                        </sections>
+                                        </view>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="cPN-KE-hdr" firstAttribute="top" secondItem="tND-dE-Btv" secondAttribute="topMargin" constant="-8" id="0Ns-hB-RaH"/>
+                                        <constraint firstItem="HV6-Cx-Ceh" firstAttribute="leading" secondItem="M8I-iH-ljE" secondAttribute="trailing" id="1mA-nd-3VV"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="M8I-iH-ljE" secondAttribute="bottom" constant="-8" id="4vP-6g-SBD"/>
+                                        <constraint firstItem="M8I-iH-ljE" firstAttribute="width" secondItem="HV6-Cx-Ceh" secondAttribute="width" id="5uE-BQ-pMn"/>
+                                        <constraint firstAttribute="trailing" secondItem="HV6-Cx-Ceh" secondAttribute="trailing" constant="8" id="AaH-xr-qOs"/>
+                                        <constraint firstItem="M8I-iH-ljE" firstAttribute="top" secondItem="tND-dE-Btv" secondAttribute="topMargin" constant="-8" id="DoO-Wf-NL0"/>
+                                        <constraint firstItem="M8I-iH-ljE" firstAttribute="width" secondItem="cPN-KE-hdr" secondAttribute="width" id="Jd3-xt-5BT"/>
+                                        <constraint firstItem="M8I-iH-ljE" firstAttribute="width" secondItem="EjH-b5-iye" secondAttribute="width" id="Jj2-lx-scT"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="EjH-b5-iye" secondAttribute="bottom" constant="-8" id="KkU-MA-2Qf"/>
+                                        <constraint firstItem="cPN-KE-hdr" firstAttribute="leading" secondItem="tND-dE-Btv" secondAttribute="leading" constant="8" id="V1o-Tw-coq"/>
+                                        <constraint firstItem="EjH-b5-iye" firstAttribute="top" secondItem="tND-dE-Btv" secondAttribute="topMargin" constant="-8" id="bzc-Rd-Z2B"/>
+                                        <constraint firstItem="EjH-b5-iye" firstAttribute="leading" secondItem="cPN-KE-hdr" secondAttribute="trailing" id="dNr-RP-GCN"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="HV6-Cx-Ceh" secondAttribute="bottom" constant="-8" id="hY5-xp-HfI"/>
+                                        <constraint firstItem="M8I-iH-ljE" firstAttribute="leading" secondItem="EjH-b5-iye" secondAttribute="trailing" id="kPt-Z6-iqL"/>
+                                        <constraint firstItem="HV6-Cx-Ceh" firstAttribute="top" secondItem="tND-dE-Btv" secondAttribute="topMargin" constant="-8" id="nbZ-fv-6OF"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="cPN-KE-hdr" secondAttribute="bottom" constant="-8" id="sun-Ek-hFD"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TodaysStatsDetails" rowHeight="66" id="dRE-rs-NGi" userLabel="Today's Stats Details" customClass="InsightsTodaysStatsTableViewCell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dRE-rs-NGi" id="hTu-9f-WBB">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iwI-u2-AsI">
+                                            <rect key="frame" x="300" y="0.0" width="146" height="65"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AgS-4W-V5O" userLabel="Divider View">
+                                                    <rect key="frame" x="145" y="0.0" width="1" height="65"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="1" id="Qbv-PO-urv"/>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="cb8-Pp-7FM"/>
+                                                    </constraints>
+                                                </view>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ab2-8S-y1h">
+                                                    <rect key="frame" x="58" y="2" width="30" height="26"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <state key="normal" title="LIKES">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayLikes:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="kHf-gG-cP6"/>
+                                                    </connections>
+                                                </button>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6H5-sV-soQ">
+                                                    <rect key="frame" x="8" y="21" width="130" height="34"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
+                                                    <state key="normal" title="0">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayLikes:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="4Qm-FM-g9S"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="ab2-8S-y1h" firstAttribute="top" secondItem="iwI-u2-AsI" secondAttribute="top" constant="2" id="A0d-Sf-gsB"/>
+                                                <constraint firstAttribute="centerX" secondItem="ab2-8S-y1h" secondAttribute="centerX" id="GrT-pM-NhK"/>
+                                                <constraint firstItem="AgS-4W-V5O" firstAttribute="top" secondItem="iwI-u2-AsI" secondAttribute="top" id="Hft-uX-HKa"/>
+                                                <constraint firstAttribute="centerX" secondItem="6H5-sV-soQ" secondAttribute="centerX" id="JV4-3c-wB6"/>
+                                                <constraint firstAttribute="bottom" secondItem="AgS-4W-V5O" secondAttribute="bottom" id="Pju-s6-nXU"/>
+                                                <constraint firstAttribute="centerY" secondItem="6H5-sV-soQ" secondAttribute="centerY" constant="-5" id="Q8y-zS-ddH"/>
+                                                <constraint firstItem="ab2-8S-y1h" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iwI-u2-AsI" secondAttribute="leading" constant="4" id="g8M-9i-KZk"/>
+                                                <constraint firstItem="6H5-sV-soQ" firstAttribute="leading" secondItem="iwI-u2-AsI" secondAttribute="leading" constant="8" id="mw9-2n-KVJ"/>
+                                                <constraint firstAttribute="trailing" secondItem="AgS-4W-V5O" secondAttribute="trailing" id="qqG-8p-P8C"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ab2-8S-y1h" secondAttribute="trailing" constant="4" id="rFK-Ev-xJK"/>
+                                                <constraint firstAttribute="trailing" secondItem="6H5-sV-soQ" secondAttribute="trailing" constant="8" id="sbJ-Up-jeE"/>
+                                            </constraints>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vap-Tr-7k3">
+                                            <rect key="frame" x="446" y="0.0" width="146" height="65"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Xj-XK-eQ8">
+                                                    <rect key="frame" x="8" y="21" width="130" height="34"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
+                                                    <state key="normal" title="0">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayComments:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="KlF-nP-CW5"/>
+                                                    </connections>
+                                                </button>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nUZ-Tg-WTV">
+                                                    <rect key="frame" x="45" y="2" width="57" height="26"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <state key="normal" title="COMMENTS">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayComments:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="LCB-GE-g5n"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="nUZ-Tg-WTV" firstAttribute="top" secondItem="vap-Tr-7k3" secondAttribute="top" constant="2" id="3ek-PM-QQy"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="nUZ-Tg-WTV" secondAttribute="trailing" constant="4" id="CuI-Rq-qY5"/>
+                                                <constraint firstAttribute="centerX" secondItem="nUZ-Tg-WTV" secondAttribute="centerX" id="Odz-dI-8CP"/>
+                                                <constraint firstAttribute="centerX" secondItem="5Xj-XK-eQ8" secondAttribute="centerX" id="Oed-Ik-zRZ"/>
+                                                <constraint firstAttribute="trailing" secondItem="5Xj-XK-eQ8" secondAttribute="trailing" constant="8" id="ZHI-eP-snC"/>
+                                                <constraint firstAttribute="centerY" secondItem="5Xj-XK-eQ8" secondAttribute="centerY" constant="-5" id="mUv-gV-ozN"/>
+                                                <constraint firstItem="5Xj-XK-eQ8" firstAttribute="leading" secondItem="vap-Tr-7k3" secondAttribute="leading" constant="8" id="qMK-bL-D0m"/>
+                                                <constraint firstItem="nUZ-Tg-WTV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="vap-Tr-7k3" secondAttribute="leading" constant="4" id="vu7-k6-pBa"/>
+                                            </constraints>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9TN-0u-X0e">
+                                            <rect key="frame" x="154" y="0.0" width="146" height="65"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZxX-Mc-USG" userLabel="Divider View">
+                                                    <rect key="frame" x="145" y="0.0" width="1" height="65"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="Z6a-z8-trh"/>
+                                                        <constraint firstAttribute="width" constant="1" id="apn-Vx-Jr3"/>
+                                                    </constraints>
+                                                </view>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g6C-KQ-1fr">
+                                                    <rect key="frame" x="8" y="21" width="130" height="34"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
+                                                    <state key="normal" title="32">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayVisitors:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="tId-3p-i1R"/>
+                                                    </connections>
+                                                </button>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="g9y-bc-4NQ">
+                                                    <rect key="frame" x="52" y="2" width="43" height="26"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <state key="normal" title="VISITORS">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayVisitors:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="q2f-xD-KRm"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="ZxX-Mc-USG" secondAttribute="bottom" id="5qc-Cv-4Ik"/>
+                                                <constraint firstAttribute="centerY" secondItem="g6C-KQ-1fr" secondAttribute="centerY" constant="-5" id="Blp-e5-I6u"/>
+                                                <constraint firstAttribute="trailing" secondItem="g6C-KQ-1fr" secondAttribute="trailing" constant="8" id="Bvc-yi-zCT"/>
+                                                <constraint firstItem="g9y-bc-4NQ" firstAttribute="top" secondItem="9TN-0u-X0e" secondAttribute="top" constant="2" id="NeH-Vq-YXv"/>
+                                                <constraint firstItem="g9y-bc-4NQ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="9TN-0u-X0e" secondAttribute="leading" constant="4" id="aIQ-9R-nN1"/>
+                                                <constraint firstItem="g6C-KQ-1fr" firstAttribute="leading" secondItem="9TN-0u-X0e" secondAttribute="leading" constant="8" id="bN7-53-jhR"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="g9y-bc-4NQ" secondAttribute="trailing" constant="4" id="bPV-Ha-wEo"/>
+                                                <constraint firstAttribute="centerX" secondItem="g9y-bc-4NQ" secondAttribute="centerX" id="dv8-zC-3Gl"/>
+                                                <constraint firstAttribute="centerX" secondItem="g6C-KQ-1fr" secondAttribute="centerX" id="k2A-eI-5bc"/>
+                                                <constraint firstAttribute="trailing" secondItem="ZxX-Mc-USG" secondAttribute="trailing" id="nh0-lt-MLy"/>
+                                                <constraint firstItem="ZxX-Mc-USG" firstAttribute="top" secondItem="9TN-0u-X0e" secondAttribute="top" id="zG1-hw-tEd"/>
+                                            </constraints>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IwY-dz-TSD">
+                                            <rect key="frame" x="8" y="0.0" width="146" height="65"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gaP-FE-Uu4" userLabel="Divider View">
+                                                    <rect key="frame" x="145" y="0.0" width="1" height="65"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="1" id="GV0-JN-SmU"/>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="KFA-Qw-kna"/>
+                                                    </constraints>
+                                                </view>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nWH-aO-4eO">
+                                                    <rect key="frame" x="8" y="21" width="130" height="34"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
+                                                    <state key="normal" title="24">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayViews:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="38w-UC-aGe"/>
+                                                    </connections>
+                                                </button>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Zp-vE-uY4">
+                                                    <rect key="frame" x="58" y="2" width="30" height="26"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <state key="normal" title="VIEWS">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayViews:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="NKu-zg-YtZ"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="4Zp-vE-uY4" secondAttribute="trailing" constant="8" id="3cw-a4-bxo"/>
+                                                <constraint firstAttribute="trailing" secondItem="nWH-aO-4eO" secondAttribute="trailing" constant="8" id="40X-oh-MUy"/>
+                                                <constraint firstAttribute="bottom" secondItem="gaP-FE-Uu4" secondAttribute="bottom" id="Axi-gZ-Awi"/>
+                                                <constraint firstAttribute="trailing" secondItem="gaP-FE-Uu4" secondAttribute="trailing" id="EkH-7F-gau"/>
+                                                <constraint firstItem="gaP-FE-Uu4" firstAttribute="top" secondItem="IwY-dz-TSD" secondAttribute="top" id="GVr-LV-PG9"/>
+                                                <constraint firstItem="4Zp-vE-uY4" firstAttribute="top" secondItem="IwY-dz-TSD" secondAttribute="top" constant="2" id="Lxc-JK-fz0"/>
+                                                <constraint firstAttribute="centerX" secondItem="nWH-aO-4eO" secondAttribute="centerX" id="OIA-DZ-VXa"/>
+                                                <constraint firstItem="4Zp-vE-uY4" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="IwY-dz-TSD" secondAttribute="leading" constant="8" id="TLQ-tw-3n3"/>
+                                                <constraint firstItem="nWH-aO-4eO" firstAttribute="leading" secondItem="IwY-dz-TSD" secondAttribute="leading" constant="8" id="o8y-pA-k9z"/>
+                                                <constraint firstAttribute="centerY" secondItem="nWH-aO-4eO" secondAttribute="centerY" constant="-5" id="oFU-Eg-zla"/>
+                                                <constraint firstAttribute="centerX" secondItem="4Zp-vE-uY4" secondAttribute="centerX" id="oXs-bi-1ay"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="9TN-0u-X0e" firstAttribute="leading" secondItem="IwY-dz-TSD" secondAttribute="trailing" id="3KS-h0-4eW"/>
+                                        <constraint firstItem="vap-Tr-7k3" firstAttribute="leading" secondItem="iwI-u2-AsI" secondAttribute="trailing" id="5Ia-58-d9Y"/>
+                                        <constraint firstItem="IwY-dz-TSD" firstAttribute="leading" secondItem="hTu-9f-WBB" secondAttribute="leading" constant="8" id="73L-Nj-zNE"/>
+                                        <constraint firstItem="vap-Tr-7k3" firstAttribute="width" secondItem="IwY-dz-TSD" secondAttribute="width" id="776-Xz-gW1"/>
+                                        <constraint firstItem="vap-Tr-7k3" firstAttribute="height" secondItem="IwY-dz-TSD" secondAttribute="height" id="CQ0-2h-Rbn"/>
+                                        <constraint firstItem="vap-Tr-7k3" firstAttribute="width" secondItem="9TN-0u-X0e" secondAttribute="width" id="DPt-hA-MV2"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="9TN-0u-X0e" secondAttribute="bottom" constant="-8" id="Dte-jh-ayr"/>
+                                        <constraint firstItem="vap-Tr-7k3" firstAttribute="height" secondItem="9TN-0u-X0e" secondAttribute="height" id="Lml-1y-HFh"/>
+                                        <constraint firstItem="vap-Tr-7k3" firstAttribute="top" secondItem="hTu-9f-WBB" secondAttribute="topMargin" constant="-8" id="PVh-7i-STk"/>
+                                        <constraint firstItem="iwI-u2-AsI" firstAttribute="top" secondItem="hTu-9f-WBB" secondAttribute="topMargin" constant="-8" id="VOb-er-OA7"/>
+                                        <constraint firstItem="vap-Tr-7k3" firstAttribute="width" secondItem="iwI-u2-AsI" secondAttribute="width" id="Vp9-LB-y8H"/>
+                                        <constraint firstItem="IwY-dz-TSD" firstAttribute="top" secondItem="hTu-9f-WBB" secondAttribute="topMargin" constant="-8" id="bv5-Eq-P3j"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="vap-Tr-7k3" secondAttribute="bottom" constant="-8" id="co7-Fc-fhq"/>
+                                        <constraint firstItem="9TN-0u-X0e" firstAttribute="top" secondItem="hTu-9f-WBB" secondAttribute="topMargin" constant="-8" id="fKI-E9-F0O"/>
+                                        <constraint firstItem="vap-Tr-7k3" firstAttribute="height" secondItem="iwI-u2-AsI" secondAttribute="height" id="ijO-pt-Joh"/>
+                                        <constraint firstAttribute="trailing" secondItem="vap-Tr-7k3" secondAttribute="trailing" constant="8" id="ksp-CF-oxT"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="IwY-dz-TSD" secondAttribute="bottom" constant="-8" id="toQ-lz-mBi"/>
+                                        <constraint firstItem="iwI-u2-AsI" firstAttribute="leading" secondItem="9TN-0u-X0e" secondAttribute="trailing" id="vXJ-6j-BSo"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="iwI-u2-AsI" secondAttribute="bottom" constant="-8" id="xGZ-oC-qDY"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <sections/>
                         <connections>
                             <outlet property="dataSource" destination="Pq6-gc-ScC" id="u32-XZ-8nm"/>
                             <outlet property="delegate" destination="Pq6-gc-ScC" id="fiJ-94-BBh"/>
                         </connections>
                     </tableView>
-                    <connections>
-                        <outlet property="allTimeBestViewsLabel" destination="Ml6-Iu-wKc" id="Qxv-NY-gle"/>
-                        <outlet property="allTimeBestViewsOnValueLabel" destination="p0T-y9-dQS" id="5YO-02-oIq"/>
-                        <outlet property="allTimeBestViewsValueLabel" destination="bhJ-yf-eeg" id="G7l-S3-rbY"/>
-                        <outlet property="allTimePostsLabel" destination="qTg-V3-QrG" id="GRz-IC-Tff"/>
-                        <outlet property="allTimePostsValueLabel" destination="kyf-cc-9Pz" id="glp-nx-Oy4"/>
-                        <outlet property="allTimeSectionHeaderLabel" destination="5F3-oE-jzA" id="wli-e6-tZo"/>
-                        <outlet property="allTimeViewsLabel" destination="SnZ-To-N2p" id="Ldq-K9-G0L"/>
-                        <outlet property="allTimeViewsValueLabel" destination="qJ0-wu-bhs" id="Yu8-6R-SAc"/>
-                        <outlet property="allTimeVisitorsLabel" destination="Ixp-TF-kKn" id="WBm-j9-M2D"/>
-                        <outlet property="allTimeVisitorsValueLabel" destination="RsC-iV-YWj" id="vWw-Mw-ZfW"/>
-                        <outlet property="mostPopularDay" destination="dPU-t1-atl" id="fMh-c3-Q4G"/>
-                        <outlet property="mostPopularDayLabel" destination="LqR-Vc-rtl" id="mRS-HX-uru"/>
-                        <outlet property="mostPopularDayPercentWeeklyViews" destination="yKD-YK-Mra" id="Nwi-Wu-YYO"/>
-                        <outlet property="mostPopularHour" destination="xx2-Ii-OSN" id="o2a-co-Ufn"/>
-                        <outlet property="mostPopularHourLabel" destination="owa-7G-DL9" id="0VD-jF-t5Z"/>
-                        <outlet property="mostPopularHourPercentDailyViews" destination="txh-pI-huu" id="Mrp-U0-iEp"/>
-                        <outlet property="popularSectionHeaderLabel" destination="U94-Ix-7EC" id="tWh-0W-j2Y"/>
-                        <outlet property="todayCommentsButton" destination="nUZ-Tg-WTV" id="at5-nf-zNS"/>
-                        <outlet property="todayCommentsValueButton" destination="5Xj-XK-eQ8" id="d85-AS-Co0"/>
-                        <outlet property="todayLikesButton" destination="ab2-8S-y1h" id="o3G-P5-OIV"/>
-                        <outlet property="todayLikesValueButton" destination="6H5-sV-soQ" id="f7Z-Ce-9hZ"/>
-                        <outlet property="todaySectionHeaderLabel" destination="FV4-Ej-Neu" id="eNc-HB-TKe"/>
-                        <outlet property="todayViewsButton" destination="4Zp-vE-uY4" id="Zhk-wR-hrS"/>
-                        <outlet property="todayViewsValueButton" destination="nWH-aO-4eO" id="ccF-gX-Tbn"/>
-                        <outlet property="todayVisitorsButton" destination="g9y-bc-4NQ" id="mlB-mT-TC6"/>
-                        <outlet property="todayVisitorsValueButton" destination="g6C-KQ-1fr" id="eXR-VW-NAE"/>
-                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="L1W-v8-za2" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -65,6 +65,23 @@
             <string>OpenSans</string>
             <string>OpenSans</string>
             <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
+            <string>OpenSans</string>
         </mutableArray>
     </customFonts>
     <scenes>
@@ -503,48 +520,11 @@
                                     <outlet property="mostPopularHourPercentDailyViews" destination="txh-pI-huu" id="WYQ-lm-j1c"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AllTimeDetails" rowHeight="100" id="3Mz-H6-0pu" userLabel="All Time Details" customClass="InsightsAllTimeTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AllTimeDetailsPad" rowHeight="100" id="3Mz-H6-0pu" userLabel="All Time Details iPad" customClass="InsightsAllTimeTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="3Mz-H6-0pu" id="tND-dE-Btv">
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cPN-KE-hdr">
-                                            <rect key="frame" x="8" y="0.0" width="146" height="99"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="128" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kyf-cc-9Pz">
-                                                    <rect key="frame" x="52" y="42" width="43" height="35"/>
-                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POSTS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qTg-V3-QrG">
-                                                    <rect key="frame" x="58" y="27" width="31" height="14"/>
-                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PUF-YG-InB" userLabel="Divider View">
-                                                    <rect key="frame" x="145" y="16" width="1" height="67"/>
-                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" constant="1" id="vqB-sa-51J"/>
-                                                    </constraints>
-                                                </view>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="PUF-YG-InB" firstAttribute="top" secondItem="cPN-KE-hdr" secondAttribute="top" constant="16" id="0jy-Qu-MCM"/>
-                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kyf-cc-9Pz" secondAttribute="trailing" constant="8" id="7ZE-R0-YlR"/>
-                                                <constraint firstItem="qTg-V3-QrG" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="cPN-KE-hdr" secondAttribute="leading" constant="4" id="Kbw-tA-dub"/>
-                                                <constraint firstAttribute="centerX" secondItem="kyf-cc-9Pz" secondAttribute="centerX" id="OcQ-Hd-fKy"/>
-                                                <constraint firstAttribute="centerX" secondItem="qTg-V3-QrG" secondAttribute="centerX" id="OtF-0g-um5"/>
-                                                <constraint firstItem="kyf-cc-9Pz" firstAttribute="top" secondItem="qTg-V3-QrG" secondAttribute="baseline" constant="4" id="QO6-x7-uck"/>
-                                                <constraint firstAttribute="trailing" secondItem="PUF-YG-InB" secondAttribute="trailing" id="Snq-2U-n55"/>
-                                                <constraint firstAttribute="bottom" secondItem="PUF-YG-InB" secondAttribute="bottom" constant="16" id="UNd-Dn-DGe"/>
-                                                <constraint firstAttribute="centerY" secondItem="kyf-cc-9Pz" secondAttribute="centerY" constant="-10" id="WPq-Kq-LbB"/>
-                                                <constraint firstItem="kyf-cc-9Pz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="cPN-KE-hdr" secondAttribute="leading" constant="8" id="bJ0-aX-Ax5"/>
-                                                <constraint firstItem="PUF-YG-InB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="qTg-V3-QrG" secondAttribute="trailing" constant="4" id="exk-OG-SRH"/>
-                                            </constraints>
-                                        </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="M8I-iH-ljE">
                                             <rect key="frame" x="300" y="0.0" width="146" height="99"/>
                                             <subviews>
@@ -656,6 +636,43 @@
                                                 <constraint firstAttribute="centerY" secondItem="qJ0-wu-bhs" secondAttribute="centerY" constant="-10" id="wKk-z9-4dd"/>
                                             </constraints>
                                         </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cPN-KE-hdr">
+                                            <rect key="frame" x="8" y="0.0" width="146" height="99"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="128" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kyf-cc-9Pz">
+                                                    <rect key="frame" x="52" y="42" width="43" height="35"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POSTS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qTg-V3-QrG">
+                                                    <rect key="frame" x="58" y="27" width="31" height="14"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PUF-YG-InB" userLabel="Divider View">
+                                                    <rect key="frame" x="145" y="16" width="1" height="67"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="1" id="vqB-sa-51J"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="PUF-YG-InB" firstAttribute="top" secondItem="cPN-KE-hdr" secondAttribute="top" constant="16" id="0jy-Qu-MCM"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kyf-cc-9Pz" secondAttribute="trailing" constant="8" id="7ZE-R0-YlR"/>
+                                                <constraint firstItem="qTg-V3-QrG" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="cPN-KE-hdr" secondAttribute="leading" constant="4" id="Kbw-tA-dub"/>
+                                                <constraint firstAttribute="centerX" secondItem="kyf-cc-9Pz" secondAttribute="centerX" id="OcQ-Hd-fKy"/>
+                                                <constraint firstAttribute="centerX" secondItem="qTg-V3-QrG" secondAttribute="centerX" id="OtF-0g-um5"/>
+                                                <constraint firstItem="kyf-cc-9Pz" firstAttribute="top" secondItem="qTg-V3-QrG" secondAttribute="baseline" constant="4" id="QO6-x7-uck"/>
+                                                <constraint firstAttribute="trailing" secondItem="PUF-YG-InB" secondAttribute="trailing" id="Snq-2U-n55"/>
+                                                <constraint firstAttribute="bottom" secondItem="PUF-YG-InB" secondAttribute="bottom" constant="16" id="UNd-Dn-DGe"/>
+                                                <constraint firstAttribute="centerY" secondItem="kyf-cc-9Pz" secondAttribute="centerY" constant="-10" id="WPq-Kq-LbB"/>
+                                                <constraint firstItem="kyf-cc-9Pz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="cPN-KE-hdr" secondAttribute="leading" constant="8" id="bJ0-aX-Ax5"/>
+                                                <constraint firstItem="PUF-YG-InB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="qTg-V3-QrG" secondAttribute="trailing" constant="4" id="exk-OG-SRH"/>
+                                            </constraints>
+                                        </view>
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="cPN-KE-hdr" firstAttribute="top" secondItem="tND-dE-Btv" secondAttribute="topMargin" constant="-8" id="0Ns-hB-RaH"/>
@@ -688,7 +705,7 @@
                                     <outlet property="allTimeVisitorsValueLabel" destination="RsC-iV-YWj" id="6G5-A0-BNc"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TodaysStatsDetails" rowHeight="66" id="dRE-rs-NGi" userLabel="Today's Stats Details" customClass="InsightsTodaysStatsTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TodaysStatsDetailsPad" rowHeight="66" id="dRE-rs-NGi" userLabel="Today's Stats Details iPad" customClass="InsightsTodaysStatsTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="dRE-rs-NGi" id="hTu-9f-WBB">
                                     <autoresizingMask key="autoresizingMask"/>
@@ -898,6 +915,423 @@
                                     <outlet property="todayViewsValueButton" destination="nWH-aO-4eO" id="VYR-Xl-FjA"/>
                                     <outlet property="todayVisitorsButton" destination="g9y-bc-4NQ" id="4JU-4J-3cM"/>
                                     <outlet property="todayVisitorsValueButton" destination="g6C-KQ-1fr" id="4NS-Qd-PKg"/>
+                                </connections>
+                            </tableViewCell>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AllTimeDetails" rowHeight="200" id="HxC-8t-Lp3" userLabel="All Time Details" customClass="InsightsAllTimeTableViewCell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="HxC-8t-Lp3" id="Ids-uQ-XjV">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gv6-zf-XEx" userLabel="Posts">
+                                            <rect key="frame" x="8" y="0.0" width="292" height="100"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="128" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="vE2-2f-R5G">
+                                                    <rect key="frame" x="125" y="43" width="43" height="35"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POSTS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nii-wq-jD8">
+                                                    <rect key="frame" x="131" y="28" width="31" height="14"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nLg-Ao-MTu" userLabel="Divider View">
+                                                    <rect key="frame" x="291" y="16" width="1" height="68"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="1" id="LBj-qK-bqG"/>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="gtc-sG-7a0"/>
+                                                    </constraints>
+                                                </view>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MtW-hg-D9a" userLabel="Horizontal Divider View">
+                                                    <rect key="frame" x="16" y="99" width="260" height="1"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="1" id="FEI-oz-laT"/>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="1" id="NrS-qV-8OY"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="nLg-Ao-MTu" firstAttribute="top" secondItem="gv6-zf-XEx" secondAttribute="top" constant="16" id="4Nr-OR-K1r"/>
+                                                <constraint firstAttribute="trailing" secondItem="nLg-Ao-MTu" secondAttribute="trailing" id="4yD-9v-tly"/>
+                                                <constraint firstAttribute="centerX" secondItem="vE2-2f-R5G" secondAttribute="centerX" id="6bu-cT-lfS"/>
+                                                <constraint firstItem="vE2-2f-R5G" firstAttribute="top" secondItem="Nii-wq-jD8" secondAttribute="baseline" constant="4" id="OR0-50-f9k"/>
+                                                <constraint firstAttribute="centerX" secondItem="Nii-wq-jD8" secondAttribute="centerX" id="Odw-0T-tLP"/>
+                                                <constraint firstAttribute="height" constant="100" id="VTl-Wv-Rya"/>
+                                                <constraint firstItem="Nii-wq-jD8" firstAttribute="top" secondItem="MtW-hg-D9a" secondAttribute="bottom" id="XwH-qF-zha"/>
+                                                <constraint firstAttribute="bottom" secondItem="nLg-Ao-MTu" secondAttribute="bottom" constant="16" id="aOW-Ok-atu"/>
+                                                <constraint firstAttribute="centerY" secondItem="vE2-2f-R5G" secondAttribute="centerY" constant="-10" id="aUB-WG-IX7"/>
+                                                <constraint firstAttribute="bottom" secondItem="MtW-hg-D9a" secondAttribute="bottom" id="mxu-fB-cj2"/>
+                                                <constraint firstItem="MtW-hg-D9a" firstAttribute="leading" secondItem="gv6-zf-XEx" secondAttribute="leading" constant="16" id="o7o-Ar-4Ud"/>
+                                                <constraint firstAttribute="trailing" secondItem="MtW-hg-D9a" secondAttribute="trailing" constant="16" id="orz-rp-chK"/>
+                                            </constraints>
+                                            <variation key="default">
+                                                <mask key="constraints">
+                                                    <exclude reference="XwH-qF-zha"/>
+                                                </mask>
+                                            </variation>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VVz-ur-nje" userLabel="Best Views">
+                                            <rect key="frame" x="300" y="100" width="292" height="99"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3,485" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="KsA-er-QuV">
+                                                    <rect key="frame" x="114" y="42" width="64" height="35"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BEST VIEWS EVER" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="TpN-dY-IW4">
+                                                    <rect key="frame" x="106" y="27" width="81" height="14"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="APRIL 4, 2015" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Upc-GK-XKb">
+                                                    <rect key="frame" x="115" y="77" width="63" height="14"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstAttribute="centerX" secondItem="TpN-dY-IW4" secondAttribute="centerX" id="0ZX-p0-46m"/>
+                                                <constraint firstAttribute="centerX" secondItem="KsA-er-QuV" secondAttribute="centerX" id="FZh-B8-qte"/>
+                                                <constraint firstItem="KsA-er-QuV" firstAttribute="top" secondItem="TpN-dY-IW4" secondAttribute="bottom" constant="4" id="SXr-4O-uVP"/>
+                                                <constraint firstItem="KsA-er-QuV" firstAttribute="top" secondItem="TpN-dY-IW4" secondAttribute="baseline" constant="4" id="c7M-t8-2xB"/>
+                                                <constraint firstAttribute="centerX" secondItem="Upc-GK-XKb" secondAttribute="centerX" id="rVl-tp-XBT"/>
+                                                <constraint firstAttribute="bottom" secondItem="Upc-GK-XKb" secondAttribute="bottom" constant="8" id="uCN-F8-c2F"/>
+                                                <constraint firstAttribute="centerY" secondItem="KsA-er-QuV" secondAttribute="centerY" constant="-10" id="uxt-qC-oKT"/>
+                                            </constraints>
+                                            <variation key="default">
+                                                <mask key="constraints">
+                                                    <exclude reference="SXr-4O-uVP"/>
+                                                </mask>
+                                            </variation>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4wd-n6-Mh0" userLabel="Visitors">
+                                            <rect key="frame" x="8" y="100" width="292" height="99"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="42,837" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="E8k-cd-ojU">
+                                                    <rect key="frame" x="107" y="42" width="78" height="35"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VISITORS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EfI-IH-BWM">
+                                                    <rect key="frame" x="125" y="27" width="43" height="14"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VBS-Y1-4M2" userLabel="Divider View">
+                                                    <rect key="frame" x="291" y="16" width="1" height="67"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="3Bk-i8-zkJ"/>
+                                                        <constraint firstAttribute="width" constant="1" id="ahm-zw-dIS"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="E8k-cd-ojU" firstAttribute="top" secondItem="EfI-IH-BWM" secondAttribute="baseline" constant="4" id="6Wm-cw-qs0"/>
+                                                <constraint firstAttribute="bottom" secondItem="VBS-Y1-4M2" secondAttribute="bottom" constant="16" id="6zy-rm-vPe"/>
+                                                <constraint firstAttribute="centerX" secondItem="EfI-IH-BWM" secondAttribute="centerX" id="EQ1-tc-aE8"/>
+                                                <constraint firstItem="E8k-cd-ojU" firstAttribute="leading" secondItem="VBS-Y1-4M2" secondAttribute="trailing" id="I9m-es-qzJ"/>
+                                                <constraint firstAttribute="trailing" secondItem="VBS-Y1-4M2" secondAttribute="trailing" id="K02-KQ-ZCj"/>
+                                                <constraint firstAttribute="centerX" secondItem="E8k-cd-ojU" secondAttribute="centerX" id="ZJN-m8-qrM"/>
+                                                <constraint firstItem="VBS-Y1-4M2" firstAttribute="top" secondItem="4wd-n6-Mh0" secondAttribute="top" constant="16" id="qSE-ey-1X1"/>
+                                                <constraint firstAttribute="centerY" secondItem="E8k-cd-ojU" secondAttribute="centerY" constant="-10" id="ukO-ik-qGz"/>
+                                            </constraints>
+                                            <variation key="default">
+                                                <mask key="constraints">
+                                                    <exclude reference="I9m-es-qzJ"/>
+                                                </mask>
+                                            </variation>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MiR-uA-7zk" userLabel="Views">
+                                            <rect key="frame" x="300" y="0.0" width="292" height="100"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="56,613" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ubr-tF-ZJH">
+                                                    <rect key="frame" x="107" y="43" width="78" height="35"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgE-C0-FH2">
+                                                    <rect key="frame" x="131" y="28" width="30" height="14"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aaT-Zf-RuJ" userLabel="Horizontal Divider View">
+                                                    <rect key="frame" x="16" y="99" width="260" height="1"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="1" id="5wF-gt-fYs"/>
+                                                        <constraint firstAttribute="height" constant="1" id="Psp-UD-gk2"/>
+                                                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="1" id="p6Y-oQ-wle"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="aaT-Zf-RuJ" secondAttribute="bottom" id="5t6-YA-kZG"/>
+                                                <constraint firstItem="aaT-Zf-RuJ" firstAttribute="leading" secondItem="MiR-uA-7zk" secondAttribute="leading" constant="16" id="NeN-Hx-M5g"/>
+                                                <constraint firstAttribute="centerX" secondItem="xgE-C0-FH2" secondAttribute="centerX" id="SCT-hW-jsQ"/>
+                                                <constraint firstAttribute="centerY" secondItem="ubr-tF-ZJH" secondAttribute="centerY" constant="-10" id="Wqa-gi-zUw"/>
+                                                <constraint firstAttribute="trailing" secondItem="aaT-Zf-RuJ" secondAttribute="trailing" constant="16" id="lSl-AK-n58"/>
+                                                <constraint firstAttribute="centerX" secondItem="ubr-tF-ZJH" secondAttribute="centerX" id="wBA-oZ-qcD"/>
+                                                <constraint firstItem="ubr-tF-ZJH" firstAttribute="top" secondItem="xgE-C0-FH2" secondAttribute="baseline" constant="4" id="ypR-lp-Kkw"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="gv6-zf-XEx" firstAttribute="top" secondItem="Ids-uQ-XjV" secondAttribute="top" id="0Bl-H3-K5e"/>
+                                        <constraint firstItem="gv6-zf-XEx" firstAttribute="leading" secondItem="Ids-uQ-XjV" secondAttribute="leadingMargin" id="0W6-ji-Qdh"/>
+                                        <constraint firstItem="VVz-ur-nje" firstAttribute="top" secondItem="MiR-uA-7zk" secondAttribute="bottom" id="GPW-uj-Wr3"/>
+                                        <constraint firstItem="gv6-zf-XEx" firstAttribute="height" secondItem="MiR-uA-7zk" secondAttribute="height" id="H62-u2-O3m"/>
+                                        <constraint firstItem="4wd-n6-Mh0" firstAttribute="width" secondItem="MiR-uA-7zk" secondAttribute="width" id="P4Q-Bb-BJv"/>
+                                        <constraint firstItem="MiR-uA-7zk" firstAttribute="leading" secondItem="gv6-zf-XEx" secondAttribute="trailing" id="Q0S-KT-jF9"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="VVz-ur-nje" secondAttribute="trailing" id="T58-sw-0RU"/>
+                                        <constraint firstItem="4wd-n6-Mh0" firstAttribute="width" secondItem="gv6-zf-XEx" secondAttribute="width" id="TD2-rs-VKr"/>
+                                        <constraint firstAttribute="bottom" secondItem="4wd-n6-Mh0" secondAttribute="bottom" id="WOR-bB-PlQ"/>
+                                        <constraint firstItem="4wd-n6-Mh0" firstAttribute="leading" secondItem="Ids-uQ-XjV" secondAttribute="leadingMargin" id="XKN-ac-xIQ"/>
+                                        <constraint firstAttribute="bottom" secondItem="VVz-ur-nje" secondAttribute="bottom" id="eKx-eI-UQA"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="MiR-uA-7zk" secondAttribute="trailing" id="gR3-wl-C28"/>
+                                        <constraint firstItem="MiR-uA-7zk" firstAttribute="top" secondItem="Ids-uQ-XjV" secondAttribute="top" id="h5R-W8-qFS"/>
+                                        <constraint firstItem="VVz-ur-nje" firstAttribute="height" secondItem="4wd-n6-Mh0" secondAttribute="height" id="i6c-Rc-aRq"/>
+                                        <constraint firstItem="4wd-n6-Mh0" firstAttribute="top" secondItem="gv6-zf-XEx" secondAttribute="bottom" id="imT-Ea-M64"/>
+                                        <constraint firstItem="4wd-n6-Mh0" firstAttribute="width" secondItem="VVz-ur-nje" secondAttribute="width" id="jtv-aS-chE"/>
+                                        <constraint firstItem="VVz-ur-nje" firstAttribute="leading" secondItem="4wd-n6-Mh0" secondAttribute="trailing" id="pnV-nS-o7M"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="allTimeBestViewsLabel" destination="TpN-dY-IW4" id="udQ-8i-Mu7"/>
+                                    <outlet property="allTimeBestViewsOnValueLabel" destination="Upc-GK-XKb" id="zqO-dF-slG"/>
+                                    <outlet property="allTimeBestViewsValueLabel" destination="KsA-er-QuV" id="5Lx-eE-WIC"/>
+                                    <outlet property="allTimePostsLabel" destination="Nii-wq-jD8" id="6qO-dy-Q2Y"/>
+                                    <outlet property="allTimePostsValueLabel" destination="vE2-2f-R5G" id="pTv-vN-uXb"/>
+                                    <outlet property="allTimeViewsLabel" destination="xgE-C0-FH2" id="SYK-oF-Ueh"/>
+                                    <outlet property="allTimeViewsValueLabel" destination="ubr-tF-ZJH" id="DvI-bi-D12"/>
+                                    <outlet property="allTimeVisitorsLabel" destination="EfI-IH-BWM" id="zmx-VA-aRQ"/>
+                                    <outlet property="allTimeVisitorsValueLabel" destination="E8k-cd-ojU" id="HnR-kS-swI"/>
+                                </connections>
+                            </tableViewCell>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="TodaysStatsDetails" rowHeight="132" id="5eL-J1-gUX" userLabel="Today's Stats Details" customClass="InsightsTodaysStatsTableViewCell">
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="5eL-J1-gUX" id="QPP-Ts-AGk">
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nex-6V-DVP" userLabel="Views">
+                                            <rect key="frame" x="8" y="0.0" width="292" height="66"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MAq-BP-G8l" userLabel="Divider View">
+                                                    <rect key="frame" x="291" y="0.0" width="1" height="66"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="1Gy-45-R4j"/>
+                                                        <constraint firstAttribute="width" constant="1" id="NeA-6C-p1p"/>
+                                                    </constraints>
+                                                </view>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jsj-wA-qH3" userLabel="Horizontal Divider View">
+                                                    <rect key="frame" x="8" y="65" width="284" height="1"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="1" id="6Ig-k2-UjH"/>
+                                                    </constraints>
+                                                </view>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9qf-7T-T32">
+                                                    <rect key="frame" x="131" y="21" width="30" height="34"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
+                                                    <state key="normal" title="24">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayViews:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="HFF-4j-ipw"/>
+                                                    </connections>
+                                                </button>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LLy-Md-Bib">
+                                                    <rect key="frame" x="131" y="2" width="30" height="26"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <state key="normal" title="VIEWS">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayViews:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="p5f-ie-g0G"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="jsj-wA-qH3" firstAttribute="leading" secondItem="Nex-6V-DVP" secondAttribute="leadingMargin" id="2bq-i9-PF8"/>
+                                                <constraint firstItem="LLy-Md-Bib" firstAttribute="top" secondItem="Nex-6V-DVP" secondAttribute="top" constant="2" id="4Y5-1E-GWK"/>
+                                                <constraint firstAttribute="trailing" secondItem="MAq-BP-G8l" secondAttribute="trailing" id="4ZS-QK-Z9x"/>
+                                                <constraint firstAttribute="trailing" secondItem="jsj-wA-qH3" secondAttribute="trailing" id="AkG-Wx-CiN"/>
+                                                <constraint firstAttribute="bottom" secondItem="MAq-BP-G8l" secondAttribute="bottom" id="C7S-eZ-eIt"/>
+                                                <constraint firstAttribute="centerX" secondItem="9qf-7T-T32" secondAttribute="centerX" id="LNX-Yg-cqa"/>
+                                                <constraint firstAttribute="height" constant="66" id="OQM-g1-2rG"/>
+                                                <constraint firstAttribute="centerY" secondItem="9qf-7T-T32" secondAttribute="centerY" constant="-5" id="WBr-cj-1n0"/>
+                                                <constraint firstItem="MAq-BP-G8l" firstAttribute="top" secondItem="Nex-6V-DVP" secondAttribute="top" id="ZxZ-nI-lnN"/>
+                                                <constraint firstAttribute="centerX" secondItem="LLy-Md-Bib" secondAttribute="centerX" id="eEE-bg-9aP"/>
+                                                <constraint firstAttribute="bottom" secondItem="jsj-wA-qH3" secondAttribute="bottom" id="nEO-Bx-131"/>
+                                            </constraints>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Q0o-C4-lyC" userLabel="Comments">
+                                            <rect key="frame" x="300" y="66" width="292" height="65"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l3c-1d-9Zr">
+                                                    <rect key="frame" x="131" y="21" width="30" height="34"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
+                                                    <state key="normal" title="0">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayComments:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="mqc-ik-2RF"/>
+                                                    </connections>
+                                                </button>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="d4o-Iq-akx">
+                                                    <rect key="frame" x="118" y="2" width="57" height="26"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <state key="normal" title="COMMENTS">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayComments:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="bSj-X6-Kfa"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstItem="d4o-Iq-akx" firstAttribute="top" secondItem="Q0o-C4-lyC" secondAttribute="top" constant="2" id="M01-VW-uZg"/>
+                                                <constraint firstAttribute="centerY" secondItem="l3c-1d-9Zr" secondAttribute="centerY" constant="-5" id="bAv-zy-aGH"/>
+                                                <constraint firstAttribute="centerX" secondItem="l3c-1d-9Zr" secondAttribute="centerX" id="lIy-yj-uga"/>
+                                                <constraint firstAttribute="centerX" secondItem="d4o-Iq-akx" secondAttribute="centerX" id="uWp-ll-30M"/>
+                                            </constraints>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xGe-pX-eYD" userLabel="Likes">
+                                            <rect key="frame" x="8" y="66" width="292" height="65"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="x5q-bl-SYk" userLabel="Divider View">
+                                                    <rect key="frame" x="291" y="0.0" width="1" height="65"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="Oh2-tS-gVy"/>
+                                                        <constraint firstAttribute="width" constant="1" id="SB8-fc-y5O"/>
+                                                    </constraints>
+                                                </view>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m4F-3j-7NG">
+                                                    <rect key="frame" x="131" y="2" width="30" height="26"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <state key="normal" title="LIKES">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayLikes:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="VV2-mY-iAb"/>
+                                                    </connections>
+                                                </button>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iCZ-K9-CUg">
+                                                    <rect key="frame" x="131" y="21" width="30" height="34"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
+                                                    <state key="normal" title="0">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayLikes:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="3RC-wI-BnZ"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstAttribute="centerX" secondItem="m4F-3j-7NG" secondAttribute="centerX" id="J25-pe-IW3"/>
+                                                <constraint firstAttribute="trailing" secondItem="x5q-bl-SYk" secondAttribute="trailing" id="QCx-Lm-96U"/>
+                                                <constraint firstAttribute="centerX" secondItem="iCZ-K9-CUg" secondAttribute="centerX" id="e7X-g8-VsV"/>
+                                                <constraint firstItem="x5q-bl-SYk" firstAttribute="top" secondItem="xGe-pX-eYD" secondAttribute="top" id="fAz-NE-1xK"/>
+                                                <constraint firstAttribute="centerY" secondItem="iCZ-K9-CUg" secondAttribute="centerY" constant="-5" id="q9S-Dm-7eb"/>
+                                                <constraint firstAttribute="bottom" secondItem="x5q-bl-SYk" secondAttribute="bottom" id="xDg-qo-fUd"/>
+                                                <constraint firstItem="m4F-3j-7NG" firstAttribute="top" secondItem="xGe-pX-eYD" secondAttribute="top" constant="2" id="ytb-ob-6Up"/>
+                                            </constraints>
+                                        </view>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BcG-A8-ztZ" userLabel="Visitors">
+                                            <rect key="frame" x="300" y="0.0" width="292" height="66"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rto-Xl-3ts" userLabel="Horizontal Divider View">
+                                                    <rect key="frame" x="0.0" y="65" width="292" height="1"/>
+                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="1" id="HmC-y0-zDt"/>
+                                                        <constraint firstAttribute="height" constant="1" id="L1k-HC-lec"/>
+                                                    </constraints>
+                                                </view>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pgb-E0-bmm">
+                                                    <rect key="frame" x="131" y="21" width="30" height="34"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="16"/>
+                                                    <state key="normal" title="32">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayVisitors:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="Eg4-nR-oXz"/>
+                                                    </connections>
+                                                </button>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nsE-Pg-YZQ">
+                                                    <rect key="frame" x="125" y="2" width="43" height="26"/>
+                                                    <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
+                                                    <state key="normal" title="VISITORS">
+                                                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                                    </state>
+                                                    <connections>
+                                                        <action selector="switchToTodayVisitors:" destination="Pq6-gc-ScC" eventType="touchUpInside" id="mKG-Ex-ygh"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="rto-Xl-3ts" secondAttribute="bottom" id="1RR-NI-kDE"/>
+                                                <constraint firstAttribute="centerX" secondItem="pgb-E0-bmm" secondAttribute="centerX" id="76Z-Mg-IB9"/>
+                                                <constraint firstItem="nsE-Pg-YZQ" firstAttribute="top" secondItem="BcG-A8-ztZ" secondAttribute="top" constant="2" id="FsM-fH-MhU"/>
+                                                <constraint firstAttribute="centerX" secondItem="nsE-Pg-YZQ" secondAttribute="centerX" id="Hy7-d0-sTn"/>
+                                                <constraint firstAttribute="centerY" secondItem="pgb-E0-bmm" secondAttribute="centerY" constant="-5" id="dRE-bU-Oat"/>
+                                                <constraint firstAttribute="trailing" secondItem="rto-Xl-3ts" secondAttribute="trailing" id="r5b-5S-fMJ"/>
+                                                <constraint firstItem="rto-Xl-3ts" firstAttribute="leading" secondItem="BcG-A8-ztZ" secondAttribute="leading" id="z1g-My-ZEb"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="xGe-pX-eYD" firstAttribute="width" secondItem="BcG-A8-ztZ" secondAttribute="width" id="497-rp-x4h"/>
+                                        <constraint firstAttribute="bottom" secondItem="Q0o-C4-lyC" secondAttribute="bottom" id="4MD-SD-Dzh"/>
+                                        <constraint firstItem="Q0o-C4-lyC" firstAttribute="top" secondItem="BcG-A8-ztZ" secondAttribute="bottom" id="66F-Ad-R8J"/>
+                                        <constraint firstItem="xGe-pX-eYD" firstAttribute="leading" secondItem="QPP-Ts-AGk" secondAttribute="leadingMargin" id="6Jq-Oe-5aM"/>
+                                        <constraint firstItem="Q0o-C4-lyC" firstAttribute="height" secondItem="xGe-pX-eYD" secondAttribute="height" id="7Fz-VO-FvS"/>
+                                        <constraint firstItem="Q0o-C4-lyC" firstAttribute="leading" secondItem="xGe-pX-eYD" secondAttribute="trailing" id="7IQ-zm-tX0"/>
+                                        <constraint firstItem="xGe-pX-eYD" firstAttribute="width" secondItem="Nex-6V-DVP" secondAttribute="width" id="AkF-X4-f1p"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="Q0o-C4-lyC" secondAttribute="trailing" id="BoN-kx-4Tn"/>
+                                        <constraint firstAttribute="trailingMargin" secondItem="BcG-A8-ztZ" secondAttribute="trailing" id="D0o-6p-aRu"/>
+                                        <constraint firstItem="xGe-pX-eYD" firstAttribute="leading" secondItem="QPP-Ts-AGk" secondAttribute="leadingMargin" id="D8j-11-vwe"/>
+                                        <constraint firstItem="Nex-6V-DVP" firstAttribute="height" secondItem="BcG-A8-ztZ" secondAttribute="height" id="ETc-9i-mVL"/>
+                                        <constraint firstItem="Nex-6V-DVP" firstAttribute="leading" secondItem="QPP-Ts-AGk" secondAttribute="leadingMargin" id="IH3-iB-958"/>
+                                        <constraint firstItem="BcG-A8-ztZ" firstAttribute="top" secondItem="QPP-Ts-AGk" secondAttribute="top" id="THh-8Z-ViS"/>
+                                        <constraint firstItem="BcG-A8-ztZ" firstAttribute="leading" secondItem="Nex-6V-DVP" secondAttribute="trailing" id="Tc8-Cy-2Xe"/>
+                                        <constraint firstItem="xGe-pX-eYD" firstAttribute="top" secondItem="Nex-6V-DVP" secondAttribute="bottom" id="hfd-Ak-7Yx"/>
+                                        <constraint firstItem="xGe-pX-eYD" firstAttribute="width" secondItem="Q0o-C4-lyC" secondAttribute="width" id="mNh-Ng-8Ci"/>
+                                        <constraint firstItem="Q0o-C4-lyC" firstAttribute="leading" secondItem="xGe-pX-eYD" secondAttribute="trailing" id="nbK-zm-Xc0"/>
+                                        <constraint firstItem="Nex-6V-DVP" firstAttribute="top" secondItem="QPP-Ts-AGk" secondAttribute="top" id="rBp-eQ-TXe"/>
+                                        <constraint firstAttribute="bottom" secondItem="xGe-pX-eYD" secondAttribute="bottom" id="tWy-sr-UFd"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="todayCommentsButton" destination="d4o-Iq-akx" id="K1Y-no-jrS"/>
+                                    <outlet property="todayCommentsValueButton" destination="l3c-1d-9Zr" id="6Ho-Ub-hYg"/>
+                                    <outlet property="todayLikesButton" destination="m4F-3j-7NG" id="Lns-MU-C5Q"/>
+                                    <outlet property="todayLikesValueButton" destination="iCZ-K9-CUg" id="0Hw-3i-zlV"/>
+                                    <outlet property="todayViewsButton" destination="LLy-Md-Bib" id="mhx-hJ-QEc"/>
+                                    <outlet property="todayViewsValueButton" destination="9qf-7T-T32" id="t3A-Ov-RzQ"/>
+                                    <outlet property="todayVisitorsButton" destination="nsE-Pg-YZQ" id="M4c-IB-1lI"/>
+                                    <outlet property="todayVisitorsValueButton" destination="l3c-1d-9Zr" id="XM9-5u-AKA"/>
                                 </connections>
                             </tableViewCell>
                         </prototypes>
@@ -1283,12 +1717,6 @@
                                     <segue destination="Tay-X0-ceG" kind="embed" identifier="StatsTableEmbed" id="n4F-Fg-DNs"/>
                                 </connections>
                             </containerView>
-                            <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dqo-w7-nT9" userLabel="Insights Container">
-                                <rect key="frame" x="0.0" y="108" width="600" height="492"/>
-                                <connections>
-                                    <segue destination="Pq6-gc-ScC" kind="embed" identifier="InsightsTableEmbed" id="Spw-SF-Sb1"/>
-                                </connections>
-                            </containerView>
                             <progressView hidden="YES" opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="jad-aV-V2h" userLabel="Insights Progress View">
                                 <rect key="frame" x="0.0" y="106" width="600" height="2"/>
                                 <color key="trackTintColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1310,6 +1738,12 @@
                                 <rect key="frame" x="0.0" y="106" width="600" height="2"/>
                                 <color key="trackTintColor" red="0.91372549020000005" green="0.93725490199999995" blue="0.95294117649999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </progressView>
+                            <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dqo-w7-nT9" userLabel="Insights Container">
+                                <rect key="frame" x="0.0" y="108" width="600" height="492"/>
+                                <connections>
+                                    <segue destination="Pq6-gc-ScC" kind="embed" identifier="InsightsTableEmbed" id="Spw-SF-Sb1"/>
+                                </connections>
+                            </containerView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -917,28 +917,28 @@
                                     <outlet property="todayVisitorsValueButton" destination="g6C-KQ-1fr" id="4NS-Qd-PKg"/>
                                 </connections>
                             </tableViewCell>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AllTimeDetails" rowHeight="200" id="HxC-8t-Lp3" userLabel="All Time Details" customClass="InsightsAllTimeTableViewCell">
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="AllTimeDetails" rowHeight="185" id="HxC-8t-Lp3" userLabel="All Time Details" customClass="InsightsAllTimeTableViewCell">
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="HxC-8t-Lp3" id="Ids-uQ-XjV">
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gv6-zf-XEx" userLabel="Posts">
-                                            <rect key="frame" x="8" y="0.0" width="292" height="100"/>
+                                            <rect key="frame" x="8" y="0.0" width="292" height="85"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="128" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="vE2-2f-R5G">
-                                                    <rect key="frame" x="125" y="43" width="43" height="35"/>
+                                                    <rect key="frame" x="125" y="35" width="43" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POSTS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nii-wq-jD8">
-                                                    <rect key="frame" x="131" y="28" width="31" height="14"/>
+                                                    <rect key="frame" x="131" y="20" width="31" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nLg-Ao-MTu" userLabel="Divider View">
-                                                    <rect key="frame" x="291" y="18" width="1" height="64"/>
+                                                    <rect key="frame" x="291" y="18" width="1" height="59"/>
                                                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="1" id="LBj-qK-bqG"/>
@@ -953,13 +953,13 @@
                                                 <constraint firstAttribute="centerX" secondItem="vE2-2f-R5G" secondAttribute="centerX" id="6bu-cT-lfS"/>
                                                 <constraint firstItem="vE2-2f-R5G" firstAttribute="top" secondItem="Nii-wq-jD8" secondAttribute="baseline" constant="4" id="OR0-50-f9k"/>
                                                 <constraint firstAttribute="centerX" secondItem="Nii-wq-jD8" secondAttribute="centerX" id="Odw-0T-tLP"/>
-                                                <constraint firstAttribute="height" constant="100" id="VTl-Wv-Rya"/>
-                                                <constraint firstAttribute="bottom" secondItem="nLg-Ao-MTu" secondAttribute="bottom" constant="18" id="aOW-Ok-atu"/>
+                                                <constraint firstAttribute="height" constant="85" id="VTl-Wv-Rya"/>
+                                                <constraint firstAttribute="bottom" secondItem="nLg-Ao-MTu" secondAttribute="bottom" constant="8" id="aOW-Ok-atu"/>
                                                 <constraint firstAttribute="centerY" secondItem="vE2-2f-R5G" secondAttribute="centerY" constant="-10" id="aUB-WG-IX7"/>
                                             </constraints>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VVz-ur-nje" userLabel="Best Views">
-                                            <rect key="frame" x="300" y="100" width="292" height="99"/>
+                                            <rect key="frame" x="300" y="85" width="292" height="99"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3,485" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="KsA-er-QuV">
                                                     <rect key="frame" x="114" y="32" width="64" height="35"/>
@@ -974,7 +974,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="APRIL 4, 2015" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Upc-GK-XKb">
-                                                    <rect key="frame" x="115" y="71" width="63" height="14"/>
+                                                    <rect key="frame" x="115" y="66" width="63" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -987,7 +987,7 @@
                                                 <constraint firstItem="KsA-er-QuV" firstAttribute="top" secondItem="TpN-dY-IW4" secondAttribute="bottom" constant="4" id="SXr-4O-uVP"/>
                                                 <constraint firstItem="KsA-er-QuV" firstAttribute="top" secondItem="TpN-dY-IW4" secondAttribute="baseline" constant="4" id="c7M-t8-2xB"/>
                                                 <constraint firstAttribute="centerX" secondItem="Upc-GK-XKb" secondAttribute="centerX" id="rVl-tp-XBT"/>
-                                                <constraint firstAttribute="bottom" secondItem="Upc-GK-XKb" secondAttribute="bottom" constant="14" id="uCN-F8-c2F"/>
+                                                <constraint firstAttribute="bottom" secondItem="Upc-GK-XKb" secondAttribute="bottom" constant="19" id="uCN-F8-c2F"/>
                                                 <constraint firstAttribute="centerY" secondItem="KsA-er-QuV" secondAttribute="centerY" id="uxt-qC-oKT"/>
                                             </constraints>
                                             <variation key="default">
@@ -997,22 +997,22 @@
                                             </variation>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4wd-n6-Mh0" userLabel="Visitors">
-                                            <rect key="frame" x="8" y="100" width="292" height="99"/>
+                                            <rect key="frame" x="8" y="85" width="292" height="99"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="42,837" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="E8k-cd-ojU">
-                                                    <rect key="frame" x="107" y="42" width="78" height="35"/>
+                                                    <rect key="frame" x="107" y="32" width="78" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VISITORS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EfI-IH-BWM">
-                                                    <rect key="frame" x="125" y="27" width="43" height="14"/>
+                                                    <rect key="frame" x="125" y="17" width="43" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VBS-Y1-4M2" userLabel="Divider View">
-                                                    <rect key="frame" x="291" y="16" width="1" height="67"/>
+                                                    <rect key="frame" x="291" y="13" width="1" height="63"/>
                                                     <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="3Bk-i8-zkJ"/>
@@ -1023,13 +1023,13 @@
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstItem="E8k-cd-ojU" firstAttribute="top" secondItem="EfI-IH-BWM" secondAttribute="baseline" constant="4" id="6Wm-cw-qs0"/>
-                                                <constraint firstAttribute="bottom" secondItem="VBS-Y1-4M2" secondAttribute="bottom" constant="16" id="6zy-rm-vPe"/>
+                                                <constraint firstAttribute="bottom" secondItem="VBS-Y1-4M2" secondAttribute="bottom" constant="23" id="6zy-rm-vPe"/>
                                                 <constraint firstAttribute="centerX" secondItem="EfI-IH-BWM" secondAttribute="centerX" id="EQ1-tc-aE8"/>
                                                 <constraint firstItem="E8k-cd-ojU" firstAttribute="leading" secondItem="VBS-Y1-4M2" secondAttribute="trailing" id="I9m-es-qzJ"/>
                                                 <constraint firstAttribute="trailing" secondItem="VBS-Y1-4M2" secondAttribute="trailing" id="K02-KQ-ZCj"/>
                                                 <constraint firstAttribute="centerX" secondItem="E8k-cd-ojU" secondAttribute="centerX" id="ZJN-m8-qrM"/>
-                                                <constraint firstItem="VBS-Y1-4M2" firstAttribute="top" secondItem="4wd-n6-Mh0" secondAttribute="top" constant="16" id="qSE-ey-1X1"/>
-                                                <constraint firstAttribute="centerY" secondItem="E8k-cd-ojU" secondAttribute="centerY" constant="-10" id="ukO-ik-qGz"/>
+                                                <constraint firstItem="VBS-Y1-4M2" firstAttribute="top" secondItem="4wd-n6-Mh0" secondAttribute="top" constant="13" id="qSE-ey-1X1"/>
+                                                <constraint firstAttribute="centerY" secondItem="E8k-cd-ojU" secondAttribute="centerY" id="ukO-ik-qGz"/>
                                             </constraints>
                                             <variation key="default">
                                                 <mask key="constraints">
@@ -1038,16 +1038,16 @@
                                             </variation>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MiR-uA-7zk" userLabel="Views">
-                                            <rect key="frame" x="300" y="0.0" width="292" height="100"/>
+                                            <rect key="frame" x="300" y="0.0" width="292" height="85"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="56,613" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ubr-tF-ZJH">
-                                                    <rect key="frame" x="107" y="43" width="78" height="35"/>
+                                                    <rect key="frame" x="107" y="35" width="78" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgE-C0-FH2">
-                                                    <rect key="frame" x="131" y="28" width="30" height="14"/>
+                                                    <rect key="frame" x="131" y="20" width="30" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -529,13 +529,13 @@
                                             <rect key="frame" x="300" y="0.0" width="146" height="99"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="42,837" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="RsC-iV-YWj">
-                                                    <rect key="frame" x="34" y="42" width="78" height="35"/>
+                                                    <rect key="frame" x="34" y="37" width="78" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VISITORS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ixp-TF-kKn">
-                                                    <rect key="frame" x="52" y="27" width="43" height="14"/>
+                                                    <rect key="frame" x="52" y="22" width="43" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -551,7 +551,7 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="RsC-iV-YWj" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="M8I-iH-ljE" secondAttribute="leading" constant="8" id="HXD-18-Amr"/>
-                                                <constraint firstAttribute="centerY" secondItem="RsC-iV-YWj" secondAttribute="centerY" constant="-10" id="HZ1-Sj-KwE"/>
+                                                <constraint firstAttribute="centerY" secondItem="RsC-iV-YWj" secondAttribute="centerY" constant="-5" id="HZ1-Sj-KwE"/>
                                                 <constraint firstAttribute="trailing" secondItem="Ivs-sp-86o" secondAttribute="trailing" id="RRe-Ng-fX8"/>
                                                 <constraint firstAttribute="centerX" secondItem="RsC-iV-YWj" secondAttribute="centerX" id="RnX-5H-bvV"/>
                                                 <constraint firstItem="Ivs-sp-86o" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Ixp-TF-kKn" secondAttribute="trailing" constant="4" id="S9G-0o-cRR"/>
@@ -567,19 +567,19 @@
                                             <rect key="frame" x="446" y="0.0" width="146" height="99"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3,485" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="bhJ-yf-eeg">
-                                                    <rect key="frame" x="41" y="42" width="64" height="35"/>
+                                                    <rect key="frame" x="41" y="37" width="64" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BEST VIEWS EVER" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Ml6-Iu-wKc">
-                                                    <rect key="frame" x="33" y="27" width="81" height="14"/>
+                                                    <rect key="frame" x="33" y="22" width="81" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="APRIL 4, 2015" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p0T-y9-dQS">
-                                                    <rect key="frame" x="42" y="77" width="63" height="14"/>
+                                                    <rect key="frame" x="42" y="73" width="63" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -590,9 +590,9 @@
                                                 <constraint firstItem="bhJ-yf-eeg" firstAttribute="top" secondItem="Ml6-Iu-wKc" secondAttribute="baseline" constant="4" id="7oe-du-RhP"/>
                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ml6-Iu-wKc" secondAttribute="trailing" constant="4" id="EPy-f0-OFa"/>
                                                 <constraint firstItem="bhJ-yf-eeg" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HV6-Cx-Ceh" secondAttribute="leading" constant="8" id="EnY-AB-i8L"/>
-                                                <constraint firstAttribute="centerY" secondItem="bhJ-yf-eeg" secondAttribute="centerY" constant="-10" id="MsL-TP-Tcu"/>
+                                                <constraint firstAttribute="centerY" secondItem="bhJ-yf-eeg" secondAttribute="centerY" constant="-5" id="MsL-TP-Tcu"/>
                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bhJ-yf-eeg" secondAttribute="trailing" constant="8" id="OAK-77-sJl"/>
-                                                <constraint firstAttribute="bottom" secondItem="p0T-y9-dQS" secondAttribute="bottom" constant="8" id="OEI-1U-kyY"/>
+                                                <constraint firstAttribute="bottom" secondItem="p0T-y9-dQS" secondAttribute="bottom" constant="12" id="OEI-1U-kyY"/>
                                                 <constraint firstAttribute="centerX" secondItem="Ml6-Iu-wKc" secondAttribute="centerX" id="Vms-tu-r8l"/>
                                                 <constraint firstItem="Ml6-Iu-wKc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HV6-Cx-Ceh" secondAttribute="leading" constant="4" id="a2a-HS-wm7"/>
                                                 <constraint firstAttribute="centerX" secondItem="bhJ-yf-eeg" secondAttribute="centerX" id="k0v-Iw-UvW"/>
@@ -602,13 +602,13 @@
                                             <rect key="frame" x="154" y="0.0" width="146" height="99"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="56,613" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="qJ0-wu-bhs">
-                                                    <rect key="frame" x="34" y="42" width="78" height="35"/>
+                                                    <rect key="frame" x="34" y="37" width="78" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SnZ-To-N2p">
-                                                    <rect key="frame" x="58" y="27" width="30" height="14"/>
+                                                    <rect key="frame" x="58" y="22" width="30" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -633,20 +633,20 @@
                                                 <constraint firstAttribute="bottom" secondItem="2hi-jg-tAu" secondAttribute="bottom" constant="16" id="jfU-bG-Wxi"/>
                                                 <constraint firstItem="qJ0-wu-bhs" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="EjH-b5-iye" secondAttribute="leading" constant="8" id="k4d-4i-7pg"/>
                                                 <constraint firstItem="2hi-jg-tAu" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="qJ0-wu-bhs" secondAttribute="trailing" constant="8" id="mUK-Kp-S9T"/>
-                                                <constraint firstAttribute="centerY" secondItem="qJ0-wu-bhs" secondAttribute="centerY" constant="-10" id="wKk-z9-4dd"/>
+                                                <constraint firstAttribute="centerY" secondItem="qJ0-wu-bhs" secondAttribute="centerY" constant="-5" id="wKk-z9-4dd"/>
                                             </constraints>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cPN-KE-hdr">
                                             <rect key="frame" x="8" y="0.0" width="146" height="99"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="128" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="kyf-cc-9Pz">
-                                                    <rect key="frame" x="52" y="42" width="43" height="35"/>
+                                                    <rect key="frame" x="52" y="37" width="43" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POSTS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qTg-V3-QrG">
-                                                    <rect key="frame" x="58" y="27" width="31" height="14"/>
+                                                    <rect key="frame" x="58" y="22" width="31" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -668,7 +668,7 @@
                                                 <constraint firstItem="kyf-cc-9Pz" firstAttribute="top" secondItem="qTg-V3-QrG" secondAttribute="baseline" constant="4" id="QO6-x7-uck"/>
                                                 <constraint firstAttribute="trailing" secondItem="PUF-YG-InB" secondAttribute="trailing" id="Snq-2U-n55"/>
                                                 <constraint firstAttribute="bottom" secondItem="PUF-YG-InB" secondAttribute="bottom" constant="16" id="UNd-Dn-DGe"/>
-                                                <constraint firstAttribute="centerY" secondItem="kyf-cc-9Pz" secondAttribute="centerY" constant="-10" id="WPq-Kq-LbB"/>
+                                                <constraint firstAttribute="centerY" secondItem="kyf-cc-9Pz" secondAttribute="centerY" constant="-5" id="WPq-Kq-LbB"/>
                                                 <constraint firstItem="kyf-cc-9Pz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="cPN-KE-hdr" secondAttribute="leading" constant="8" id="bJ0-aX-Ax5"/>
                                                 <constraint firstItem="PUF-YG-InB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="qTg-V3-QrG" secondAttribute="trailing" constant="4" id="exk-OG-SRH"/>
                                             </constraints>
@@ -926,13 +926,13 @@
                                             <rect key="frame" x="8" y="0.0" width="292" height="100"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="128" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="vE2-2f-R5G">
-                                                    <rect key="frame" x="125" y="43" width="43" height="35"/>
+                                                    <rect key="frame" x="125" y="33" width="43" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POSTS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nii-wq-jD8">
-                                                    <rect key="frame" x="131" y="28" width="31" height="14"/>
+                                                    <rect key="frame" x="131" y="18" width="31" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -945,14 +945,6 @@
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="1" id="gtc-sG-7a0"/>
                                                     </constraints>
                                                 </view>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MtW-hg-D9a" userLabel="Horizontal Divider View">
-                                                    <rect key="frame" x="16" y="99" width="260" height="1"/>
-                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="1" id="FEI-oz-laT"/>
-                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="1" id="NrS-qV-8OY"/>
-                                                    </constraints>
-                                                </view>
                                             </subviews>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
@@ -962,36 +954,27 @@
                                                 <constraint firstItem="vE2-2f-R5G" firstAttribute="top" secondItem="Nii-wq-jD8" secondAttribute="baseline" constant="4" id="OR0-50-f9k"/>
                                                 <constraint firstAttribute="centerX" secondItem="Nii-wq-jD8" secondAttribute="centerX" id="Odw-0T-tLP"/>
                                                 <constraint firstAttribute="height" constant="100" id="VTl-Wv-Rya"/>
-                                                <constraint firstItem="Nii-wq-jD8" firstAttribute="top" secondItem="MtW-hg-D9a" secondAttribute="bottom" id="XwH-qF-zha"/>
                                                 <constraint firstAttribute="bottom" secondItem="nLg-Ao-MTu" secondAttribute="bottom" constant="16" id="aOW-Ok-atu"/>
-                                                <constraint firstAttribute="centerY" secondItem="vE2-2f-R5G" secondAttribute="centerY" constant="-10" id="aUB-WG-IX7"/>
-                                                <constraint firstAttribute="bottom" secondItem="MtW-hg-D9a" secondAttribute="bottom" id="mxu-fB-cj2"/>
-                                                <constraint firstItem="MtW-hg-D9a" firstAttribute="leading" secondItem="gv6-zf-XEx" secondAttribute="leading" constant="16" id="o7o-Ar-4Ud"/>
-                                                <constraint firstAttribute="trailing" secondItem="MtW-hg-D9a" secondAttribute="trailing" constant="16" id="orz-rp-chK"/>
+                                                <constraint firstAttribute="centerY" secondItem="vE2-2f-R5G" secondAttribute="centerY" id="aUB-WG-IX7"/>
                                             </constraints>
-                                            <variation key="default">
-                                                <mask key="constraints">
-                                                    <exclude reference="XwH-qF-zha"/>
-                                                </mask>
-                                            </variation>
                                         </view>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VVz-ur-nje" userLabel="Best Views">
                                             <rect key="frame" x="300" y="100" width="292" height="99"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3,485" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="KsA-er-QuV">
-                                                    <rect key="frame" x="114" y="42" width="64" height="35"/>
+                                                    <rect key="frame" x="114" y="37" width="64" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BEST VIEWS EVER" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="TpN-dY-IW4">
-                                                    <rect key="frame" x="106" y="27" width="81" height="14"/>
+                                                    <rect key="frame" x="106" y="22" width="81" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="APRIL 4, 2015" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Upc-GK-XKb">
-                                                    <rect key="frame" x="115" y="77" width="63" height="14"/>
+                                                    <rect key="frame" x="115" y="73" width="63" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -1004,8 +987,8 @@
                                                 <constraint firstItem="KsA-er-QuV" firstAttribute="top" secondItem="TpN-dY-IW4" secondAttribute="bottom" constant="4" id="SXr-4O-uVP"/>
                                                 <constraint firstItem="KsA-er-QuV" firstAttribute="top" secondItem="TpN-dY-IW4" secondAttribute="baseline" constant="4" id="c7M-t8-2xB"/>
                                                 <constraint firstAttribute="centerX" secondItem="Upc-GK-XKb" secondAttribute="centerX" id="rVl-tp-XBT"/>
-                                                <constraint firstAttribute="bottom" secondItem="Upc-GK-XKb" secondAttribute="bottom" constant="8" id="uCN-F8-c2F"/>
-                                                <constraint firstAttribute="centerY" secondItem="KsA-er-QuV" secondAttribute="centerY" constant="-10" id="uxt-qC-oKT"/>
+                                                <constraint firstAttribute="bottom" secondItem="Upc-GK-XKb" secondAttribute="bottom" constant="12" id="uCN-F8-c2F"/>
+                                                <constraint firstAttribute="centerY" secondItem="KsA-er-QuV" secondAttribute="centerY" constant="-5" id="uxt-qC-oKT"/>
                                             </constraints>
                                             <variation key="default">
                                                 <mask key="constraints">
@@ -1017,13 +1000,13 @@
                                             <rect key="frame" x="8" y="100" width="292" height="99"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="42,837" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="E8k-cd-ojU">
-                                                    <rect key="frame" x="107" y="42" width="78" height="35"/>
+                                                    <rect key="frame" x="107" y="37" width="78" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VISITORS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EfI-IH-BWM">
-                                                    <rect key="frame" x="125" y="27" width="43" height="14"/>
+                                                    <rect key="frame" x="125" y="22" width="43" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -1046,7 +1029,7 @@
                                                 <constraint firstAttribute="trailing" secondItem="VBS-Y1-4M2" secondAttribute="trailing" id="K02-KQ-ZCj"/>
                                                 <constraint firstAttribute="centerX" secondItem="E8k-cd-ojU" secondAttribute="centerX" id="ZJN-m8-qrM"/>
                                                 <constraint firstItem="VBS-Y1-4M2" firstAttribute="top" secondItem="4wd-n6-Mh0" secondAttribute="top" constant="16" id="qSE-ey-1X1"/>
-                                                <constraint firstAttribute="centerY" secondItem="E8k-cd-ojU" secondAttribute="centerY" constant="-10" id="ukO-ik-qGz"/>
+                                                <constraint firstAttribute="centerY" secondItem="E8k-cd-ojU" secondAttribute="centerY" constant="-5" id="ukO-ik-qGz"/>
                                             </constraints>
                                             <variation key="default">
                                                 <mask key="constraints">
@@ -1058,34 +1041,22 @@
                                             <rect key="frame" x="300" y="0.0" width="292" height="100"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="56,613" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ubr-tF-ZJH">
-                                                    <rect key="frame" x="107" y="43" width="78" height="35"/>
+                                                    <rect key="frame" x="107" y="33" width="78" height="35"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="25"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="VIEWS" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgE-C0-FH2">
-                                                    <rect key="frame" x="131" y="28" width="30" height="14"/>
+                                                    <rect key="frame" x="131" y="18" width="30" height="14"/>
                                                     <fontDescription key="fontDescription" name="OpenSans" family="Open Sans" pointSize="10"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aaT-Zf-RuJ" userLabel="Horizontal Divider View">
-                                                    <rect key="frame" x="16" y="99" width="260" height="1"/>
-                                                    <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="1" id="5wF-gt-fYs"/>
-                                                        <constraint firstAttribute="height" constant="1" id="Psp-UD-gk2"/>
-                                                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="1" id="p6Y-oQ-wle"/>
-                                                    </constraints>
-                                                </view>
                                             </subviews>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="aaT-Zf-RuJ" secondAttribute="bottom" id="5t6-YA-kZG"/>
-                                                <constraint firstItem="aaT-Zf-RuJ" firstAttribute="leading" secondItem="MiR-uA-7zk" secondAttribute="leading" constant="16" id="NeN-Hx-M5g"/>
                                                 <constraint firstAttribute="centerX" secondItem="xgE-C0-FH2" secondAttribute="centerX" id="SCT-hW-jsQ"/>
-                                                <constraint firstAttribute="centerY" secondItem="ubr-tF-ZJH" secondAttribute="centerY" constant="-10" id="Wqa-gi-zUw"/>
-                                                <constraint firstAttribute="trailing" secondItem="aaT-Zf-RuJ" secondAttribute="trailing" constant="16" id="lSl-AK-n58"/>
+                                                <constraint firstAttribute="centerY" secondItem="ubr-tF-ZJH" secondAttribute="centerY" id="Wqa-gi-zUw"/>
                                                 <constraint firstAttribute="centerX" secondItem="ubr-tF-ZJH" secondAttribute="centerX" id="wBA-oZ-qcD"/>
                                                 <constraint firstItem="ubr-tF-ZJH" firstAttribute="top" secondItem="xgE-C0-FH2" secondAttribute="baseline" constant="4" id="ypR-lp-Kkw"/>
                                             </constraints>

--- a/WordPressCom-Stats-iOS/StatsGroup.m
+++ b/WordPressCom-Stats-iOS/StatsGroup.m
@@ -151,6 +151,9 @@
             break;
 
         case StatsSectionGraph:
+        case StatsSectionInsightsAllTime:
+        case StatsSectionInsightsMostPopular:
+        case StatsSectionInsightsTodaysStats:
         case StatsSectionPeriodHeader:
         case StatsSectionWebVersion:
         case StatsSectionPostDetailsGraph:

--- a/WordPressCom-Stats-iOS/StatsSection.h
+++ b/WordPressCom-Stats-iOS/StatsSection.h
@@ -18,7 +18,10 @@ typedef NS_ENUM(NSInteger, StatsSection) {
     StatsSectionPostDetailsGraph,
     StatsSectionPostDetailsMonthsYears,
     StatsSectionPostDetailsAveragePerDay,
-    StatsSectionPostDetailsRecentWeeks
+    StatsSectionPostDetailsRecentWeeks,
+    StatsSectionInsightsMostPopular,
+    StatsSectionInsightsAllTime,
+    StatsSectionInsightsTodaysStats
 };
 
 typedef NS_ENUM(NSInteger, StatsSubSection) {

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -910,6 +910,9 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
             break;
         case StatsSectionPostDetailsAveragePerDay:
         case StatsSectionPostDetailsGraph:
+        case StatsSectionInsightsAllTime:
+        case StatsSectionInsightsMostPopular:
+        case StatsSectionInsightsTodaysStats:
         case StatsSectionPostDetailsLoadingIndicator:
         case StatsSectionPostDetailsMonthsYears:
         case StatsSectionPostDetailsRecentWeeks:
@@ -1210,6 +1213,9 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
                 text = NSLocalizedString(@"No videos played", @"");
                 break;
             case StatsSectionGraph:
+            case StatsSectionInsightsAllTime:
+            case StatsSectionInsightsMostPopular:
+            case StatsSectionInsightsTodaysStats:
             case StatsSectionPeriodHeader:
             case StatsSectionWebVersion:
             case StatsSectionPostDetailsAveragePerDay:


### PR DESCRIPTION
Closes #264 

On iPhones, show All Time and Today's Stats on Insights in a 2x2 grid rather than a 1x4.

I had a refactor a bunch of the storyboard to move from static cells to dynamic prototypes. This helps pave the way for #257 to be completed easier. I wanted iPhone portrait to be the only size class that got the 2x2 grid but I ran into problems. I time-boxed the solution and the next best solution is 2x2 for all iPhone orientations.

To test, launch StatsDemo after putting a current OAuth2 token and site ID in WPSViewController. Or just use the latest StatsDemo internal release.

![ios simulator screen shot jul 22 2015 2 39 11 pm](https://cloud.githubusercontent.com/assets/373903/8835801/4c23de72-3082-11e5-8680-60251bf07810.png)

Needs Review: @jancavan, @jleandroperez