### PR TITLE
Use weak self references in service completion blocks

### DIFF
--- a/WordPressCom-Stats-iOS/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/InsightsTableViewController.m
@@ -1082,145 +1082,147 @@ static CGFloat const InsightsTableSectionFooterHeight = 10.0f;
         self.refreshControl = nil;
     }
     
+    __weak __typeof(self) weakSelf = self;
+    
     [self.statsService retrieveInsightsStatsWithAllTimeStatsCompletionHandler:^(StatsAllTime *allTime, NSError *error)
      {
          if (allTime) {
-             self.sectionData[@(StatsSectionInsightsAllTime)] = allTime;
+             weakSelf.sectionData[@(StatsSectionInsightsAllTime)] = allTime;
          }
      }
                                                     insightsCompletionHandler:^(StatsInsights *insights, NSError *error)
      {
          if (insights) {
-             self.sectionData[@(StatsSectionInsightsMostPopular)] = insights;
+             weakSelf.sectionData[@(StatsSectionInsightsMostPopular)] = insights;
          }
      }
                                                 todaySummaryCompletionHandler:^(StatsSummary *summary, NSError *error)
      {
          if (summary) {
-             self.sectionData[@(StatsSectionInsightsTodaysStats)] = summary;
+             weakSelf.sectionData[@(StatsSectionInsightsTodaysStats)] = summary;
          }
      }
                                            latestPostSummaryCompletionHandler:^(StatsLatestPostSummary *summary, NSError *error)
      {
-         self.sectionData[@(StatsSectionInsightsLatestPostSummary)] = summary;
-         [self.tableView beginUpdates];
+         weakSelf.sectionData[@(StatsSectionInsightsLatestPostSummary)] = summary;
+         [weakSelf.tableView beginUpdates];
          
-         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionInsightsLatestPostSummary)];
+         NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionInsightsLatestPostSummary)];
          NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
          
-         [self.tableView endUpdates];
+         [weakSelf.tableView endUpdates];
 
      }                                               commentsAuthorCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetWithGroupSelector;
-         self.sectionData[@(StatsSectionComments)][@(StatsSubSectionCommentsByAuthor)] = group;
+         weakSelf.sectionData[@(StatsSectionComments)][@(StatsSubSectionCommentsByAuthor)] = group;
          
-         if ([self.selectedSubsections[@(StatsSectionComments)] isEqualToNumber:@(StatsSubSectionCommentsByAuthor)]) {
-             [self.tableView beginUpdates];
+         if ([weakSelf.selectedSubsections[@(StatsSectionComments)] isEqualToNumber:@(StatsSubSectionCommentsByAuthor)]) {
+             [weakSelf.tableView beginUpdates];
              
-             NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionComments)];
+             NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionComments)];
              NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-             [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+             [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
              
-             [self.tableView endUpdates];
+             [weakSelf.tableView endUpdates];
          }
      }
                                                commentsPostsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetWithGroupSelector;
-         self.sectionData[@(StatsSectionComments)][@(StatsSubSectionCommentsByPosts)] = group;
+         weakSelf.sectionData[@(StatsSectionComments)][@(StatsSubSectionCommentsByPosts)] = group;
          
-         if ([self.selectedSubsections[@(StatsSectionComments)] isEqualToNumber:@(StatsSubSectionCommentsByPosts)]) {
-             [self.tableView beginUpdates];
+         if ([weakSelf.selectedSubsections[@(StatsSectionComments)] isEqualToNumber:@(StatsSubSectionCommentsByPosts)]) {
+             [weakSelf.tableView beginUpdates];
              
-             NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionComments)];
+             NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionComments)];
              NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-             [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+             [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
              
-             [self.tableView endUpdates];
+             [weakSelf.tableView endUpdates];
          }
      }
                                               tagsCategoriesCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
-         self.sectionData[@(StatsSectionTagsCategories)] = group;
+         weakSelf.sectionData[@(StatsSectionTagsCategories)] = group;
          
-         [self.tableView beginUpdates];
+         [weakSelf.tableView beginUpdates];
          
-         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionTagsCategories)];
+         NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionTagsCategories)];
          NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
          
-         [self.tableView endUpdates];
+         [weakSelf.tableView endUpdates];
      }
                                              followersDotComCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetWithGroupSelectorAndTotal;
