### PR TITLE
Do a nil check on self.presentedViewController before dismissing

### DIFF
--- a/WordPressCom-Stats-iOS/UI/WPStatsViewController.m
+++ b/WordPressCom-Stats-iOS/UI/WPStatsViewController.m
@@ -67,7 +67,7 @@
 {
     [super traitCollectionDidChange:previousTraitCollection];
 
-    if (self.presentedViewController == self.periodActionSheet) {
+    if (self.presentedViewController != nil && self.presentedViewController == self.periodActionSheet) {
         [self dismissViewControllerAnimated:YES completion:nil];
     }
     [self updateSegmentedControlForceUpdate:YES];


### PR DESCRIPTION
Fixes #374 

Make sure the presented view controller isn't nil before calling dismissViewController. Comparing two nils is true in the case of stats VC being presented modaly after selecting the blog in the today widget in WPiOS.

Needs Review: @aerych 