### PR TITLE
Framework pods fixes

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
-  - AFNetworking (2.6.2):
-    - AFNetworking/NSURLConnection (= 2.6.2)
-    - AFNetworking/NSURLSession (= 2.6.2)
-    - AFNetworking/Reachability (= 2.6.2)
-    - AFNetworking/Security (= 2.6.2)
-    - AFNetworking/Serialization (= 2.6.2)
-    - AFNetworking/UIKit (= 2.6.2)
-  - AFNetworking/NSURLConnection (2.6.2):
+  - AFNetworking (2.6.3):
+    - AFNetworking/NSURLConnection (= 2.6.3)
+    - AFNetworking/NSURLSession (= 2.6.3)
+    - AFNetworking/Reachability (= 2.6.3)
+    - AFNetworking/Security (= 2.6.3)
+    - AFNetworking/Serialization (= 2.6.3)
+    - AFNetworking/UIKit (= 2.6.3)
+  - AFNetworking/NSURLConnection (2.6.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.6.2):
+  - AFNetworking/NSURLSession (2.6.3):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.6.2)
-  - AFNetworking/Security (2.6.2)
-  - AFNetworking/Serialization (2.6.2)
-  - AFNetworking/UIKit (2.6.2):
+  - AFNetworking/Reachability (2.6.3)
+  - AFNetworking/Security (2.6.3)
+  - AFNetworking/Serialization (2.6.3)
+  - AFNetworking/UIKit (2.6.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
   - CocoaLumberjack (2.0.0):
@@ -31,10 +31,10 @@ PODS:
   - NSObject-SafeExpectations (0.0.2)
   - OCMock (3.2)
   - OHHTTPStubs (3.1.1)
-  - WordPress-iOS-Shared (0.4.4):
+  - WordPress-iOS-Shared (0.5.0):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
-  - WordPressCom-Analytics-iOS (0.0.39)
+  - WordPressCom-Analytics-iOS (0.0.40)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.6.0)
@@ -46,12 +46,12 @@ DEPENDENCIES:
   - WordPressCom-Analytics-iOS (~> 0.0.37)
 
 SPEC CHECKSUMS:
-  AFNetworking: 7f317038a9710cabfa43ec56396b307b45df72ab
+  AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
   CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   OCMock: 28def049ef47f996b515a8eeea958be7ccab2dbb
   OHHTTPStubs: cc1b9cb45b963daf891aa736f35d29d74308f0c9
-  WordPress-iOS-Shared: 345f7c1c49d298114353c3856c53317f0d826078
-  WordPressCom-Analytics-iOS: 5628c4ad2d4a9d49b290e076b7f593d632492dcc
+  WordPress-iOS-Shared: 5480e7b5c9c55158ea22c89ff44fca5597852224
+  WordPressCom-Analytics-iOS: 460c40e66cf4e75d19ca691f6a50c30cd16e8a79
 
 COCOAPODS: 0.39.0

--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -36,21 +36,21 @@ PODS:
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
   - WordPressCom-Analytics-iOS (0.0.40)
-  - WordPressCom-Stats-iOS (0.4.10):
+  - WordPressCom-Stats-iOS (0.4.11):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.4)
     - WordPressCom-Analytics-iOS (~> 0.0.37)
-    - WordPressCom-Stats-iOS/Services (= 0.4.10)
-    - WordPressCom-Stats-iOS/UI (= 0.4.10)
-  - WordPressCom-Stats-iOS/Services (0.4.10):
+    - WordPressCom-Stats-iOS/Services (= 0.4.11)
+    - WordPressCom-Stats-iOS/UI (= 0.4.11)
+  - WordPressCom-Stats-iOS/Services (0.4.11):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.4)
     - WordPressCom-Analytics-iOS (~> 0.0.37)
-  - WordPressCom-Stats-iOS/UI (0.4.10):
+  - WordPressCom-Stats-iOS/UI (0.4.11):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (= 0.0.2)
@@ -73,6 +73,6 @@ SPEC CHECKSUMS:
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   WordPress-iOS-Shared: 5480e7b5c9c55158ea22c89ff44fca5597852224
   WordPressCom-Analytics-iOS: 460c40e66cf4e75d19ca691f6a50c30cd16e8a79
-  WordPressCom-Stats-iOS: c9812cc1c0499380657d5f97f4a16939e1f45bc8
+  WordPressCom-Stats-iOS: 961611065f2eba13ec4c36fcb595ca731a196619
 
 COCOAPODS: 0.39.0

--- a/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
@@ -4,8 +4,8 @@
 #import "StatsItem.h"
 #import "StatsItemAction.h"
 #import <NSObject-SafeExpectations/NSObject+SafeExpectations.h>
-#import <WordPress-iOS-Shared/NSString+XMLExtensions.h>
-#import <WordPressCom-Analytics-iOS/WPAnalytics.h>
+#import <WordPressShared/NSString+XMLExtensions.h>
+#import <WordPressComAnalytics/WPAnalytics.h>
 
 static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.wordpress.com/rest/v1.1";
 

