### PR TITLE
Add caching for insight stats data

### DIFF
--- a/WordPressCom-Stats-iOS.podspec
+++ b/WordPressCom-Stats-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Stats-iOS"
-  s.version      = "0.7.0"
+  s.version      = "0.7.1"
   s.summary      = "Reusable component for displaying WordPress.com site stats in an iOS application."
 
   s.description  = <<-DESC

--- a/WordPressCom-Stats-iOS/Services/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/Services/WPStatsService.m
@@ -88,7 +88,7 @@ NSString *const TodayCacheKey = @"Today";
     id videosData = cacheDictionary[@(StatsSectionVideos)];
     id authorsData = cacheDictionary[@(StatsSectionAuthors)];
     id searchTermsData = cacheDictionary[@(StatsSectionSearchTerms)];
-    
+
     if (cacheDictionary
         && (!visitsCompletion || visitsData)
         && (!eventsCompletion || eventsData)
@@ -257,6 +257,8 @@ NSString *const TodayCacheKey = @"Today";
         return;
     }
 
+    cacheDictionary = [NSMutableDictionary new];
+    
     [self.remote batchFetchInsightsStatsWithAllTimeCompletionHandler:^(NSString *posts, NSNumber *postsValue, NSString *views, NSNumber *viewsValue, NSString *visitors, NSNumber *visitorsValue, NSString *bestViews, NSNumber *bestViewsValue, NSString *bestViewsOn, NSError *error)
      {
          StatsAllTime *allTime;
@@ -346,6 +348,7 @@ NSString *const TodayCacheKey = @"Today";
          if (overallCompletionHandler) {
              overallCompletionHandler();
          }
+         [self.ephemory setObject:cacheDictionary forKey:BatchInsightsCacheKey];
      }];
 }
 

--- a/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
@@ -117,6 +117,7 @@ static CGFloat const InsightsTableSectionFooterHeight = 10.0f;
 
 - (void)viewWillAppear:(BOOL)animated
 {
+    [super viewWillAppear:animated];
     [self retrieveStats];
 }
 

--- a/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/InsightsTableViewController.m
@@ -113,10 +113,12 @@ static CGFloat const InsightsTableSectionFooterHeight = 10.0f;
     [self wipeDataAndSeedGroups];
 
     [self setupRefreshControl];
-
-    [self retrieveStats];
 }
 
+- (void)viewWillAppear:(BOOL)animated
+{
+    [self retrieveStats];
+}
 
 - (void)viewDidAppear:(BOOL)animated
 {
@@ -1128,7 +1130,7 @@ static CGFloat const InsightsTableSectionFooterHeight = 10.0f;
         && self.refreshControl.isRefreshing == NO) {
         self.refreshControl = nil;
     }
-    
+
     __weak __typeof(self) weakSelf = self;
     
     [self.statsService retrieveInsightsStatsWithAllTimeStatsCompletionHandler:^(StatsAllTime *allTime, NSError *error)


### PR DESCRIPTION
Noticed that the insights stats was meant be cached, but the cache dictionary wasn't being saved.

Fixed that, and also fixed `InsightsTableViewController` to be able to handle when the data returns immediately.

This will be necessary for wordpress-mobile/WordPress-iOS#5537. Isn't very testable alone, until there is code that takes advantage of the caching.

### Review

A small one, hope you don't mind looking this over, @astralbodies, since I saw you've worked on a big chunk of this code.