-         self.sectionData[@(StatsSectionFollowers)][@(StatsSubSectionFollowersDotCom)] = group;
+         weakSelf.sectionData[@(StatsSectionFollowers)][@(StatsSubSectionFollowersDotCom)] = group;
          
-         if ([self.selectedSubsections[@(StatsSectionFollowers)] isEqualToNumber:@(StatsSubSectionFollowersDotCom)]) {
-             [self.tableView beginUpdates];
+         if ([weakSelf.selectedSubsections[@(StatsSectionFollowers)] isEqualToNumber:@(StatsSubSectionFollowersDotCom)]) {
+             [weakSelf.tableView beginUpdates];
              
-             NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionFollowers)];
+             NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionFollowers)];
              NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-             [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+             [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
              
-             [self.tableView endUpdates];
+             [weakSelf.tableView endUpdates];
          }
      }
                                               followersEmailCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetWithGroupSelectorAndTotal;
-         self.sectionData[@(StatsSectionFollowers)][@(StatsSubSectionFollowersEmail)] = group;
+         weakSelf.sectionData[@(StatsSectionFollowers)][@(StatsSubSectionFollowersEmail)] = group;
          
-         if ([self.selectedSubsections[@(StatsSectionFollowers)] isEqualToNumber:@(StatsSubSectionFollowersEmail)]) {
-             [self.tableView beginUpdates];
+         if ([weakSelf.selectedSubsections[@(StatsSectionFollowers)] isEqualToNumber:@(StatsSubSectionFollowersEmail)]) {
+             [weakSelf.tableView beginUpdates];
              
-             NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionFollowers)];
+             NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionFollowers)];
              NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-             [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+             [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
              
-             [self.tableView endUpdates];
+             [weakSelf.tableView endUpdates];
          }
      }
                                                    publicizeCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
-         self.sectionData[@(StatsSectionPublicize)] = group;
+         weakSelf.sectionData[@(StatsSectionPublicize)] = group;
          
-         [self.tableView beginUpdates];
+         [weakSelf.tableView beginUpdates];
          
-         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionPublicize)];
+         NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionPublicize)];
          NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
          
-         [self.tableView endUpdates];
+         [weakSelf.tableView endUpdates];
      }
                                                                 progressBlock:^(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations)
      {
-         if (numberOfFinishedOperations == 0 && [self.statsProgressViewDelegate respondsToSelector:@selector(statsViewControllerDidBeginLoadingStats:)]) {
-             [self.statsProgressViewDelegate statsViewControllerDidBeginLoadingStats:self];
+         if (numberOfFinishedOperations == 0 && [weakSelf.statsProgressViewDelegate respondsToSelector:@selector(statsViewControllerDidBeginLoadingStats:)]) {
+             [weakSelf.statsProgressViewDelegate statsViewControllerDidBeginLoadingStats:weakSelf];
          }
          
-         if (numberOfFinishedOperations > 0 && [self.statsProgressViewDelegate respondsToSelector:@selector(statsViewController:loadingProgressPercentage:)]) {
+         if (numberOfFinishedOperations > 0 && [weakSelf.statsProgressViewDelegate respondsToSelector:@selector(statsViewController:loadingProgressPercentage:)]) {
              CGFloat percentage = (CGFloat)numberOfFinishedOperations / (CGFloat)totalNumberOfOperations;
-             [self.statsProgressViewDelegate statsViewController:self loadingProgressPercentage:percentage];
+             [weakSelf.statsProgressViewDelegate statsViewController:weakSelf loadingProgressPercentage:percentage];
          }
      }
                                                   andOverallCompletionHandler:^
      {
          // Set the colors to what they should be (previous color for unknown data)
          
-         [self setupRefreshControl];
-         [self.refreshControl endRefreshing];
+         [weakSelf setupRefreshControl];
+         [weakSelf.refreshControl endRefreshing];
          
          
          // FIXME - Do something elegant possibly
-         [self.tableView reloadData];
+         [weakSelf.tableView reloadData];
          
-         if ([self.statsProgressViewDelegate respondsToSelector:@selector(statsViewControllerDidEndLoadingStats:)]) {
-             [self.statsProgressViewDelegate statsViewControllerDidEndLoadingStats:self];
+         if ([weakSelf.statsProgressViewDelegate respondsToSelector:@selector(statsViewControllerDidEndLoadingStats:)]) {
+             [weakSelf.statsProgressViewDelegate statsViewControllerDidEndLoadingStats:weakSelf];
          }
      }];
 }

--- a/WordPressCom-Stats-iOS/StatsPostDetailsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsPostDetailsTableViewController.m
@@ -312,6 +312,8 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
         [self.tableView reloadData];
     }
     