--- a/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
@@ -7,14 +7,14 @@
 #import "InsightsTodaysStatsTableViewCell.h"
 #import "StatsTableSectionHeaderView.h"
 #import "StatsSection.h"
-#import <WordPressCom-Analytics-iOS/WPAnalytics.h>
+#import <WordPressComAnalytics/WPAnalytics.h>
 #import "StatsTwoColumnTableViewCell.h"
 #import "StatsItemAction.h"
 #import "StatsViewAllTableViewController.h"
 #import "StatsPostDetailsTableViewController.h"
 #import "UIViewController+SizeClass.h"
 #import "NSObject+StatsBundleHelper.h"
-#import <WordPress-iOS-Shared/WPFontManager.h>
+#import <WordPressShared/WPFontManager.h>
 
 @interface InlineTextAttachment : NSTextAttachment
 

--- a/WordPressCom-Stats-iOS/UI/StatsPostDetailsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsPostDetailsTableViewController.m
@@ -6,7 +6,7 @@
 #import "StatsTwoColumnTableViewCell.h"
 #import "WPStyleGuide+Stats.h"
 #import "StatsTableSectionHeaderView.h"
-#import <WordPressCom-Analytics-iOS/WPAnalytics.h>
+#import <WordPressComAnalytics/WPAnalytics.h>
 #import "UIViewController+SizeClass.h"
 
 static CGFloat const StatsTableGraphHeight = 185.0f;

--- a/WordPressCom-Stats-iOS/UI/StatsSelectableTableViewCell.m
+++ b/WordPressCom-Stats-iOS/UI/StatsSelectableTableViewCell.m
@@ -1,5 +1,5 @@
 #import "StatsSelectableTableViewCell.h"
-#import <WordPress-iOS-Shared/UIImage+Util.h>
+#import <WordPressShared/UIImage+Util.h>
 #import "WPStyleGuide+Stats.h"
 #import "StatsBorderedCellBackgroundView.h"
 #import "NSObject+StatsBundleHelper.h"

--- a/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
@@ -5,14 +5,14 @@
 #import "StatsItem.h"
 #import "StatsItemAction.h"
 #import "WPStyleGuide+Stats.h"
-#import <WordPress-iOS-Shared/WPImageSource.h>
+#import <WordPressShared/WPImageSource.h>
 #import "StatsTableSectionHeaderView.h"
 #import "StatsDateUtilities.h"
 #import "StatsTwoColumnTableViewCell.h"
 #import "StatsViewAllTableViewController.h"
 #import "StatsPostDetailsTableViewController.h"
 #import "StatsSection.h"
-#import <WordPressCom-Analytics-iOS/WPAnalytics.h>
+#import <WordPressComAnalytics/WPAnalytics.h>
 #import "UIViewController+SizeClass.h"
 
 static CGFloat const StatsTableGraphHeight = 185.0f;

--- a/WordPressCom-Stats-iOS/UI/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/UI/StatsTwoColumnTableViewCell.m
@@ -1,6 +1,6 @@
 #import "StatsTwoColumnTableViewCell.h"
 #import "WPStyleGuide+Stats.h"
-#import <WordPress-iOS-Shared/WPImageSource.h>
+#import <WordPressShared/WPImageSource.h>
 #import "StatsBorderedCellBackgroundView.h"
 #import <QuartzCore/QuartzCore.h>
 #import "WPStyleGuide+Stats.h"

--- a/WordPressCom-Stats-iOS/UI/WPStyleGuide+Stats.h
+++ b/WordPressCom-Stats-iOS/UI/WPStyleGuide+Stats.h
@@ -1,4 +1,4 @@
-#import <WordPress-iOS-Shared/WPStyleGuide.h>
+#import <WordPressShared/WPStyleGuide.h>
 
 extern const CGFloat StatsVCHorizontalOuterPadding;
 extern const CGFloat StatsCVerticalOuterPadding;

--- a/WordPressCom-Stats-iOS/UI/WPStyleGuide+Stats.m
+++ b/WordPressCom-Stats-iOS/UI/WPStyleGuide+Stats.m
@@ -1,5 +1,5 @@
 #import "WPStyleGuide+Stats.h"
-#import <WordPress-iOS-Shared/WPFontManager.h>
+#import <WordPressShared/WPFontManager.h>
 
 const CGFloat StatsVCHorizontalOuterPadding = 8.0f;
 const CGFloat StatsVCVerticalOuterPadding = 16.0f;

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
@@ -5,7 +5,7 @@
 #import "WPStatsServiceRemote.h"
 #import "StatsItem.h"
 #import "StatsItemAction.h"
-#import <WordPressCom-Analytics-iOS/WPAnalytics.h>
+#import <WordPressComAnalytics/WPAnalytics.h>
 
 @interface WPStatsServiceRemoteTests : XCTestCase
 


### PR DESCRIPTION
Brings in fixes for 0.4.11 to get it to compile with last minute changes made to other pods to support frameworks.

Related: #347 