### PR TITLE
Switch to setLocalizedDateFormatFromTemplate on UI NSDateFormatters

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
   - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
   - NSObject-SafeExpectations (0.0.2)
-  - OCMock (3.3)
+  - OCMock (3.3.1)
   - OHHTTPStubs (4.6.0):
     - OHHTTPStubs/Default (= 4.6.0)
   - OHHTTPStubs/Core (4.6.0)
@@ -54,7 +54,7 @@ SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
-  OCMock: d68685bde31f69cb61d518dcb39269080c78b5ed
+  OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
   OHHTTPStubs: cb1aefbbeb4de4e741644455d4b945538e5248a2
   WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
   WordPressCom-Analytics-iOS: e1a7111255e98561c4b5a33ef4baa75a68e0d5d3

--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -22,28 +22,28 @@ PODS:
     - CocoaLumberjack/Core
   - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
-  - HockeySDK (4.0.1):
-    - HockeySDK/AllFeaturesLib (= 4.0.1)
-  - HockeySDK/AllFeaturesLib (4.0.1)
+  - HockeySDK (4.0.2):
+    - HockeySDK/AllFeaturesLib (= 4.0.2)
+  - HockeySDK/AllFeaturesLib (4.0.2)
   - NSObject-SafeExpectations (0.0.2)
   - WordPress-iOS-Shared (0.5.9):
     - CocoaLumberjack (~> 2.2.0)
   - WordPressCom-Analytics-iOS (0.1.15)
-  - WordPressCom-Stats-iOS (0.7.3):
+  - WordPressCom-Stats-iOS (0.7.4):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.3)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-    - WordPressCom-Stats-iOS/Services (= 0.7.3)
-    - WordPressCom-Stats-iOS/UI (= 0.7.3)
-  - WordPressCom-Stats-iOS/Services (0.7.3):
+    - WordPressCom-Stats-iOS/Services (= 0.7.4)
+    - WordPressCom-Stats-iOS/UI (= 0.7.4)
+  - WordPressCom-Stats-iOS/Services (0.7.4):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
     - WordPress-iOS-Shared (~> 0.5.3)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-  - WordPressCom-Stats-iOS/UI (0.7.3):
+  - WordPressCom-Stats-iOS/UI (0.7.4):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
@@ -62,11 +62,11 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
-  HockeySDK: 1b69a82782f6a3d4a1c0b1f04dca4bca83fc8c82
+  HockeySDK: ebaabf41808b4e4ea85b4d5266d425aef0d19c88
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
   WordPressCom-Analytics-iOS: e1a7111255e98561c4b5a33ef4baa75a68e0d5d3
-  WordPressCom-Stats-iOS: 9914c649c89fafad69b61876e492b71646b2f254
+  WordPressCom-Stats-iOS: 87b64bc36015e90789fec4abdb931af87c6e4cfe
 
 PODFILE CHECKSUM: 370d0f0593d313302b1555d22d18108c29964011
 

--- a/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
+++ b/WordPressCom-Stats-iOS/Services/WPStatsServiceRemote.m
@@ -1775,16 +1775,16 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
     
     switch (unit) {
         case StatsPeriodUnitDay:
-            dateFormatter.dateFormat = @"LLL d";
+            [dateFormatter setLocalizedDateFormatFromTemplate:@"LLL d"];
             break;
         case StatsPeriodUnitWeek:
-            dateFormatter.dateFormat = @"LLL d";
+            [dateFormatter setLocalizedDateFormatFromTemplate:@"LLL d"];
             break;
         case StatsPeriodUnitMonth:
-            dateFormatter.dateFormat = @"LLL";
+            [dateFormatter setLocalizedDateFormatFromTemplate:@"LLL"];
             break;
         case StatsPeriodUnitYear:
-            dateFormatter.dateFormat = @"yyyy";
+            [dateFormatter setLocalizedDateFormatFromTemplate:@"yyyy"];
             break;
     }
     