+    __weak __typeof(self) weakSelf = self;
+    
     [self.statsService retrievePostDetailsStatsForPostID:self.postID
                                    numberOfDaysForVisits:self.isViewHorizontallyCompact ? 7 : 12
                                    withCompletionHandler:^(StatsVisits *visits, StatsGroup *monthsYears, StatsGroup *averagePerDay, StatsGroup *recentWeeks, NSError *error)
@@ -319,27 +321,27 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
 #ifndef AF_APP_EXTENSIONS
         [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
 #endif
-        [self setupRefreshControl];
-        [self.refreshControl endRefreshing];
+        [weakSelf setupRefreshControl];
+        [weakSelf.refreshControl endRefreshing];
 
-        self.isRefreshing = NO;
+        weakSelf.isRefreshing = NO;
         
         monthsYears.offsetRows = 2;
         averagePerDay.offsetRows = 2;
         recentWeeks.offsetRows = 2;
 
-        self.sectionData[@(StatsSectionPostDetailsGraph)] = visits;
-        self.sectionData[@(StatsSectionPostDetailsMonthsYears)] = monthsYears;
-        self.sectionData[@(StatsSectionPostDetailsAveragePerDay)] = averagePerDay;
-        self.sectionData[@(StatsSectionPostDetailsRecentWeeks)] = recentWeeks;
+        weakSelf.sectionData[@(StatsSectionPostDetailsGraph)] = visits;
+        weakSelf.sectionData[@(StatsSectionPostDetailsMonthsYears)] = monthsYears;
+        weakSelf.sectionData[@(StatsSectionPostDetailsAveragePerDay)] = averagePerDay;
+        weakSelf.sectionData[@(StatsSectionPostDetailsRecentWeeks)] = recentWeeks;
 
-        self.selectedDate = [visits.statsData.lastObject date];
-        [self.tableView reloadData];
+        weakSelf.selectedDate = [visits.statsData.lastObject date];
+        [weakSelf.tableView reloadData];
         
         
-        NSInteger sectionNumber = (NSInteger)[self.sections indexOfObject:@(StatsSectionPostDetailsGraph)];
+        NSInteger sectionNumber = (NSInteger)[weakSelf.sections indexOfObject:@(StatsSectionPostDetailsGraph)];
         NSIndexPath *indexPath = [NSIndexPath indexPathForRow:1 inSection:sectionNumber];
-        [self.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+        [weakSelf.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
     }];
     
 }

--- a/WordPressCom-Stats-iOS/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsTableViewController.m
@@ -500,6 +500,8 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
         self.refreshControl = nil;
     }
     
+    __weak __typeof(self) weakSelf = self;
+    
     [self.statsService retrieveAllStatsForDate:self.selectedDate
                                           unit:self.selectedPeriodUnit
                          numberOfDaysForVisits:self.isViewHorizontallyCompact ? 7 : 12
@@ -509,131 +511,131 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
              return;
          }
          
-         self.sectionData[@(StatsSectionGraph)] = visits;
+         weakSelf.sectionData[@(StatsSectionGraph)] = visits;
          
          if (visits.errorWhileRetrieving == NO) {
-             self.selectedDate = ((StatsSummary *)visits.statsData.lastObject).date;
+             weakSelf.selectedDate = ((StatsSummary *)visits.statsData.lastObject).date;
          }
          
-         [self.tableView reloadData];
+         [weakSelf.tableView reloadData];
          
-         NSInteger sectionNumber = (NSInteger)[self.sections indexOfObject:@(StatsSectionGraph)];
-         NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(self.selectedSummaryType + 1) inSection:sectionNumber];
-         [self.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
+         NSInteger sectionNumber = (NSInteger)[weakSelf.sections indexOfObject:@(StatsSectionGraph)];
+         NSIndexPath *indexPath = [NSIndexPath indexPathForItem:(weakSelf.selectedSummaryType + 1) inSection:sectionNumber];
+         [weakSelf.tableView selectRowAtIndexPath:indexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
      }
                        eventsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetWithoutGroupHeader;
-         self.sectionData[@(StatsSectionEvents)] = group;
+         weakSelf.sectionData[@(StatsSectionEvents)] = group;
          
-         [self.tableView beginUpdates];
+         [weakSelf.tableView beginUpdates];
          
-         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionEvents)];
+         NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionEvents)];
          NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
          
