### PR TITLE
Update to AFNetworking to version 3.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ platform :ios, '9.0'
 use_frameworks!
 
 target 'WordPressCom-Stats-iOS' do
-  pod 'AFNetworking',	'~> 2.6.0'
+  pod 'AFNetworking',	'~> 3.1.0'
   pod 'CocoaLumberjack', '~> 2.2.0'
   pod 'WordPress-iOS-Shared', '~> 0.5.3'
   pod 'NSObject-SafeExpectations', '0.0.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,24 +1,18 @@
 PODS:
-  - AFNetworking (2.6.3):
-    - AFNetworking/NSURLConnection (= 2.6.3)
-    - AFNetworking/NSURLSession (= 2.6.3)
-    - AFNetworking/Reachability (= 2.6.3)
-    - AFNetworking/Security (= 2.6.3)
-    - AFNetworking/Serialization (= 2.6.3)
-    - AFNetworking/UIKit (= 2.6.3)
-  - AFNetworking/NSURLConnection (2.6.3):
+  - AFNetworking (3.1.0):
+    - AFNetworking/NSURLSession (= 3.1.0)
+    - AFNetworking/Reachability (= 3.1.0)
+    - AFNetworking/Security (= 3.1.0)
+    - AFNetworking/Serialization (= 3.1.0)
+    - AFNetworking/UIKit (= 3.1.0)
+  - AFNetworking/NSURLSession (3.1.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.6.3):
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.6.3)
-  - AFNetworking/Security (2.6.3)
-  - AFNetworking/Serialization (2.6.3)
-  - AFNetworking/UIKit (2.6.3):
-    - AFNetworking/NSURLConnection
+  - AFNetworking/Reachability (3.1.0)
+  - AFNetworking/Security (3.1.0)
+  - AFNetworking/Serialization (3.1.0)
+  - AFNetworking/UIKit (3.1.0):
     - AFNetworking/NSURLSession
   - CocoaLumberjack (2.2.0):
     - CocoaLumberjack/Default (= 2.2.0)
@@ -48,7 +42,7 @@ PODS:
   - WordPressCom-Analytics-iOS (0.1.11)
 
 DEPENDENCIES:
-  - AFNetworking (~> 2.6.0)
+  - AFNetworking (~> 3.1.0)
   - CocoaLumberjack (~> 2.2.0)
   - NSObject-SafeExpectations (= 0.0.2)
   - OCMock
@@ -57,7 +51,7 @@ DEPENDENCIES:
   - WordPressCom-Analytics-iOS (~> 0.1.4)
 
 SPEC CHECKSUMS:
-  AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
+  AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   OCMock: d68685bde31f69cb61d518dcb39269080c78b5ed
@@ -65,6 +59,6 @@ SPEC CHECKSUMS:
   WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
   WordPressCom-Analytics-iOS: a844ac791b2627dbb64ba62090654f43dd2abc1c
 
-PODFILE CHECKSUM: b4a0349adafb154fc6b6bf54371047a0212c3c6c
+PODFILE CHECKSUM: 7a8308dbf54fe6d90aab0c86755e8e727b9f21ea
 
 COCOAPODS: 1.0.1

--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -1,24 +1,18 @@
 PODS:
