### PR TITLE
This will quiet those nullability warnings

### DIFF
--- a/WordPressCom-Stats-iOS/UI/WPStatsViewController.h
+++ b/WordPressCom-Stats-iOS/UI/WPStatsViewController.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSInteger, StatsPeriodType)
 @optional
 
 - (void)statsViewController:(WPStatsViewController *)controller openURL:(NSURL *)url;
-- (nullable NSObject *)statsService;
+- (NSObject *)statsService;
 
 @end
 


### PR DESCRIPTION
The nullability warnings in `WPStatsViewController.h` will go silent. 

It was either getting rid of the one `nullable` specifier or adding a bunch of `null_unspecified`. I decided on the former.

How's this look @astralbodies?