### PR TITLE
Removed "View Web Version" from stats table

### DIFF
--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -35,7 +35,7 @@ PODS:
   - WordPress-iOS-Shared (0.5.1):
     - AFNetworking (~> 2.5)
     - CocoaLumberjack (~> 2.2.0)
-  - WordPressCom-Analytics-iOS (0.1.0)
+  - WordPressCom-Analytics-iOS (0.1.1)
   - WordPressCom-Stats-iOS (0.5.1):
     - AFNetworking (~> 2.6.0)
     - CocoaLumberjack (~> 2.2.0)
@@ -64,7 +64,7 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   WordPressCom-Stats-iOS:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
@@ -72,7 +72,7 @@ SPEC CHECKSUMS:
   HockeySDK: dd11a2b9da3372fd025643bee5bc10c8c613d169
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   WordPress-iOS-Shared: ced218039d88c91572f3205882832f7a05c61f97
-  WordPressCom-Analytics-iOS: 355b8c6cf1d50d64ca7667e6f9e94c989e466775
+  WordPressCom-Analytics-iOS: c5fce07d0bc0e17ca5fad3b7131f63fe6b48bf86
   WordPressCom-Stats-iOS: 9346d0e9441113eca614a6a9a333216571e4adc8
 
 COCOAPODS: 0.39.0

--- a/WordPressCom-Stats-iOS/UI/SiteStats.storyboard
+++ b/WordPressCom-Stats-iOS/UI/SiteStats.storyboard
@@ -1871,7 +1871,7 @@
             <objects>
                 <tableViewController storyboardIdentifier="StatsViewAllTableViewController" modalPresentationStyle="currentContext" id="uuT-Sq-uB0" customClass="StatsViewAllTableViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="URJ-3C-2Md">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="800"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="1200"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <animations/>
                         <color key="backgroundColor" red="0.90980392160000001" green="0.94117647059999998" blue="0.96078431369999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -2376,7 +2376,7 @@
         <image name="icon-user-16x16.png" width="16" height="16"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="ljy-WF-WHT"/>
         <segue reference="2q2-gC-NHT"/>
+        <segue reference="iGi-oi-ldL"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
@@ -33,7 +33,6 @@ static NSString *const StatsTableGraphCellIdentifier = @"GraphRow";
 static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
 static NSString *const StatsTablePeriodHeaderCellIdentifier = @"PeriodHeader";
 static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSectionHeaderSimpleBorder";
-static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
 
 @interface StatsTableViewController () <WPStatsGraphViewControllerDelegate>
 
@@ -68,8 +67,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
                            @(StatsSectionCountry),
                            @(StatsSectionSearchTerms),
                            @(StatsSectionEvents),
-                           @(StatsSectionVideos),
-                           @(StatsSectionWebVersion)];
+                           @(StatsSectionVideos)];
     
     [self wipeDataAndSeedGroups];
     
@@ -123,7 +121,6 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
         case StatsSectionGraph:
             return 5;
         case StatsSectionPeriodHeader:
-        case StatsSectionWebVersion:
             return 1;
             
         // TODO :: Pull offset from StatsGroup
@@ -237,8 +234,6 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
         return indexPath;
     } else if ([[self cellIdentifierForIndexPath:indexPath] isEqualToString:StatsTableViewAllCellIdentifier]) {
         return indexPath;
-    } else if ([[self cellIdentifierForIndexPath:indexPath] isEqualToString:StatsTableViewWebVersionCellIdentifier]) {
-        return indexPath;
     } else if ([[self cellIdentifierForIndexPath:indexPath] isEqualToString:StatsTableTwoColumnCellIdentifier]) {
         // Disable taps on rows without children
         StatsGroup *group = [self statsDataForStatsSection:statsSection];
@@ -330,17 +325,6 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
                     break;
                 }
             }
-        }
-    } else if ([[self cellIdentifierForIndexPath:indexPath] isEqualToString:StatsTableViewWebVersionCellIdentifier]) {
-        [WPAnalytics track:WPAnalyticsStatStatsOpenedWebVersion];
-        [tableView deselectRowAtIndexPath:indexPath animated:YES];
-
-        if ([self.statsDelegate respondsToSelector:@selector(statsViewController:didSelectViewWebStatsForSiteID:)]) {
-            WPStatsViewController *statsViewController = (WPStatsViewController *)self.navigationController;
-            [self.statsDelegate statsViewController:statsViewController didSelectViewWebStatsForSiteID:self.statsService.siteId];
-        } else {
-            NSURL *webURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://wordpress.com/stats/day/%@", self.statsService.siteId]];
-            [[UIApplication sharedApplication] openURL:webURL];
         }
     }
 }
@@ -747,9 +731,6 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
             
             break;
         }
-        case StatsSectionWebVersion:
-            identifier = StatsTableViewWebVersionCellIdentifier;
-            break;
         case StatsSectionPostDetailsAveragePerDay:
         case StatsSectionPostDetailsGraph:
         case StatsSectionInsightsAllTime:
@@ -759,6 +740,7 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
         case StatsSectionPostDetailsLoadingIndicator:
         case StatsSectionPostDetailsMonthsYears:
         case StatsSectionPostDetailsRecentWeeks:
+        case StatsSectionWebVersion:
             break;
     }
 
@@ -804,10 +786,6 @@ static NSString *const StatsTableViewWebVersionCellIdentifier = @"WebVersion";
                         forStatsSection:statsSection
                           withStatsItem:item
                        andNextStatsItem:nextItem];
-    } else if ([cellIdentifier isEqualToString:StatsTableViewWebVersionCellIdentifier]) {
-        UILabel *label = (UILabel *)[cell.contentView viewWithTag:100];
-        label.text = NSLocalizedString(@"View Web Version", @"View Web Version button in stats");
-        
     }
 }
 

--- a/WordPressCom-Stats-iOS/UI/WPStatsViewController.h
+++ b/WordPressCom-Stats-iOS/UI/WPStatsViewController.h
@@ -23,7 +23,6 @@ typedef NS_ENUM(NSInteger, StatsPeriodType)
 
 @optional
 
-- (void)statsViewController:(WPStatsViewController *)controller didSelectViewWebStatsForSiteID:(NSNumber *)siteID;
 - (void)statsViewController:(WPStatsViewController *)controller openURL:(NSURL *)url;
 
 @end


### PR DESCRIPTION
Closes #357 

Removes the delegate method to view web stats and the actual table view cell. 

View Web Stats was never visible in StatsDemo so you'll have to test in WPiOS with a local pod.

Needs Review: @jleandroperez, @daniloercoli 