-         [self.tableView endUpdates];
+         [weakSelf.tableView endUpdates];
      }
                          postsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
-         self.sectionData[@(StatsSectionPosts)] = group;
+         weakSelf.sectionData[@(StatsSectionPosts)] = group;
          
-         [self.tableView beginUpdates];
+         [weakSelf.tableView beginUpdates];
          
-         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionPosts)];
+         NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionPosts)];
          NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
          
-         [self.tableView endUpdates];
+         [weakSelf.tableView endUpdates];
      }
                      referrersCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
-         self.sectionData[@(StatsSectionReferrers)] = group;
+         weakSelf.sectionData[@(StatsSectionReferrers)] = group;
          
-         [self.tableView beginUpdates];
+         [weakSelf.tableView beginUpdates];
          
-         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionReferrers)];
+         NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionReferrers)];
          NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
          
-         [self.tableView endUpdates];
+         [weakSelf.tableView endUpdates];
      }
                         clicksCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
-         self.sectionData[@(StatsSectionClicks)] = group;
+         weakSelf.sectionData[@(StatsSectionClicks)] = group;
          
-         [self.tableView beginUpdates];
+         [weakSelf.tableView beginUpdates];
          
-         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionClicks)];
+         NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionClicks)];
          NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
          
-         [self.tableView endUpdates];
+         [weakSelf.tableView endUpdates];
      }
                        countryCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
-         self.sectionData[@(StatsSectionCountry)] = group;
+         weakSelf.sectionData[@(StatsSectionCountry)] = group;
          
-         [self.tableView beginUpdates];
+         [weakSelf.tableView beginUpdates];
          
-         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionCountry)];
+         NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionCountry)];
          NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
          
-         [self.tableView endUpdates];
+         [weakSelf.tableView endUpdates];
      }
                         videosCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
-         self.sectionData[@(StatsSectionVideos)] = group;
+         weakSelf.sectionData[@(StatsSectionVideos)] = group;
          
-         [self.tableView beginUpdates];
+         [weakSelf.tableView beginUpdates];
          
-         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionVideos)];
+         NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionVideos)];
          NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
          
-         [self.tableView endUpdates];
+         [weakSelf.tableView endUpdates];
      }
                       authorsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
-         self.sectionData[@(StatsSectionAuthors)] = group;
+         weakSelf.sectionData[@(StatsSectionAuthors)] = group;
          
-         [self.tableView beginUpdates];
+         [weakSelf.tableView beginUpdates];
          
-         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionAuthors)];
+         NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionAuthors)];
          NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
          
