### PR TITLE
Put the UINavigationController back into the Storyboard to assist iOS 7

### DIFF
--- a/StatsDemo/StatsDemo/WPSViewController.m
+++ b/StatsDemo/StatsDemo/WPSViewController.m
@@ -82,12 +82,12 @@ NSString *const WPStatsTodayWidgetOAuth2TokenKeychainAccessGroup = @"99KV9Z6BKV.
     NSString *path = [[NSBundle mainBundle] pathForResource:@"WordPressCom-Stats-iOS" ofType:@"bundle"];
     NSBundle *bundle = [NSBundle bundleWithPath:path];
 
-    WPStatsViewController *statsViewController = [[UIStoryboard storyboardWithName:@"SiteStats" bundle:bundle] instantiateInitialViewController];
+    UINavigationController *navController = [[UIStoryboard storyboardWithName:@"SiteStats" bundle:bundle] instantiateInitialViewController];
+    WPStatsViewController *statsViewController = (WPStatsViewController *)navController.viewControllers.firstObject;
     statsViewController.siteID = self.siteID;
     statsViewController.siteTimeZone = self.timeZone;
     statsViewController.oauth2Token = self.oauth2Token;
     statsViewController.statsDelegate = self;
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:statsViewController];
     
     [self addChildViewController:navController];
     [self.view addSubview:[navController view]];

--- a/WordPressCom-Stats-iOS/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/SiteStats.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="qzH-Vg-Gi3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="PF0-fe-QqW">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
@@ -1320,7 +1320,7 @@
         <!--Stats View All Table View Controller-->
         <scene sceneID="nII-vT-hUT">
             <objects>
-                <tableViewController storyboardIdentifier="StatsViewAllTableViewController" id="uuT-Sq-uB0" customClass="StatsViewAllTableViewController" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="StatsViewAllTableViewController" modalPresentationStyle="currentContext" id="uuT-Sq-uB0" customClass="StatsViewAllTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="URJ-3C-2Md">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="492"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1451,6 +1451,7 @@
                             <outlet property="delegate" destination="uuT-Sq-uB0" id="cAe-ur-XRK"/>
                         </connections>
                     </tableView>
+                    <navigationItem key="navigationItem" id="K0z-1w-VpJ"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="yjI-9F-acs" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -1751,6 +1752,22 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fb0-xY-90L" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1669" y="98"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="9O0-Fl-a22">
+            <objects>
+                <navigationController id="PF0-fe-QqW" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="uCj-Eh-cV1">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="qzH-Vg-Gi3" kind="relationship" relationship="rootViewController" id="TCN-t1-J8D"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="rCg-lT-qBX" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="930" y="98"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
Fixes #258 

The UINavigationController existed outside of the Storyboard to allow for greater reusability. This is okay on iOS 8 with the new segues (show instead of push) but it breaks things on iOS 7. Readded the nav controller and updated the StatsDemo app to not instantiate another Nav VC.

WPiOS will need to be updated accordingly to support this.

Needs Review: @aerych 