### PR TITLE
If Followers has no data, do not display the section title cell.

### DIFF
--- a/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
@@ -168,7 +168,7 @@ static CGFloat const InsightsTableSectionFooterHeight = 10.0f;
             } else if (statsSection == StatsSectionFollowers) {
                 count += StatsTableRowDataOffsetWithGroupSelectorAndTotal;
                 
-                if (group.errorWhileRetrieving) {
+                if (group.errorWhileRetrieving || count == StatsTableRowDataOffsetWithGroupSelectorAndTotal) {
                     count--;
                 }
             } else if (statsSection == StatsSectionEvents) {


### PR DESCRIPTION
Fixes #385 

When Followers has no data (or has an error) properly calculate the number of rows and do not show the section title after the headers.

![simulator screen shot mar 29 2016 7 31 25 am](https://cloud.githubusercontent.com/assets/373903/14107955/8ec4ae50-f580-11e5-94a0-e82aa6f03140.png)

cc: @jancavan, @bummytime 