-         [self.tableView endUpdates];
+         [weakSelf.tableView endUpdates];
      }
                   searchTermsCompletionHandler:^(StatsGroup *group, NSError *error)
      {
          group.offsetRows = StatsTableRowDataOffsetStandard;
-         self.sectionData[@(StatsSectionSearchTerms)] = group;
+         weakSelf.sectionData[@(StatsSectionSearchTerms)] = group;
          
-         [self.tableView beginUpdates];
+         [weakSelf.tableView beginUpdates];
          
-         NSUInteger sectionNumber = [self.sections indexOfObject:@(StatsSectionSearchTerms)];
+         NSUInteger sectionNumber = [weakSelf.sections indexOfObject:@(StatsSectionSearchTerms)];
          NSIndexSet *indexSet = [NSIndexSet indexSetWithIndex:sectionNumber];
-         [self.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
+         [weakSelf.tableView reloadSections:indexSet withRowAnimation:UITableViewRowAnimationAutomatic];
          
-         [self.tableView endUpdates];
+         [weakSelf.tableView endUpdates];
      }
                                  progressBlock:^(NSUInteger numberOfFinishedOperations, NSUInteger totalNumberOfOperations)
     {
-        if (numberOfFinishedOperations == 0 && [self.statsProgressViewDelegate respondsToSelector:@selector(statsViewControllerDidBeginLoadingStats:)]) {
-            [self.statsProgressViewDelegate statsViewControllerDidBeginLoadingStats:self];
+        if (numberOfFinishedOperations == 0 && [weakSelf.statsProgressViewDelegate respondsToSelector:@selector(statsViewControllerDidBeginLoadingStats:)]) {
+            [weakSelf.statsProgressViewDelegate statsViewControllerDidBeginLoadingStats:weakSelf];
         }
         
-        if (numberOfFinishedOperations > 0 && [self.statsProgressViewDelegate respondsToSelector:@selector(statsViewController:loadingProgressPercentage:)]) {
+        if (numberOfFinishedOperations > 0 && [weakSelf.statsProgressViewDelegate respondsToSelector:@selector(statsViewController:loadingProgressPercentage:)]) {
             CGFloat percentage = (CGFloat)numberOfFinishedOperations / (CGFloat)totalNumberOfOperations;
-            [self.statsProgressViewDelegate statsViewController:self loadingProgressPercentage:percentage];
+            [weakSelf.statsProgressViewDelegate statsViewController:weakSelf loadingProgressPercentage:percentage];
         }
      }
                    andOverallCompletionHandler:^
@@ -642,11 +644,11 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
          [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
 #endif
          
-         [self setupRefreshControl];
-         [self.refreshControl endRefreshing];
+         [weakSelf setupRefreshControl];
+         [weakSelf.refreshControl endRefreshing];
          
-         if ([self.statsProgressViewDelegate respondsToSelector:@selector(statsViewControllerDidEndLoadingStats:)]) {
-             [self.statsProgressViewDelegate statsViewControllerDidEndLoadingStats:self];
+         if ([weakSelf.statsProgressViewDelegate respondsToSelector:@selector(statsViewControllerDidEndLoadingStats:)]) {
+             [weakSelf.statsProgressViewDelegate statsViewControllerDidEndLoadingStats:weakSelf];
          }
      }];
 }

--- a/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
+++ b/WordPressCom-Stats-iOS/StatsViewAllTableViewController.m
@@ -213,24 +213,26 @@ static NSString *const StatsTableLoadingIndicatorCellIdentifier = @"LoadingIndic
         [self.tableView reloadData];
     }
     
+    __weak __typeof(self) weakSelf = self;
+    
     StatsGroupCompletion completion = ^(StatsGroup *group, NSError *error) {
 #ifndef AF_APP_EXTENSIONS
         [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
 #endif
-        [self.refreshControl endRefreshing];
+        [weakSelf.refreshControl endRefreshing];
 
-        self.statsGroup = group;
-        self.statsGroup.offsetRows = 1;
+        weakSelf.statsGroup = group;
+        weakSelf.statsGroup.offsetRows = 1;
         
         NSMutableArray *indexPaths = [NSMutableArray new];
-        for (NSInteger row = 1; row < (NSInteger)(1 + self.statsGroup.items.count); ++row) {
+        for (NSInteger row = 1; row < (NSInteger)(1 + weakSelf.statsGroup.items.count); ++row) {
             [indexPaths addObject:[NSIndexPath indexPathForRow:row inSection:0]];
         }
         
-        [self.tableView beginUpdates];
-        [self.tableView deleteRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:1 inSection:0]] withRowAnimation:UITableViewRowAnimationTop];
-        [self.tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationTop];
-        [self.tableView endUpdates];
+        [weakSelf.tableView beginUpdates];
+        [weakSelf.tableView deleteRowsAtIndexPaths:@[[NSIndexPath indexPathForRow:1 inSection:0]] withRowAnimation:UITableViewRowAnimationTop];
+        [weakSelf.tableView insertRowsAtIndexPaths:indexPaths withRowAnimation:UITableViewRowAnimationTop];
+        [weakSelf.tableView endUpdates];
     };
     
     if (self.statsSection == StatsSectionPosts) {


### PR DESCRIPTION
Fixes: #335

In the four table view controllers use a weak self reference in all of the completion blocks passed to service calls. This should help prevent crashes when remote calls finish after the view is dismissed and a table animation exception is thrown.

This is a little hard to review with StatsDemo due to the nature of stats being the root view controller. In reality, the best way to test is to point WPiOS at the local directory on your disk:

```
pod 'WordPressCom-Stats-iOS', :path => '../WordPressCom-Stats-iOS/'
```

Needs Review: @koke 