### PR TITLE
Selects new pod versions that revert framework fixes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,9 +5,9 @@ inhibit_all_warnings!
 
 pod 'AFNetworking',	'~> 2.6.0'
 pod 'CocoaLumberjack', '2.0.0'
-pod 'WordPress-iOS-Shared', '~> 0.4'
+pod 'WordPress-iOS-Shared', '~> 0.4.4'
 pod 'NSObject-SafeExpectations', '0.0.2'
-pod 'WordPressCom-Analytics-iOS', '~>0.0.37'
+pod 'WordPressCom-Analytics-iOS', '~>0.0.41'
 
 target 'WordPressCom-Stats-iOSTests', :exclusive => true do
     pod 'OHHTTPStubs', '3.1.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -31,10 +31,10 @@ PODS:
   - NSObject-SafeExpectations (0.0.2)
   - OCMock (3.2)
   - OHHTTPStubs (3.1.1)
-  - WordPress-iOS-Shared (0.5.0):
+  - WordPress-iOS-Shared (0.4.4):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
-  - WordPressCom-Analytics-iOS (0.0.40)
+  - WordPressCom-Analytics-iOS (0.0.41)
 
 DEPENDENCIES:
   - AFNetworking (~> 2.6.0)
@@ -42,8 +42,8 @@ DEPENDENCIES:
   - NSObject-SafeExpectations (= 0.0.2)
   - OCMock
   - OHHTTPStubs (= 3.1.1)
-  - WordPress-iOS-Shared (~> 0.4)
-  - WordPressCom-Analytics-iOS (~> 0.0.37)
+  - WordPress-iOS-Shared (~> 0.4.4)
+  - WordPressCom-Analytics-iOS (~> 0.0.41)
 
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
@@ -51,7 +51,7 @@ SPEC CHECKSUMS:
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   OCMock: 28def049ef47f996b515a8eeea958be7ccab2dbb
   OHHTTPStubs: cc1b9cb45b963daf891aa736f35d29d74308f0c9
-  WordPress-iOS-Shared: 5480e7b5c9c55158ea22c89ff44fca5597852224
-  WordPressCom-Analytics-iOS: 460c40e66cf4e75d19ca691f6a50c30cd16e8a79
+  WordPress-iOS-Shared: 345f7c1c49d298114353c3856c53317f0d826078
+  WordPressCom-Analytics-iOS: 73de8c9a0f1a43bac03fd2fcd881389be73ee820
 
 COCOAPODS: 0.39.0

--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -32,30 +32,30 @@ PODS:
     - HockeySDK/AllFeaturesLib (= 3.8.5)
   - HockeySDK/AllFeaturesLib (3.8.5)
   - NSObject-SafeExpectations (0.0.2)
-  - WordPress-iOS-Shared (0.5.0):
+  - WordPress-iOS-Shared (0.4.4):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (= 2.0.0)
-  - WordPressCom-Analytics-iOS (0.0.40)
-  - WordPressCom-Stats-iOS (0.4.11):
+  - WordPressCom-Analytics-iOS (0.0.41)
+  - WordPressCom-Stats-iOS (0.4.12):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.4)
-    - WordPressCom-Analytics-iOS (~> 0.0.37)
-    - WordPressCom-Stats-iOS/Services (= 0.4.11)
-    - WordPressCom-Stats-iOS/UI (= 0.4.11)
-  - WordPressCom-Stats-iOS/Services (0.4.11):
+    - WordPress-iOS-Shared (~> 0.4.4)
+    - WordPressCom-Analytics-iOS (~> 0.0.41)
+    - WordPressCom-Stats-iOS/Services (= 0.4.12)
+    - WordPressCom-Stats-iOS/UI (= 0.4.12)
+  - WordPressCom-Stats-iOS/Services (0.4.12):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.4)
-    - WordPressCom-Analytics-iOS (~> 0.0.37)
-  - WordPressCom-Stats-iOS/UI (0.4.11):
+    - WordPress-iOS-Shared (~> 0.4.4)
+    - WordPressCom-Analytics-iOS (~> 0.0.41)
+  - WordPressCom-Stats-iOS/UI (0.4.12):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (= 2.0.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.4)
-    - WordPressCom-Analytics-iOS (~> 0.0.37)
+    - WordPress-iOS-Shared (~> 0.4.4)
+    - WordPressCom-Analytics-iOS (~> 0.0.41)
     - WordPressCom-Stats-iOS/Services
 
 DEPENDENCIES:
@@ -71,8 +71,8 @@ SPEC CHECKSUMS:
   CocoaLumberjack: a6f77d987d65dc7ba86b0f84db7d0b9084f77bcb
   HockeySDK: dd11a2b9da3372fd025643bee5bc10c8c613d169
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
-  WordPress-iOS-Shared: 5480e7b5c9c55158ea22c89ff44fca5597852224
-  WordPressCom-Analytics-iOS: 460c40e66cf4e75d19ca691f6a50c30cd16e8a79
-  WordPressCom-Stats-iOS: 961611065f2eba13ec4c36fcb595ca731a196619
+  WordPress-iOS-Shared: 345f7c1c49d298114353c3856c53317f0d826078
+  WordPressCom-Analytics-iOS: 73de8c9a0f1a43bac03fd2fcd881389be73ee820
+  WordPressCom-Stats-iOS: 950454010791a4661952f92e3935ba03951caf94
 
 COCOAPODS: 0.39.0

--- a/StatsDemo/StatsDemo/WPSAppDelegate.m
+++ b/StatsDemo/StatsDemo/WPSAppDelegate.m
@@ -1,9 +1,9 @@
 #import "WPSAppDelegate.h"
 #import <HockeySDK/HockeySDK.h>
-#import <WordPressShared/WPStyleGuide.h>
-#import <WordPressShared/WPFontManager.h>
-#import <WordPressShared/UIImage+Util.h>
-#import <WordPressShared/UIColor+Helpers.h>
+#import <WordPress-iOS-Shared/WPStyleGuide.h>
+#import <WordPress-iOS-Shared/WPFontManager.h>
+#import <WordPress-iOS-Shared/UIImage+Util.h>
+#import <WordPress-iOS-Shared/UIColor+Helpers.h>
 
 int ddLogLevel = DDLogLevelVerbose;
 

--- a/WordPressCom-Stats-iOS.podspec
+++ b/WordPressCom-Stats-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Stats-iOS"
-  s.version      = "0.4.11"
+  s.version      = "0.4.12"
   s.summary      = "Reusable component for displaying WordPress.com site stats in an iOS application."
 
   s.description  = <<-DESC
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   
   s.dependency 'AFNetworking',	'~> 2.6.0'
   s.dependency 'CocoaLumberjack', '2.0.0'
-  s.dependency 'WordPress-iOS-Shared', '~> 0.4'
+  s.dependency 'WordPress-iOS-Shared', '~> 0.4.4'
   s.dependency 'NSObject-SafeExpectations', '0.0.2'
-  s.dependency 'WordPressCom-Analytics-iOS', '~>0.0.37'
+  s.dependency 'WordPressCom-Analytics-iOS', '~> 0.0.41'
 end

--- a/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
@@ -4,8 +4,8 @@
 #import "StatsItem.h"
 #import "StatsItemAction.h"
 #import <NSObject-SafeExpectations/NSObject+SafeExpectations.h>
-#import <WordPressShared/NSString+XMLExtensions.h>
-#import <WordPressComAnalytics/WPAnalytics.h>
+#import <WordPress-iOS-Shared/NSString+XMLExtensions.h>
+#import <WordPressCom-Analytics-iOS/WPAnalytics.h>
 
 static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.wordpress.com/rest/v1.1";
 

--- a/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
@@ -7,14 +7,14 @@
 #import "InsightsTodaysStatsTableViewCell.h"
 #import "StatsTableSectionHeaderView.h"
 #import "StatsSection.h"
-#import <WordPressComAnalytics/WPAnalytics.h>
+#import <WordPressCom-Analytics-iOS/WPAnalytics.h>
 #import "StatsTwoColumnTableViewCell.h"
 #import "StatsItemAction.h"
 #import "StatsViewAllTableViewController.h"
 #import "StatsPostDetailsTableViewController.h"
 #import "UIViewController+SizeClass.h"
 #import "NSObject+StatsBundleHelper.h"
-#import <WordPressShared/WPFontManager.h>
+#import <WordPress-iOS-Shared/WPFontManager.h>
 
 @interface InlineTextAttachment : NSTextAttachment
 

