### PR TITLE
WPStatsViewController: Adds popover presentation source

### DIFF
--- a/WordPressCom-Stats-iOS/UI/WPStatsViewController.m
+++ b/WordPressCom-Stats-iOS/UI/WPStatsViewController.m
@@ -130,6 +130,11 @@
         [alertController addAction:monthsAction];
         [alertController addAction:yearsAction];
 
+        // If not displayed full screen, the alert controller is automatically displayed in a popover by the system
+        alertController.popoverPresentationController.sourceView = control;
+        CGFloat segmentWidth = CGRectGetWidth(control.bounds) / control.numberOfSegments;
+        alertController.popoverPresentationController.sourceRect = CGRectMake(control.selectedSegmentIndex * segmentWidth, 0, segmentWidth, CGRectGetHeight(control.bounds));
+
         self.periodActionSheet = alertController;
         [self presentViewController:alertController animated:YES completion:nil];
     } else {


### PR DESCRIPTION
Fixes a crash I was seeing whilst working on the `feature/ipad-splitview-mysites` split view branch of WPiOS. 

When displayed in a split (compact horizontal size class), but not full screen (multitasking), the stats view controller wants to display the "More..." alert controller in a popover instead of an action sheet. 

![simulator screen shot 1 aug 2016 17 43 29](https://cloud.githubusercontent.com/assets/4780/17301660/10cf1556-5810-11e6-9029-0f9fd26616d2.png)

However, as this configuration hasn't previously been possible in the app, we weren't configuring the popover presentation delegate. This resulted in a crash.

To test:

Run the `feature/ipad-splitview-mysites` branch of WPiOS, with these tweaks to `WPStatsViewController`. Navigate to stats in the multitasking configuration described / shown above, and try tapping on "More...". Ensure that the popover displays correctly and the app doesn't crash.

Needs review: @astralbodies 