### PR TITLE
Fixes a crash in InsightsTableViewController in WPiOS

### DIFF
--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -29,21 +29,21 @@ PODS:
   - WordPress-iOS-Shared (0.6.0):
     - CocoaLumberjack (~> 2.2.0)
   - WordPressCom-Analytics-iOS (0.1.17)
-  - WordPressCom-Stats-iOS (0.7.7):
+  - WordPressCom-Stats-iOS (0.7.8):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPress-iOS-Shared (~> 0.5)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-    - WordPressCom-Stats-iOS/Services (= 0.7.7)
-    - WordPressCom-Stats-iOS/UI (= 0.7.7)
-  - WordPressCom-Stats-iOS/Services (0.7.7):
+    - WordPressCom-Stats-iOS/Services (= 0.7.8)
+    - WordPressCom-Stats-iOS/UI (= 0.7.8)
+  - WordPressCom-Stats-iOS/Services (0.7.8):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPress-iOS-Shared (~> 0.5)
     - WordPressCom-Analytics-iOS (~> 0.1.4)
-  - WordPressCom-Stats-iOS/UI (0.7.7):
+  - WordPressCom-Stats-iOS/UI (0.7.8):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
@@ -66,7 +66,7 @@ SPEC CHECKSUMS:
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   WordPress-iOS-Shared: f799334b41f3af509ccb76d7970f8c74a7716f14
   WordPressCom-Analytics-iOS: 02c94167d80f43684bdc83cf8df2f4b6fc0909ba
-  WordPressCom-Stats-iOS: 5996ea5bc7ce2096400fdc33e3368b5524f7288a
+  WordPressCom-Stats-iOS: fe144146738b8cdafead8245073a1c10a43d0e28
 
 PODFILE CHECKSUM: 370d0f0593d313302b1555d22d18108c29964011
 

--- a/WordPressCom-Stats-iOS.podspec
+++ b/WordPressCom-Stats-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "WordPressCom-Stats-iOS"
-  s.version      = "0.7.7"
+  s.version      = "0.7.8"
   s.summary      = "Reusable component for displaying WordPress.com site stats in an iOS application."
 
   s.description  = <<-DESC

--- a/WordPressCom-Stats-iOS/Services/WPStatsService.m
+++ b/WordPressCom-Stats-iOS/Services/WPStatsService.m
@@ -206,53 +206,55 @@ NSString *const TodayCacheKey = @"Today";
         && (!streakCompletion || streakData)
         )
     {
-        if (commentsAuthorsCompletion) {
-            commentsAuthorsCompletion(commentsAuthorData, nil);
-        }
-        
-        if (commentsPostsCompletion) {
-            commentsPostsCompletion(commentsPostsData, nil);
-        }
-        
-        if (tagsCategoriesCompletion) {
-            tagsCategoriesCompletion(tagsCategoriesData, nil);
-        }
-        
-        if (followersDotComCompletion) {
-            followersDotComCompletion(followersDotComData, nil);
-        }
-        
-        if (followersEmailCompletion) {
-            followersEmailCompletion(followersEmailData, nil);
-        }
-        
-        if (publicizeCompletion) {
-            publicizeCompletion(publicizeData, nil);
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (commentsAuthorsCompletion) {
+                commentsAuthorsCompletion(commentsAuthorData, nil);
+            }
+            
+            if (commentsPostsCompletion) {
+                commentsPostsCompletion(commentsPostsData, nil);
+            }
+            
+            if (tagsCategoriesCompletion) {
+                tagsCategoriesCompletion(tagsCategoriesData, nil);
+            }
+            
+            if (followersDotComCompletion) {
+                followersDotComCompletion(followersDotComData, nil);
+            }
+            
+            if (followersEmailCompletion) {
+                followersEmailCompletion(followersEmailData, nil);
+            }
+            
+            if (publicizeCompletion) {
+                publicizeCompletion(publicizeData, nil);
+            }
 
-        if (allTimeCompletion) {
-            allTimeCompletion(allTimeData, nil);
-        }
-        
-        if (insightsCompletion) {
-            insightsCompletion(insightsData, nil);
-        }
-        
-        if (todaySummaryCompletion) {
-            todaySummaryCompletion(todayData, nil);
-        }
-        
-        if (streakCompletion) {
-            streakCompletion(streakData, nil);
-        }
-        
-        if (latestPostCompletion) {
-            latestPostCompletion(latestPostData, nil);
-        }
-        
-        if (overallCompletionHandler) {
-            overallCompletionHandler();
-        }
+            if (allTimeCompletion) {
+                allTimeCompletion(allTimeData, nil);
+            }
+            
+            if (insightsCompletion) {
+                insightsCompletion(insightsData, nil);
+            }
+            
+            if (todaySummaryCompletion) {
+                todaySummaryCompletion(todayData, nil);
+            }
+            
+            if (streakCompletion) {
+                streakCompletion(streakData, nil);
+            }
+            
+            if (latestPostCompletion) {
+                latestPostCompletion(latestPostData, nil);
+            }
+            
+            if (overallCompletionHandler) {
+                overallCompletionHandler();
+            }
+        });
 
         return;
     }


### PR DESCRIPTION
In the working `feature/ipad-splitview-mysites` branch in WPiOS, we ran into a couple of crashes in `InsightsTableViewController`, seemingly when data was loaded and perhaps the VC wasn't yet onscreen. In particular, the app was crashing on calls to `[tableView endUpdates]` in the callbacks for `retrieveInsightsStatsWithAllTimeStatsCompletionHandler...`.

This PR wraps the cached data callbacks in `retrieveInsightsStatsWithAllTimeStatsCompletionHandler...` in a `dispatch_async`, which ensures they're called on the main queue, and also appears to allow `UITableView` to correctly refresh itself.

To test: Use this branch with the iPad Splitview PR on WPiOS, and verify that the Stats crashes no longer occur: https://github.com/wordpress-mobile/WordPress-iOS/pull/5802

Needs review: @kurzee
Ping @astralbodies 