@@ -1818,7 +1818,7 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
 {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     formatter.locale = [NSLocale currentLocale];
-    formatter.dateFormat = @"MMM dd";
+    [formatter setLocalizedDateFormatFromTemplate:@"MMM dd"];
     formatter.timeZone = [NSTimeZone localTimeZone];
     
     NSString *startString = [formatter stringFromDate:startDate];
@@ -1832,7 +1832,7 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
 {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     formatter.locale = [NSLocale currentLocale];
-    formatter.dateFormat = @"EEE, MMM dd";
+    [formatter setLocalizedDateFormatFromTemplate:@"EEE, MMM dd"];
     formatter.timeZone = [NSTimeZone localTimeZone];
     
     NSString *dateString = [formatter stringFromDate:date];

--- a/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
+++ b/WordPressCom-Stats-iOS/UI/StatsTableViewController.m
@@ -814,23 +814,23 @@ static NSString *const StatsTableSectionHeaderSimpleBorder = @"StatsTableSection
     
     switch (self.selectedPeriodUnit) {
         case StatsPeriodUnitDay:
-            dateFormatter.dateFormat = @"MMMM d";
+            [dateFormatter setLocalizedDateFormatFromTemplate:@"MMMM d"];
             labelText = [NSString stringWithFormat:NSLocalizedString(@"Stats for %@", @"Stats header for single date"), [dateFormatter stringFromDate:self.selectedDate]];
             break;
         case StatsPeriodUnitWeek:
         {
-            dateFormatter.dateFormat = @"MMMM d";
+            [dateFormatter setLocalizedDateFormatFromTemplate:@"MMMM d"];
             StatsDateUtilities *dateUtils = [StatsDateUtilities new];
             NSDate *endDate = [dateUtils calculateEndDateForPeriodUnit:self.selectedPeriodUnit withDateWithinPeriod:self.selectedDate];
             labelText = [NSString stringWithFormat:NSLocalizedString(@"Stats for %@ - %@", @"Stats header label for date range"), [dateFormatter stringFromDate:self.selectedDate], [dateFormatter stringFromDate:endDate]];
             break;
         }
         case StatsPeriodUnitMonth:
-            dateFormatter.dateFormat = @"MMMM";
+            [dateFormatter setLocalizedDateFormatFromTemplate:@"MMMM"];
             labelText = [NSString stringWithFormat:NSLocalizedString(@"Stats for %@", @"Stats header for single date"), [dateFormatter stringFromDate:self.selectedDate]];
             break;
         case StatsPeriodUnitYear:
-            dateFormatter.dateFormat = @"yyyy";
+            [dateFormatter setLocalizedDateFormatFromTemplate:@"yyyy"];
             labelText = [NSString stringWithFormat:NSLocalizedString(@"Stats for %@", @"Stats header for single date"), [dateFormatter stringFromDate:self.selectedDate]];
             break;
     }

--- a/WordPressCom-Stats-iOS/UI/WPStatsContributionGraph.m
+++ b/WordPressCom-Stats-iOS/UI/WPStatsContributionGraph.m
@@ -193,8 +193,7 @@ static NSString *const ClearPostActivityDateNotification = @"ClearPostActivityDa
 
     // Draw the abbreviated month name below the graph
     NSDateFormatter* formatter = [[NSDateFormatter alloc] init];
-    [formatter setDateStyle:NSDateFormatterMediumStyle];
-    [formatter setDateFormat:@"MMM"];
+    [formatter setLocalizedDateFormatFromTemplate:@"MMM"];
     NSString *monthName = [formatter stringFromDate:self.monthForGraph];
     CGRect labelRect = CGRectMake( (((self.cellSize * columnCount)/2.0)-(self.cellSize/1.1)), self.cellSize * 9.0, self.cellSize * 3.0, self.cellSize * 1.2);
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle defaultParagraphStyle] mutableCopy];

--- a/WordPressCom-Stats-iOS/UI/WPStatsViewController.h
+++ b/WordPressCom-Stats-iOS/UI/WPStatsViewController.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSInteger, StatsPeriodType)
 @optional
 
 - (void)statsViewController:(WPStatsViewController *)controller openURL:(NSURL *)url;
-- (NSObject *)statsService;
+- (WPStatsService *)statsService;
 
 @end
 


### PR DESCRIPTION
Fixes #419 

Switches to set custom date formats with the `setLocalizedDateFormatFromTemplate` method so format strings are translated properly for different locales. Does not change any date formatters for things interpreting dates from JSON data.

To test:

1. Using StatsDemo (or WPiOS pointing at your local copy of this pod) launch the app with the locale changed to something like Netherlands/Dutch.
2. Verify all dates are localized properly including: Insights posting activity, Days/Weeks/Months/Years graph x-axis labels, header between graph & Posts & Pages.
3. Validate stats data matches the same period in web-based Calypso stats.

Needs Review: @jleandroperez