### PR TITLE
Bump stats version for 0.7.2

### DIFF
--- a/WordPressCom-Stats-iOS.podspec
+++ b/WordPressCom-Stats-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Stats-iOS"
-  s.version      = "0.7.1"
+  s.version      = "0.7.2"
   s.summary      = "Reusable component for displaying WordPress.com site stats in an iOS application."
 
   s.description  = <<-DESC


### PR DESCRIPTION
Includes:

* Migration to NSURLSession for networking. #414 
* Allow for stats preloading with delegate access to stats service. #413 