--- a/WordPressCom-Stats-iOS/UI/StatsPostDetailsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsPostDetailsTableViewController.m
@@ -6,7 +6,7 @@
 #import "StatsTwoColumnTableViewCell.h"
 #import "WPStyleGuide+Stats.h"
 #import "StatsTableSectionHeaderView.h"
-#import <WordPressComAnalytics/WPAnalytics.h>
+#import <WordPressCom-Analytics-iOS/WPAnalytics.h>
 #import "UIViewController+SizeClass.h"
 
 static CGFloat const StatsTableGraphHeight = 185.0f;

--- a/WordPressCom-Stats-iOS/UI/StatsSelectableTableViewCell.m
+++ b/WordPressCom-Stats-iOS/UI/StatsSelectableTableViewCell.m
@@ -1,5 +1,5 @@
 #import "StatsSelectableTableViewCell.h"
-#import <WordPressShared/UIImage+Util.h>
+#import <WordPress-iOS-Shared/UIImage+Util.h>
 #import "WPStyleGuide+Stats.h"
 #import "StatsBorderedCellBackgroundView.h"
 #import "NSObject+StatsBundleHelper.h"

--- a/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
@@ -5,14 +5,14 @@
 #import "StatsItem.h"
 #import "StatsItemAction.h"
 #import "WPStyleGuide+Stats.h"
-#import <WordPressShared/WPImageSource.h>
+#import <WordPress-iOS-Shared/WPImageSource.h>
 #import "StatsTableSectionHeaderView.h"
 #import "StatsDateUtilities.h"
 #import "StatsTwoColumnTableViewCell.h"
 #import "StatsViewAllTableViewController.h"
 #import "StatsPostDetailsTableViewController.h"
 #import "StatsSection.h"
-#import <WordPressComAnalytics/WPAnalytics.h>
+#import <WordPressCom-Analytics-iOS/WPAnalytics.h>
 #import "UIViewController+SizeClass.h"
 
 static CGFloat const StatsTableGraphHeight = 185.0f;

--- a/WordPressCom-Stats-iOS/UI/StatsTwoColumnTableViewCell.m
+++ b/WordPressCom-Stats-iOS/UI/StatsTwoColumnTableViewCell.m
@@ -1,6 +1,6 @@
 #import "StatsTwoColumnTableViewCell.h"
 #import "WPStyleGuide+Stats.h"
-#import <WordPressShared/WPImageSource.h>
+#import <WordPress-iOS-Shared/WPImageSource.h>
 #import "StatsBorderedCellBackgroundView.h"
 #import <QuartzCore/QuartzCore.h>
 #import "WPStyleGuide+Stats.h"

--- a/WordPressCom-Stats-iOS/UI/WPStyleGuide+Stats.h
+++ b/WordPressCom-Stats-iOS/UI/WPStyleGuide+Stats.h
@@ -1,4 +1,4 @@
-#import <WordPressShared/WPStyleGuide.h>
+#import <WordPress-iOS-Shared/WPStyleGuide.h>
 
 extern const CGFloat StatsVCHorizontalOuterPadding;
 extern const CGFloat StatsCVerticalOuterPadding;

--- a/WordPressCom-Stats-iOS/UI/WPStyleGuide+Stats.m
+++ b/WordPressCom-Stats-iOS/UI/WPStyleGuide+Stats.m
@@ -1,5 +1,5 @@
 #import "WPStyleGuide+Stats.h"
-#import <WordPressShared/WPFontManager.h>
+#import <WordPress-iOS-Shared/WPFontManager.h>
 
 const CGFloat StatsVCHorizontalOuterPadding = 8.0f;
 const CGFloat StatsVCVerticalOuterPadding = 16.0f;

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
@@ -5,7 +5,7 @@
 #import "WPStatsServiceRemote.h"
 #import "StatsItem.h"
 #import "StatsItemAction.h"
-#import <WordPressComAnalytics/WPAnalytics.h>
+#import <WordPressCom-Analytics-iOS/WPAnalytics.h>
 
 @interface WPStatsServiceRemoteTests : XCTestCase
 


### PR DESCRIPTION
Creates a new version of the stats pod (0.4.12) that pulls in corrected dependency pods that don't rename the header file directories to support frameworks. All dependencies now have been versioned in such a way that won't conflict (minor version bumped instead of patch version).

Needs Review: @jleandroperez 