### PR TITLE
Simplifies data behind graph to fix a bug and improve multitasking

### DIFF
--- a/WordPressCom-Stats-iOS/Services/WPStatsService.h
+++ b/WordPressCom-Stats-iOS/Services/WPStatsService.h
@@ -34,7 +34,6 @@ typedef NS_ENUM(NSUInteger, StatsFollowerType) {
 
 - (void)retrieveAllStatsForDate:(NSDate *)date
                            unit:(StatsPeriodUnit)unit
-          numberOfDaysForVisits:(NSUInteger)numberOfDays
     withVisitsCompletionHandler:(StatsVisitsCompletion)visitsCompletion
         eventsCompletionHandler:(StatsGroupCompletion)eventsCompletion
          postsCompletionHandler:(StatsGroupCompletion)postsCompletion
@@ -48,7 +47,6 @@ typedef NS_ENUM(NSUInteger, StatsFollowerType) {
      andOverallCompletionHandler:(void (^)())completionHandler;
 
 - (void)retrievePostDetailsStatsForPostID:(NSNumber *)postID
-                    numberOfDaysForVisits:(NSUInteger)numberOfDays
                     withCompletionHandler:(StatsPostDetailsCompletion)completion;
 
 - (void)retrievePostsForDate:(NSDate *)date

--- a/WordPressCom-Stats-iOS/Services/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/Services/WPStatsService.m
@@ -60,7 +60,6 @@ NSString *const TodayCacheKey = @"Today";
 
 - (void)retrieveAllStatsForDate:(NSDate *)date
                            unit:(StatsPeriodUnit)unit
-          numberOfDaysForVisits:(NSUInteger)numberOfDays
     withVisitsCompletionHandler:(StatsVisitsCompletion)visitsCompletion
         eventsCompletionHandler:(StatsGroupCompletion)eventsCompletion
          postsCompletionHandler:(StatsGroupCompletion)postsCompletion
@@ -148,7 +147,6 @@ NSString *const TodayCacheKey = @"Today";
     [self.remote cancelAllRemoteOperations];
     [self.remote batchFetchStatsForDate:endDate
                                    unit:unit
-                  numberOfDaysForVisits:numberOfDays
             withVisitsCompletionHandler:[self remoteVisitsCompletionWithCache:cacheDictionary andCompletionHandler:visitsCompletion]
                 eventsCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionEvents andCompletionHandler:eventsCompletion]
                  postsCompletionHandler:[self remoteItemCompletionWithCache:cacheDictionary forStatsSection:StatsSectionPosts andCompletionHandler:postsCompletion]
@@ -344,7 +342,6 @@ NSString *const TodayCacheKey = @"Today";
 
 
 - (void)retrievePostDetailsStatsForPostID:(NSNumber *)postID
-                    numberOfDaysForVisits:(NSUInteger)numberOfDays
                     withCompletionHandler:(StatsPostDetailsCompletion)completion
 {
     if (!postID || !completion) {
@@ -352,7 +349,6 @@ NSString *const TodayCacheKey = @"Today";
     }
     
     [self.remote fetchPostDetailsStatsForPostID:postID
-                          numberOfDaysForVisits:numberOfDays
                           withCompletionHandler:^(StatsVisits *visits, NSArray *monthsYearsItems, NSArray *averagePerDayItems, NSArray *recentWeeksItems, NSError *error) {
         StatsGroup *monthsYears = [[StatsGroup alloc] initWithStatsSection:StatsSectionPostDetailsMonthsYears andStatsSubSection:StatsSubSectionNone];
         monthsYears.items = monthsYearsItems;

--- a/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.h
+++ b/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.h
@@ -36,7 +36,6 @@ typedef void (^StatsRemoteInsightsCompletion)(NSString *highestHour, NSString *h
  */
 - (void)batchFetchStatsForDate:(NSDate *)date
                           unit:(StatsPeriodUnit)unit
-         numberOfDaysForVisits:(NSUInteger)numberOfDays
    withVisitsCompletionHandler:(StatsRemoteVisitsCompletion)visitsCompletion
        eventsCompletionHandler:(StatsRemoteItemsCompletion)eventsCompletion
         postsCompletionHandler:(StatsRemoteItemsCompletion)postsCompletion
@@ -62,7 +61,6 @@ typedef void (^StatsRemoteInsightsCompletion)(NSString *highestHour, NSString *h
                                 andOverallCompletionHandler:(void (^)())completionHandler;
 
 - (void)fetchPostDetailsStatsForPostID:(NSNumber *)postID
-                 numberOfDaysForVisits:(NSUInteger)numberOfDays
                  withCompletionHandler:(StatsRemotePostDetailsCompletion)completionHandler;
 
 - (void)fetchSummaryStatsForDate:(NSDate *)date
@@ -74,7 +72,6 @@ typedef void (^StatsRemoteInsightsCompletion)(NSString *highestHour, NSString *h
 
 - (void)fetchVisitsStatsForDate:(NSDate *)date
                            unit:(StatsPeriodUnit)unit
-          numberOfDaysForVisits:(NSUInteger)numberOfDays
           withCompletionHandler:(StatsRemoteVisitsCompletion)completionHandler;
 
 - (void)fetchPostsStatsForDate:(NSDate *)date

--- a/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
@@ -8,6 +8,7 @@
 #import <AFNetworking/AFNetworking.h>
 
 static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.wordpress.com/rest/v1.1";
+static NSInteger const NumberOfDays = 12;
 
 @interface WPStatsServiceRemote ()
 
@@ -23,9 +24,7 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
 
 @end
 
-@implementation WPStatsServiceRemote {
-    
-}
+@implementation WPStatsServiceRemote
 
 - (instancetype)initWithOAuth2Token:(NSString *)oauth2Token siteId:(NSNumber *)siteId andSiteTimeZone:(NSTimeZone *)timeZone
 {
@@ -68,7 +67,6 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
 
 - (void)batchFetchStatsForDate:(NSDate *)date
                           unit:(StatsPeriodUnit)unit
-         numberOfDaysForVisits:(NSUInteger)numberOfDays
    withVisitsCompletionHandler:(StatsRemoteVisitsCompletion)visitsCompletion
        eventsCompletionHandler:(StatsRemoteItemsCompletion)eventsCompletion
         postsCompletionHandler:(StatsRemoteItemsCompletion)postsCompletion
@@ -84,7 +82,7 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
     NSMutableArray *mutableOperations = [NSMutableArray new];
     
     if (visitsCompletion) {
-        [mutableOperations addObject:[self operationForVisitsForDate:date unit:unit numberOfDaysForVisits:numberOfDays withCompletionHandler:visitsCompletion]];
+        [mutableOperations addObject:[self operationForVisitsForDate:date unit:unit withCompletionHandler:visitsCompletion]];
     }
     if (eventsCompletion) {
         [mutableOperations addObject:[self operationForEventsForDate:date andUnit:unit withCompletionHandler:eventsCompletion]];
@@ -198,7 +196,6 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
 
 
 - (void)fetchPostDetailsStatsForPostID:(NSNumber *)postID
-                 numberOfDaysForVisits:(NSUInteger)numberOfDays
                  withCompletionHandler:(StatsRemotePostDetailsCompletion)completionHandler
 {
     NSParameterAssert(postID != nil);
@@ -225,8 +222,8 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
         visits.statsData = visitsArray;
         visits.statsDataByDate = visitsDictionary;
         
-        if (visitsData.count > numberOfDays) {
-            visitsData = [visitsData subarrayWithRange:NSMakeRange(visitsData.count - numberOfDays, numberOfDays)];
+        if (visitsData.count > NumberOfDays) {
+            visitsData = [visitsData subarrayWithRange:NSMakeRange(visitsData.count - NumberOfDays, NumberOfDays)];
         }
 
         for (NSArray *visit in visitsData) {
@@ -334,11 +331,10 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
 
 - (void)fetchVisitsStatsForDate:(NSDate *)date
                            unit:(StatsPeriodUnit)unit
-          numberOfDaysForVisits:(NSUInteger)numberOfDays
           withCompletionHandler:(StatsRemoteVisitsCompletion)completionHandler
 {
     
-    AFHTTPRequestOperation *operation = [self operationForVisitsForDate:date unit:unit numberOfDaysForVisits:numberOfDays withCompletionHandler:completionHandler];
+    AFHTTPRequestOperation *operation = [self operationForVisitsForDate:date unit:unit withCompletionHandler:completionHandler];
     [operation start];
 }
 
@@ -678,7 +674,6 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
 
 - (AFHTTPRequestOperation *)operationForVisitsForDate:(NSDate *)date
                                                  unit:(StatsPeriodUnit)unit
-                                numberOfDaysForVisits:(NSUInteger)numberOfDays
                                 withCompletionHandler:(StatsRemoteVisitsCompletion)completionHandler
 {
     id handler = ^(AFHTTPRequestOperation *operation, id responseObject)
@@ -730,7 +725,7 @@ static NSString *const WordPressComApiClientEndpointURL = @"https://public-api.w
         }
     };
     
-    NSDictionary *parameters = @{@"quantity" : @(numberOfDays),
+    NSDictionary *parameters = @{@"quantity" : @(NumberOfDays),
                                  @"unit"     : [self stringForPeriodUnit:unit],
                                  @"date"     : [self deviceLocalStringForDate:date]};
     

--- a/WordPressCom-Stats-iOS/UI/StatsPostDetailsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsPostDetailsTableViewController.m
@@ -77,10 +77,6 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     [self abortRetrieveStats];
 }
 
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
-}
 
 #pragma mark - Table view data source
 
@@ -382,8 +378,6 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
 
 - (void)configureSectionGraphCell:(UITableViewCell *)cell
 {
-    StatsVisits *visits = [self statsDataForStatsSection:StatsSectionPostDetailsGraph];
-    
     if (![[cell.contentView subviews] containsObject:self.graphViewController.view]) {
         UIView *graphView = self.graphViewController.view;
         [graphView removeFromSuperview];
@@ -392,11 +386,8 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
         [cell.contentView addSubview:graphView];
     }
     
-    self.graphViewController.currentSummaryType = StatsSummaryTypeViews;
-    self.graphViewController.visits = visits;
-    [self.graphViewController doneSettingProperties];
-    [self.graphViewController.collectionView reloadData];
-    [self.graphViewController selectGraphBarWithDate:self.selectedDate];
+    StatsVisits *visits = [self statsDataForStatsSection:StatsSectionPostDetailsGraph];
+    [self.graphViewController setVisits:visits forSummaryType:StatsSummaryTypeViews withSelectedDate:self.selectedDate];
 }
 
 

--- a/WordPressCom-Stats-iOS/UI/StatsPostDetailsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsPostDetailsTableViewController.m
@@ -311,7 +311,6 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
     __weak __typeof(self) weakSelf = self;
     
     [self.statsService retrievePostDetailsStatsForPostID:self.postID
-                                   numberOfDaysForVisits:self.isViewHorizontallyCompact ? 7 : 12
                                    withCompletionHandler:^(StatsVisits *visits, StatsGroup *monthsYears, StatsGroup *averagePerDay, StatsGroup *recentWeeks, NSError *error)
     {
         [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;

--- a/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
@@ -471,7 +471,6 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
     
     [self.statsService retrieveAllStatsForDate:self.selectedDate
                                           unit:self.selectedPeriodUnit
-                         numberOfDaysForVisits:self.isViewHorizontallyCompact ? 7 : 12
                     withVisitsCompletionHandler:^(StatsVisits *visits, NSError *error)
      {
          if (skipGraph) {

--- a/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
@@ -88,8 +88,8 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-
-    [self retrieveStatsSkipGraph:NO];
+    
+    [self.tableView reloadData];
 
     [self trackViewControllerAnalytics];
 }
@@ -791,8 +791,6 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
 
 - (void)configureSectionGraphCell:(StatsStandardBorderedTableViewCell *)cell
 {
-    StatsVisits *visits = [self statsDataForStatsSection:StatsSectionGraph];
-
     if (![[cell.contentView subviews] containsObject:self.graphViewController.view]) {
         UIView *graphView = self.graphViewController.view;
         [graphView removeFromSuperview];
@@ -803,11 +801,8 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
     
     cell.bottomBorderEnabled = NO;
     
-    self.graphViewController.currentSummaryType = self.selectedSummaryType;
-    self.graphViewController.visits = visits;
-    [self.graphViewController doneSettingProperties];
-    [self.graphViewController.collectionView reloadData];
-    [self.graphViewController selectGraphBarWithDate:self.selectedDate];
+    StatsVisits *visits = [self statsDataForStatsSection:StatsSectionGraph];
+    [self.graphViewController setVisits:visits forSummaryType:self.selectedSummaryType withSelectedDate:self.selectedDate];
 }
 
 

--- a/WordPressCom-Stats-iOS/UI/UIViewController+SizeClass.m
+++ b/WordPressCom-Stats-iOS/UI/UIViewController+SizeClass.m
@@ -4,12 +4,6 @@
 
 - (BOOL)isViewHorizontallyCompact
 {
-    // iOS <= 8:
-    // We'll just consider 'Compact' all of non iPad Devices
-    if ([self respondsToSelector:@selector(traitCollection)] == false) {
-        return ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) == false;
-    }
-    
     return self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact;
 }
 

--- a/WordPressCom-Stats-iOS/UI/WPStatsGraphViewController.h
+++ b/WordPressCom-Stats-iOS/UI/WPStatsGraphViewController.h
@@ -12,7 +12,6 @@
 
 - (void)setVisits:(StatsVisits *)visits forSummaryType:(StatsSummaryType)summaryType withSelectedDate:(NSDate *)selectedDate;
 - (void)selectGraphBarWithDate:(NSDate *)selectedDate;
-- (void)doneSettingProperties;
 
 @end
 

--- a/WordPressCom-Stats-iOS/UI/WPStatsGraphViewController.h
+++ b/WordPressCom-Stats-iOS/UI/WPStatsGraphViewController.h
@@ -7,10 +7,10 @@
 @interface WPStatsGraphViewController : UICollectionViewController
 
 @property (nonatomic, weak) id<WPStatsGraphViewControllerDelegate> graphDelegate;
-@property (nonatomic, strong) StatsVisits *visits;
-@property (nonatomic, assign) StatsSummaryType currentSummaryType;
 @property (nonatomic, assign) BOOL allowDeselection; // defaults to YES
 
+
+- (void)setVisits:(StatsVisits *)visits forSummaryType:(StatsSummaryType)summaryType withSelectedDate:(NSDate *)selectedDate;
 - (void)selectGraphBarWithDate:(NSDate *)selectedDate;
 - (void)doneSettingProperties;
 

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceRemoteTests.m
@@ -82,7 +82,6 @@
     
     [self.subject fetchVisitsStatsForDate:[NSDate date]
                                      unit:StatsPeriodUnitDay
-                    numberOfDaysForVisits:12
                     withCompletionHandler:^(StatsVisits *visits, NSError *error)
      {
          XCTAssertNotNil(visits, @"visits should not be nil.");
@@ -118,7 +117,6 @@
     
     [self.subject fetchVisitsStatsForDate:[NSDate date]
                                      unit:StatsPeriodUnitDay
-                    numberOfDaysForVisits:12
                     withCompletionHandler:^(StatsVisits *visits, NSError *error)
      {
          [expectation fulfill];
@@ -140,7 +138,6 @@
     
     [self.subject fetchVisitsStatsForDate:[NSDate date]
                                      unit:StatsPeriodUnitDay
-                    numberOfDaysForVisits:12
                     withCompletionHandler:^(StatsVisits *visits, NSError *error)
      {
          XCTAssertNotNil(visits, @"visits should not be nil.");
@@ -183,7 +180,6 @@
     
     [self.subject fetchVisitsStatsForDate:[NSDate date]
                                      unit:StatsPeriodUnitDay
-                    numberOfDaysForVisits:12
                     withCompletionHandler:^(StatsVisits *visits, NSError *error)
      {
          XCTAssertNotNil(visits, @"visits should not be nil.");
@@ -858,7 +854,6 @@
     }];
     
     [self.subject fetchPostDetailsStatsForPostID:@123
-                           numberOfDaysForVisits:12
                            withCompletionHandler:^(StatsVisits *visits, NSArray *monthsYearsItems, NSArray *averagePerDayItems, NSArray *recentWeeksItems, NSError *error)
      {
          XCTAssertNotNil(visits);

--- a/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
+++ b/WordPressCom-Stats-iOSTests/WPStatsServiceTests.m
@@ -46,7 +46,6 @@
     
     [self.subject retrieveAllStatsForDate:[NSDate date]
                                      unit:StatsPeriodUnitDay
-                    numberOfDaysForVisits:12
               withVisitsCompletionHandler:^(StatsVisits *visits, NSError *error) {
                   [visitsExpectation fulfill];
               }
@@ -319,7 +318,6 @@
     
     OCMExpect([remote batchFetchStatsForDate:dateCheckBlock
                                         unit:unit
-                       numberOfDaysForVisits:12
                  withVisitsCompletionHandler:[OCMArg any]
                      eventsCompletionHandler:[OCMArg any]
                       postsCompletionHandler:[OCMArg any]
@@ -336,7 +334,6 @@
     
     [self.subject retrieveAllStatsForDate:baseDate
                                      unit:unit
-                    numberOfDaysForVisits:12
               withVisitsCompletionHandler:nil
                   eventsCompletionHandler:nil
                    postsCompletionHandler:nil
@@ -361,7 +358,6 @@
 
 - (void)batchFetchStatsForDate:(NSDate *)date
                           unit:(StatsPeriodUnit)unit
-         numberOfDaysForVisits:(NSUInteger)numberOfDays
    withVisitsCompletionHandler:(StatsRemoteVisitsCompletion)visitsCompletion
        eventsCompletionHandler:(StatsRemoteItemsCompletion)eventsCompletion
         postsCompletionHandler:(StatsRemoteItemsCompletion)postsCompletion


### PR DESCRIPTION
Fixes: #364
Fixes: #332 

Updated the data behind the graph to be filtered by the graph view controller instead of in the remote service layer. 12 days are picked by default for all remote calls and that data is cached accordingly. When the view controller orientation changes, the data is then truncated for display purposes only. This allows the graph to be refreshed often without expiring the cache or causing a visual delay.

Also fixed with this PR is a problem with the current date selected. If a date was selected in the graph in the past, then view a post detail or view all was tapped, when coming back the graph was redrawn with that date in the past being the most current date selectable. This PR detaches the logic for selected date from the graph being refreshed.

**Testing**
In order to properly test this PR I suggest you check out WPiOS and point the stats pod at this branch or locally on disk to the checked out copy of this branch using `:path =>`.

Test the following:
* Rotations
* Multitasking on iPad: floating, docked 1/3, docked 1/2
* Go into another level (post details, view all)
* Select dates on the graph

Just make sure the general feel of everything isn't wonky. Not a ton was changed but there are some app lifecycle and rotation/size class changes that could futz things up.

Needs Review: @jleandroperez, @daniloercoli 