### PR TITLE
Re-selects cell and calculates number of bars after rotation

### DIFF
--- a/WordPressCom-Stats-iOS/UI/WPStatsGraphViewController.m
+++ b/WordPressCom-Stats-iOS/UI/WPStatsGraphViewController.m
@@ -19,6 +19,7 @@
 @property (nonatomic, strong) StatsVisits *visits;
 @property (nonatomic, strong) NSArray<StatsSummary *> *statsData;
 @property (nonatomic, assign) StatsSummaryType currentSummaryType;
+@property (nonatomic, strong) NSDate *selectedDate;
 
 @end
 
@@ -68,8 +69,8 @@ static NSInteger const RecommendedYAxisTicks = 2;
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
     
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
-        [self truncateDataIfNecessary];
-        [self.collectionView reloadData];
+        // Forces data to be re-analyzed and drawn
+        [self setVisits:self.visits forSummaryType:self.currentSummaryType withSelectedDate:self.selectedDate];
     } completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
     }];
 }
@@ -177,6 +178,8 @@ static NSInteger const RecommendedYAxisTicks = 2;
 
 - (void)selectGraphBarWithDate:(NSDate *)selectedDate
 {
+    self.selectedDate = selectedDate;
+    
     for (StatsSummary *summary in self.statsData) {
         NSInteger index = (NSInteger)[self.statsData indexOfObject:summary];
         NSIndexPath *indexPath = [NSIndexPath indexPathForItem:index inSection:0];


### PR DESCRIPTION
Fixes #367 

Rotation now forces re-selection of the cell and recalculation of the number of cells to show.

To Test:
1. Run iPhone 6s Plus or iPad simulator.
2. Rotate the days/weeks/months/years view and make sure the bars animate properly and select the current period.

Needs Review: @bummytime 