### PR TITLE
Adds blog and post ID to stats analytics tracking

### DIFF
--- a/StatsDemo/StatsDemo.xcodeproj/project.pbxproj
+++ b/StatsDemo/StatsDemo.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		93B682EE194F95AD00EBF6DF /* WPSViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 93B682ED194F95AD00EBF6DF /* WPSViewController.m */; };
 		93B682F0194F95AD00EBF6DF /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 93B682EF194F95AD00EBF6DF /* Images.xcassets */; };
 		B72E1240C6524ED200BBD883 /* Pods_StatsDemo_Internal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA9D7E756B2CB50AF72144E9 /* Pods_StatsDemo_Internal.framework */; };
-		D2B54CB62CB9D04295FA3119 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EFB566E523828C3E497251F4 /* Pods.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -90,7 +89,6 @@
 				93B682D7194F95AD00EBF6DF /* CoreGraphics.framework in Frameworks */,
 				93B682D9194F95AD00EBF6DF /* UIKit.framework in Frameworks */,
 				93B682D5194F95AD00EBF6DF /* Foundation.framework in Frameworks */,
-				D2B54CB62CB9D04295FA3119 /* Pods.framework in Frameworks */,
 				3E98F5216310EABD5E00DE28 /* Pods_StatsDemo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
@@ -713,7 +713,8 @@ static NSInteger const NumberOfDays = 12;
             } else {
                 DDLogError(@"operationForVisitsForDate resulted in nil date: raw date: %@", period[periodIndex]);
                 [WPAnalytics track:WPAnalyticsStatLogSpecialCondition withProperties:@{@"error_condition" : @"WPStatsServiceRemote operationForVisitsForDate:andUnit:withCompletionHandler",
-                                                                                       @"error_details" : [NSString stringWithFormat:@"Date in raw format: %@", period[periodIndex]] }];
+                                                                                       @"error_details" : [NSString stringWithFormat:@"Date in raw format: %@, period: %@ ", period[periodIndex], @(unit)],
+                                                                                       @"blog_id" : self.siteId}];
             }
         }
         

--- a/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
@@ -114,7 +114,7 @@ static CGFloat const InsightsTableSectionFooterHeight = 10.0f;
 {
     [super viewDidAppear:animated];
     
-    [WPAnalytics track:WPAnalyticsStatStatsInsightsAccessed];
+    [WPAnalytics track:WPAnalyticsStatStatsInsightsAccessed withProperties:@{ @"blog_id" : self.statsService.siteId}];
 }
 
 

--- a/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
@@ -434,8 +434,6 @@ static CGFloat const InsightsTableSectionFooterHeight = 10.0f;
     StatsSubSection statsSubSection = [self statsSubSectionForStatsSection:statsSection];
     
     if ([segue.destinationViewController isKindOfClass:[StatsViewAllTableViewController class]]) {
-        [WPAnalytics track:WPAnalyticsStatStatsViewAllAccessed];
-        
         StatsViewAllTableViewController *viewAllVC = (StatsViewAllTableViewController *)segue.destinationViewController;
         viewAllVC.selectedDate = nil;
         viewAllVC.periodUnit = StatsPeriodUnitDay;
@@ -445,8 +443,6 @@ static CGFloat const InsightsTableSectionFooterHeight = 10.0f;
         viewAllVC.statsDelegate = self.statsDelegate;
     } else if ([segue.identifier isEqualToString:SegueLatestPostDetails] ||
                [segue.identifier isEqualToString:SegueLatestPostDetailsiPad]) {
-        [WPAnalytics track:WPAnalyticsStatStatsSinglePostAccessed];
-        
         // This is kind of a hack since we trigger this seque programmatically sometimes
         // and don't have a reference to the UITableViewCell for section calculation always
         StatsLatestPostSummary *summary = [self statsDataForStatsSection:StatsSectionInsightsLatestPostSummary];

--- a/WordPressCom-Stats-iOS/UI/StatsPostDetailsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsPostDetailsTableViewController.m
@@ -35,7 +35,7 @@ static NSString *const StatsTableNoResultsCellIdentifier = @"NoResultsRow";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    [WPAnalytics track:WPAnalyticsStatStatsSinglePostAccessed];
+    [WPAnalytics track:WPAnalyticsStatStatsSinglePostAccessed withProperties:@{ @"blog_id" : self.statsService.siteId, @"post_id" : self.postID }];
     
     self.sections = [@[@(StatsSectionPostDetailsLoadingIndicator), @(StatsSectionPostDetailsGraph), @(StatsSectionPostDetailsMonthsYears), @(StatsSectionPostDetailsAveragePerDay), @(StatsSectionPostDetailsRecentWeeks)] mutableCopy];
     self.sectionData = [NSMutableDictionary new];

--- a/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
@@ -366,8 +366,6 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
     StatsSection statsSection = [self statsSectionForTableViewSection:indexPath.section];
     
     if ([segue.destinationViewController isKindOfClass:[StatsViewAllTableViewController class]]) {
-        [WPAnalytics track:WPAnalyticsStatStatsViewAllAccessed];
-
         StatsViewAllTableViewController *viewAllVC = (StatsViewAllTableViewController *)segue.destinationViewController;
         viewAllVC.selectedDate = self.selectedDate;
         viewAllVC.periodUnit = self.selectedPeriodUnit;
@@ -376,8 +374,6 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
         viewAllVC.statsService = self.statsService;
         viewAllVC.statsDelegate = self.statsDelegate;
     } else if ([segue.destinationViewController isKindOfClass:[StatsPostDetailsTableViewController class]]) {
-        [WPAnalytics track:WPAnalyticsStatStatsSinglePostAccessed];
-        
         StatsGroup *statsGroup = [self statsDataForStatsSection:statsSection];
         StatsItem *statsItem = [statsGroup statsItemForTableViewRow:indexPath.row];
 

--- a/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
@@ -335,7 +335,7 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
     NSInteger numberOfRows = [self.tableView numberOfRowsInSection:(numberOfSections - 1)];
     
     if (indexPath.section == (numberOfSections - 1) && indexPath.row == (numberOfRows - 1)) {
-        [WPAnalytics track:WPAnalyticsStatStatsScrolledToBottom];
+        [WPAnalytics track:WPAnalyticsStatStatsScrolledToBottom withProperties:@{ @"blog_id" : self.statsService.siteId}];
     }
 }
 
@@ -397,7 +397,7 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
 
 - (void)statsGraphViewController:(WPStatsGraphViewController *)controller didSelectDate:(NSDate *)date
 {
-    [WPAnalytics track:WPAnalyticsStatStatsTappedBarChart];
+    [WPAnalytics track:WPAnalyticsStatStatsTappedBarChart withProperties:@{ @"blog_id" : self.statsService.siteId}];
 
     self.selectedDate = date;
 
@@ -1089,7 +1089,7 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
             break;
     }
     
-    [WPAnalytics track:stat];
+    [WPAnalytics track:stat withProperties:@{ @"blog_id" : self.statsService.siteId}];
 }
 
 

--- a/WordPressCom-Stats-iOS/UI/StatsViewAllTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsViewAllTableViewController.m
@@ -5,6 +5,7 @@
 #import "StatsTwoColumnTableViewCell.h"
 #import "WPStyleGuide+Stats.h"
 #import "StatsTableSectionHeaderView.h"
+#import <WordPressComAnalytics/WPAnalytics.h>
 
 static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSectionHeaderSimpleBorder";
 static NSString *const StatsTableGroupHeaderCellIdentifier = @"GroupHeader";
@@ -34,6 +35,8 @@ static NSString *const StatsTableLoadingIndicatorCellIdentifier = @"LoadingIndic
     
     self.statsGroup = [[StatsGroup alloc] initWithStatsSection:self.statsSection andStatsSubSection:self.statsSubSection];
     self.title = self.statsGroup.groupTitle;
+    
+    [WPAnalytics track:WPAnalyticsStatStatsViewAllAccessed withProperties:@{ @"blog_id" : self.statsService.siteId}];
 }
 
 - (void)viewDidAppear:(BOOL)animated


### PR DESCRIPTION
Fixes #369 

Adds `blog_id` and `post_id` to WPAnalytics calls where appropriate. The blog ID is always available and post ID is available when looking at post details.

I also removed some duplicate calls for tracking of view all and post details.

cc: @martinremy

Needs Review: @sendhil, @daniloercoli