### PR TITLE
Picking the right images for latest post summary & today's stats

### DIFF
--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -361,6 +361,14 @@
 		9367D9D51A6EB5770033911A /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				9311AC241B581E5200BBC877 /* InsightsAllTimeTableViewCell.h */,
+				9311AC251B581E5200BBC877 /* InsightsAllTimeTableViewCell.m */,
+				9311AC281B5845FE00BBC877 /* InsightsMostPopularTableViewCell.h */,
+				9311AC291B5845FE00BBC877 /* InsightsMostPopularTableViewCell.m */,
+				9311AC2B1B58462C00BBC877 /* InsightsSectionHeaderTableViewCell.h */,
+				9311AC2C1B58462C00BBC877 /* InsightsSectionHeaderTableViewCell.m */,
+				9311AC2E1B58466900BBC877 /* InsightsTodaysStatsTableViewCell.h */,
+				9311AC2F1B58466900BBC877 /* InsightsTodaysStatsTableViewCell.m */,
 				938056931B989E44001100B9 /* InsightsWrappingTextCell.xib */,
 				9367D9DA1A7018350033911A /* StatsBorderedCellBackgroundView.h */,
 				9367D9DB1A7018350033911A /* StatsBorderedCellBackgroundView.m */,
@@ -372,14 +380,6 @@
 				936E74A61A69A8990048F552 /* StatsTableSectionHeaderView.m */,
 				9367D9D61A6EB5A90033911A /* StatsTwoColumnTableViewCell.h */,
 				9367D9D71A6EB5A90033911A /* StatsTwoColumnTableViewCell.m */,
-				9311AC241B581E5200BBC877 /* InsightsAllTimeTableViewCell.h */,
-				9311AC251B581E5200BBC877 /* InsightsAllTimeTableViewCell.m */,
-				9311AC281B5845FE00BBC877 /* InsightsMostPopularTableViewCell.h */,
-				9311AC291B5845FE00BBC877 /* InsightsMostPopularTableViewCell.m */,
-				9311AC2B1B58462C00BBC877 /* InsightsSectionHeaderTableViewCell.h */,
-				9311AC2C1B58462C00BBC877 /* InsightsSectionHeaderTableViewCell.m */,
-				9311AC2E1B58466900BBC877 /* InsightsTodaysStatsTableViewCell.h */,
-				9311AC2F1B58466900BBC877 /* InsightsTodaysStatsTableViewCell.m */,
 			);
 			name = Cells;
 			sourceTree = "<group>";

--- a/WordPressCom-Stats-iOS/UI/InsightsTodaysStatsTableViewCell.m
+++ b/WordPressCom-Stats-iOS/UI/InsightsTodaysStatsTableViewCell.m
@@ -19,12 +19,12 @@
     [self.todayVisitorsButton setTitle:[NSLocalizedString(@"Visitors", @"Stats Visitors label") uppercaseStringWithLocale:[NSLocale currentLocale]] forState:UIControlStateNormal];
     [self.todayVisitorsButton setTitleColor:[WPStyleGuide darkGrey] forState:UIControlStateNormal];
     
-    self.todayLikesImage.image = [[UIImage imageNamed:@"icon-eye-16x16" inBundle:self.statsBundle compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    self.todayLikesImage.image = [[UIImage imageNamed:@"icon-star-16x16" inBundle:self.statsBundle compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     self.todayLikesImage.tintColor = [WPStyleGuide darkGrey];
     [self.todayLikesButton setTitle:[NSLocalizedString(@"Likes", @"Stats Likes label") uppercaseStringWithLocale:[NSLocale currentLocale]] forState:UIControlStateNormal];
     [self.todayLikesButton setTitleColor:[WPStyleGuide darkGrey] forState:UIControlStateNormal];
     
-    self.todayCommentsImage.image = [[UIImage imageNamed:@"icon-eye-16x16" inBundle:self.statsBundle compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    self.todayCommentsImage.image = [[UIImage imageNamed:@"icon-comment-16x16" inBundle:self.statsBundle compatibleWithTraitCollection:nil] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
     self.todayCommentsImage.tintColor = [WPStyleGuide darkGrey];
     [self.todayCommentsButton setTitle:[NSLocalizedString(@"Comments", @"Stats Comments label") uppercaseStringWithLocale:[NSLocale currentLocale]] forState:UIControlStateNormal];
     [self.todayCommentsButton setTitleColor:[WPStyleGuide darkGrey] forState:UIControlStateNormal];


### PR DESCRIPTION
Fixes #393 

Somehow we're picking the wrong images for latest post summary & today's stats in insights for likes and comments. This fixes that typo.

Needs Review: @bummytime 