### PR TITLE
Adds support to set log level from outside the pod

### DIFF
--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -73,6 +73,6 @@ SPEC CHECKSUMS:
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   WordPress-iOS-Shared: 43f55f24f0685e431167084071b7914d7c7134a8
   WordPressCom-Analytics-iOS: 1d4cf0426fdc91393ea1ba65daf19133e440ff6a
-  WordPressCom-Stats-iOS: 75dbdf4765c09b90a8fe00375dc96a93e64feffa
+  WordPressCom-Stats-iOS: 6257443f56a2ff070edcedb918c75ea2c9b9310c
 
 COCOAPODS: 0.39.0

--- a/StatsDemo/StatsDemo/WPSAppDelegate.m
+++ b/StatsDemo/StatsDemo/WPSAppDelegate.m
@@ -4,6 +4,7 @@
 #import <WordPressShared/WPFontManager.h>
 #import <WordPressShared/UIImage+Util.h>
 #import <WordPressShared/UIColor+Helpers.h>
+@import WordPressComStatsiOS;
 
 int ddLogLevel = DDLogLevelVerbose;
 
@@ -53,6 +54,7 @@ int ddLogLevel = DDLogLevelVerbose;
     // Override point for customization after application launch.
     [DDLog addLogger:[DDASLLogger sharedInstance]];
     [DDLog addLogger:[DDTTYLogger sharedInstance]];
+    WPStatsSetLoggingLevel(ddLogLevel);
 
 #ifndef DEBUG
     [[BITHockeyManager sharedHockeyManager] configureWithIdentifier:@"070b75fd7cb3b4f5068c9d59d7052ec4"];

--- a/WordPressCom-Stats-iOS.podspec
+++ b/WordPressCom-Stats-iOS.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/wordpress-mobile/WordPressCom-Stats-iOS.git", :tag => s.version.to_s }
   # s.source_files  = "WordPressCom-Stats-iOS", "WordPressCom-Stats-iOS/**/*.{h,m,swift}"
+  s.source_files  = "WordPressCom-Stats-iOS/Common/*.{h,m,swift}"
   s.exclude_files = "WordPressCom-Stats-iOS/Exclude"
   s.prefix_header_file = "WordPressCom-Stats-iOS/WordPressCom-Stats-iOS-Prefix.pch"
 

--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -127,6 +127,8 @@
 		936DA3EC1C999F3500D1E440 /* stats-v1.1-visits-day.json in Resources */ = {isa = PBXBuildFile; fileRef = 93274AE51A07CCE40017238F /* stats-v1.1-visits-day.json */; };
 		936DA3ED1C999F3500D1E440 /* stats-v1.1-latest-post.json in Resources */ = {isa = PBXBuildFile; fileRef = 93C7C8BD1C513647009F2686 /* stats-v1.1-latest-post.json */; };
 		936DA3EE1C999F3500D1E440 /* stats-v1.1-latest-post-views.json in Resources */ = {isa = PBXBuildFile; fileRef = 93C7C8BF1C513844009F2686 /* stats-v1.1-latest-post-views.json */; };
+		E184E11D1C99B34E006AA92D /* WPStatsLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = E184E11B1C99B34E006AA92D /* WPStatsLogging.h */; };
+		E184E11E1C99B34E006AA92D /* WPStatsLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = E184E11C1C99B34E006AA92D /* WPStatsLogging.m */; };
 		F477606655BA2039961A2F05 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5355AAFDF7F1C173DA0B01D3 /* Pods.framework */; };
 /* End PBXBuildFile section */
 
@@ -313,6 +315,8 @@
 		93FE88701B05307D0096F187 /* StatsInsights.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StatsInsights.h; path = Services/StatsInsights.h; sourceTree = "<group>"; };
 		93FE88711B05307D0096F187 /* StatsInsights.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = StatsInsights.m; path = Services/StatsInsights.m; sourceTree = "<group>"; };
 		953128FBE4F75FA57DB90546 /* Pods_WordPressCom_Stats_iOSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressCom_Stats_iOSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E184E11B1C99B34E006AA92D /* WPStatsLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPStatsLogging.h; sourceTree = "<group>"; };
+		E184E11C1C99B34E006AA92D /* WPStatsLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPStatsLogging.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -485,6 +489,7 @@
 		9396CFB41921096B006A66D7 /* WordPressCom-Stats-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				E184E11A1C99B34E006AA92D /* Common */,
 				9396CFDA19215356006A66D7 /* UI */,
 				9396CFD91921534E006A66D7 /* Services */,
 				9396CFD819215346006A66D7 /* Model */,
@@ -621,6 +626,15 @@
 			name = "Test Data";
 			sourceTree = "<group>";
 		};
+		E184E11A1C99B34E006AA92D /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				E184E11B1C99B34E006AA92D /* WPStatsLogging.h */,
+				E184E11C1C99B34E006AA92D /* WPStatsLogging.m */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
 		E3A80993E8D02E9C1E3E5FAC /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -641,6 +655,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E184E11D1C99B34E006AA92D /* WPStatsLogging.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -911,6 +926,7 @@
 				936DA3981C999E9E00D1E440 /* StatsGroup.m in Sources */,
 				936DA38C1C999E8700D1E440 /* StatsPostDetailsTableViewController.m in Sources */,
 				936DA3881C999E7800D1E440 /* WPStatsCollectionViewFlowLayout.m in Sources */,
+				E184E11E1C99B34E006AA92D /* WPStatsLogging.m in Sources */,
 				936DA39B1C999E9E00D1E440 /* StatsItemAction.m in Sources */,
 				936DA3871C999E7800D1E440 /* WPStatsGraphBarCell.m in Sources */,
 				936DA3791C999E5D00D1E440 /* InsightsTableViewController.m in Sources */,

--- a/WordPressCom-Stats-iOS/Common/WPStatsLogging.h
+++ b/WordPressCom-Stats-iOS/Common/WPStatsLogging.h
@@ -1,0 +1,3 @@
+extern int ddLogLevel;
+int WPStatsGetLoggingLevel();
+void WPStatsSetLoggingLevel(int level);

--- a/WordPressCom-Stats-iOS/Common/WPStatsLogging.m
+++ b/WordPressCom-Stats-iOS/Common/WPStatsLogging.m
@@ -1,0 +1,11 @@
+#import "WPStatsLogging.h"
+
+int ddLogLevel = DDLogLevelWarning;
+
+int WPStatsGetLoggingLevel() {
+  return ddLogLevel;
+}
+
+void WPStatsSetLoggingLevel(int level) {
+  ddLogLevel = level;
+}

--- a/WordPressCom-Stats-iOS/WordPressCom-Stats-iOS-Prefix.pch
+++ b/WordPressCom-Stats-iOS/WordPressCom-Stats-iOS-Prefix.pch
@@ -7,7 +7,7 @@
 #ifdef __OBJC__
 
 #import <Foundation/Foundation.h>
+#import "WPStatsLogging.h"
 #import <CocoaLumberjack/CocoaLumberjack.h>
-static const DDLogLevel ddLogLevel = DDLogLevelWarning;
 
 #endif


### PR DESCRIPTION
Based on #391

Previously we defined ddLogLevel as a static variable in the prefix file.
This declares it to every file in the pod but it means that we're stuck with
the default (const) value even if the app setting is different.

AFAIK, there's no way we can directly use the app's ddLogLevel as it needs to
be defined when the framework is linked, so the only way to control this is to
turn that const into a variable, and provide a couple of accessor methods.

cc @astralbodies 