-  - AFNetworking (2.6.3):
-    - AFNetworking/NSURLConnection (= 2.6.3)
-    - AFNetworking/NSURLSession (= 2.6.3)
-    - AFNetworking/Reachability (= 2.6.3)
-    - AFNetworking/Security (= 2.6.3)
-    - AFNetworking/Serialization (= 2.6.3)
-    - AFNetworking/UIKit (= 2.6.3)
-  - AFNetworking/NSURLConnection (2.6.3):
+  - AFNetworking (3.1.0):
+    - AFNetworking/NSURLSession (= 3.1.0)
+    - AFNetworking/Reachability (= 3.1.0)
+    - AFNetworking/Security (= 3.1.0)
+    - AFNetworking/Serialization (= 3.1.0)
+    - AFNetworking/UIKit (= 3.1.0)
+  - AFNetworking/NSURLSession (3.1.0):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/NSURLSession (2.6.3):
-    - AFNetworking/Reachability
-    - AFNetworking/Security
-    - AFNetworking/Serialization
-  - AFNetworking/Reachability (2.6.3)
-  - AFNetworking/Security (2.6.3)
-  - AFNetworking/Serialization (2.6.3)
-  - AFNetworking/UIKit (2.6.3):
-    - AFNetworking/NSURLConnection
+  - AFNetworking/Reachability (3.1.0)
+  - AFNetworking/Security (3.1.0)
+  - AFNetworking/Serialization (3.1.0)
+  - AFNetworking/UIKit (3.1.0):
     - AFNetworking/NSURLSession
   - CocoaLumberjack (2.2.0):
     - CocoaLumberjack/Default (= 2.2.0)
@@ -35,22 +29,22 @@ PODS:
   - WordPress-iOS-Shared (0.5.9):
     - CocoaLumberjack (~> 2.2.0)
   - WordPressCom-Analytics-iOS (0.1.15)
-  - WordPressCom-Stats-iOS (0.7.1):
-    - AFNetworking (~> 2.6.0)
+  - WordPressCom-Stats-iOS (0.7.2):
+    - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.3)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-    - WordPressCom-Stats-iOS/Services (= 0.7.1)
-    - WordPressCom-Stats-iOS/UI (= 0.7.1)
-  - WordPressCom-Stats-iOS/Services (0.7.1):
-    - AFNetworking (~> 2.6.0)
+    - WordPressCom-Stats-iOS/Services (= 0.7.2)
+    - WordPressCom-Stats-iOS/UI (= 0.7.2)
+  - WordPressCom-Stats-iOS/Services (0.7.2):
+    - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.3)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-  - WordPressCom-Stats-iOS/UI (0.7.1):
-    - AFNetworking (~> 2.6.0)
+  - WordPressCom-Stats-iOS/UI (0.7.2):
+    - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.3)
@@ -66,13 +60,13 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  AFNetworking: cb8d14a848e831097108418f5d49217339d4eb60
+  AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   HockeySDK: 1b69a82782f6a3d4a1c0b1f04dca4bca83fc8c82
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
   WordPressCom-Analytics-iOS: e1a7111255e98561c4b5a33ef4baa75a68e0d5d3
-  WordPressCom-Stats-iOS: 34847edf6e8e4175f9b770e08b0736d5d4c8ce84
+  WordPressCom-Stats-iOS: 4ab524eac1dc10c0fb142d65883e0b305df089c5
 
 PODFILE CHECKSUM: 370d0f0593d313302b1555d22d18108c29964011
 

--- a/WordPressCom-Stats-iOS.podspec
+++ b/WordPressCom-Stats-iOS.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   
   s.header_dir = 'WordPressComStatsiOS'
   s.module_name = 'WordPressComStatsiOS'
-  s.dependency 'AFNetworking',	'~> 2.6.0'
+  s.dependency 'AFNetworking',	'~> 3.1.0'
   s.dependency 'CocoaLumberjack', '~> 2.2.0'
   s.dependency 'WordPress-iOS-Shared', '~> 0.5.3'
   s.dependency 'NSObject-SafeExpectations', '0.0.2'

--- a/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
@@ -1573,7 +1573,7 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
                                                  success:(void (^)(NSURLSessionDataTask *task, id responseObject))success
                                                  failure:(void (^)(NSURLSessionDataTask *task, NSError *error))failure
 {
-    NSURLSessionDataTask *task = [self.manager GET:url parameters:parameters success:success failure:failure];
+    NSURLSessionDataTask *task = [self.manager GET:url parameters:parameters progress:nil success:success failure:failure];
     return task;
 }
 


### PR DESCRIPTION
Closes #417 

Updates AFNetworking to version 3.1

- How to test:
  - Launch the StatsDemo app
  - Test the several sections of the app and see if everything is working ok.

Needs Review: @astralbodies 