### PR TITLE
Update WordPress-Shared-iOS dependency to 0.6.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ use_frameworks!
 target 'WordPressCom-Stats-iOS' do
   pod 'AFNetworking',	'~> 3.1.0'
   pod 'CocoaLumberjack', '~> 2.2.0'
-  pod 'WordPress-iOS-Shared', '~> 0.5.3'
+  pod 'WordPress-iOS-Shared', '~> 0.6.0'
   pod 'NSObject-SafeExpectations', '0.0.2'
   pod 'WordPressCom-Analytics-iOS', '~> 0.1.4'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -37,7 +37,7 @@ PODS:
   - OHHTTPStubs/NSURLSession (4.6.0):
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (4.6.0)
-  - WordPress-iOS-Shared (0.5.9):
+  - WordPress-iOS-Shared (0.6.0):
     - CocoaLumberjack (~> 2.2.0)
   - WordPressCom-Analytics-iOS (0.1.15)
 
@@ -47,7 +47,7 @@ DEPENDENCIES:
   - NSObject-SafeExpectations (= 0.0.2)
   - OCMock
   - OHHTTPStubs (~> 4.6.0)
-  - WordPress-iOS-Shared (~> 0.5.3)
+  - WordPress-iOS-Shared (~> 0.6.0)
   - WordPressCom-Analytics-iOS (~> 0.1.4)
 
 SPEC CHECKSUMS:
@@ -56,9 +56,9 @@ SPEC CHECKSUMS:
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
   OHHTTPStubs: cb1aefbbeb4de4e741644455d4b945538e5248a2
-  WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
+  WordPress-iOS-Shared: f799334b41f3af509ccb76d7970f8c74a7716f14
   WordPressCom-Analytics-iOS: e1a7111255e98561c4b5a33ef4baa75a68e0d5d3
 
-PODFILE CHECKSUM: 7a8308dbf54fe6d90aab0c86755e8e727b9f21ea
+PODFILE CHECKSUM: 135829e601ad5d50b885138b363f337f7d6309e3
 
 COCOAPODS: 1.0.1

--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -26,28 +26,28 @@ PODS:
     - HockeySDK/AllFeaturesLib (= 4.0.2)
   - HockeySDK/AllFeaturesLib (4.0.2)
   - NSObject-SafeExpectations (0.0.2)
-  - WordPress-iOS-Shared (0.5.9):
+  - WordPress-iOS-Shared (0.6.0):
     - CocoaLumberjack (~> 2.2.0)
-  - WordPressCom-Analytics-iOS (0.1.15)
-  - WordPressCom-Stats-iOS (0.7.4):
+  - WordPressCom-Analytics-iOS (0.1.16)
+  - WordPressCom-Stats-iOS (0.7.6):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.3)
+    - WordPress-iOS-Shared (~> 0.6.0)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-    - WordPressCom-Stats-iOS/Services (= 0.7.4)
-    - WordPressCom-Stats-iOS/UI (= 0.7.4)
-  - WordPressCom-Stats-iOS/Services (0.7.4):
+    - WordPressCom-Stats-iOS/Services (= 0.7.6)
+    - WordPressCom-Stats-iOS/UI (= 0.7.6)
+  - WordPressCom-Stats-iOS/Services (0.7.6):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.3)
+    - WordPress-iOS-Shared (~> 0.6.0)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-  - WordPressCom-Stats-iOS/UI (0.7.4):
+  - WordPressCom-Stats-iOS/UI (0.7.6):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (= 0.0.2)
-    - WordPress-iOS-Shared (~> 0.5.3)
+    - WordPress-iOS-Shared (~> 0.6.0)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
     - WordPressCom-Stats-iOS/Services
 
@@ -64,9 +64,9 @@ SPEC CHECKSUMS:
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   HockeySDK: ebaabf41808b4e4ea85b4d5266d425aef0d19c88
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
-  WordPress-iOS-Shared: 50a7bd7056b8721e86c3cbe167eab49ef85ec07b
-  WordPressCom-Analytics-iOS: e1a7111255e98561c4b5a33ef4baa75a68e0d5d3
-  WordPressCom-Stats-iOS: 87b64bc36015e90789fec4abdb931af87c6e4cfe
+  WordPress-iOS-Shared: f799334b41f3af509ccb76d7970f8c74a7716f14
+  WordPressCom-Analytics-iOS: 46cbb47a84670f3b8548c8617da939c6b74cfda8
+  WordPressCom-Stats-iOS: 2689a457fd18268d36266fca76e96dd13e4af991
 
 PODFILE CHECKSUM: 370d0f0593d313302b1555d22d18108c29964011
 

--- a/WordPressCom-Stats-iOS.podspec
+++ b/WordPressCom-Stats-iOS.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.module_name = 'WordPressComStatsiOS'
   s.dependency 'AFNetworking',	'~> 3.1.0'
   s.dependency 'CocoaLumberjack', '~> 2.2.0'
-  s.dependency 'WordPress-iOS-Shared', '~> 0.5.3'
+  s.dependency 'WordPress-iOS-Shared', '~> 0.6.0'
   s.dependency 'NSObject-SafeExpectations', '0.0.2'
   s.dependency 'WordPressCom-Analytics-iOS', '~> 0.1.4'
 end

--- a/WordPressCom-Stats-iOS.podspec
+++ b/WordPressCom-Stats-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Stats-iOS"
-  s.version      = "0.7.5"
+  s.version      = "0.7.6"
   s.summary      = "Reusable component for displaying WordPress.com site stats in an iOS application."
 
   s.description  = <<-DESC


### PR DESCRIPTION
Updates WordPress-Shared-iOS dependency to version 0.6.0.

Needs review: @astralbodies