### PR TITLE
Add sanity checks to the graph view controller size calculations.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -37,9 +37,9 @@ PODS:
   - OHHTTPStubs/NSURLSession (4.6.0):
     - OHHTTPStubs/Core
   - OHHTTPStubs/OHPathHelpers (4.6.0)
-  - WordPress-iOS-Shared (0.6.0):
+  - WordPress-iOS-Shared (0.6.3):
     - CocoaLumberjack (~> 2.2.0)
-  - WordPressCom-Analytics-iOS (0.1.15)
+  - WordPressCom-Analytics-iOS (0.1.21)
 
 DEPENDENCIES:
   - AFNetworking (~> 3.1.0)
@@ -56,9 +56,9 @@ SPEC CHECKSUMS:
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   OCMock: f3f61e6eaa16038c30caa5798c5e49d3307b6f22
   OHHTTPStubs: cb1aefbbeb4de4e741644455d4b945538e5248a2
-  WordPress-iOS-Shared: f799334b41f3af509ccb76d7970f8c74a7716f14
-  WordPressCom-Analytics-iOS: e1a7111255e98561c4b5a33ef4baa75a68e0d5d3
+  WordPress-iOS-Shared: 2496fba282efcdcb8182f8f282ca0eb56dc4eb32
+  WordPressCom-Analytics-iOS: ee6cc3a4feb63cebba167ce762c6e12c0b7b6671
 
 PODFILE CHECKSUM: 135829e601ad5d50b885138b363f337f7d6309e3
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.1.1

--- a/StatsDemo/Podfile.lock
+++ b/StatsDemo/Podfile.lock
@@ -22,13 +22,13 @@ PODS:
     - CocoaLumberjack/Core
   - CocoaLumberjack/Extensions (2.2.0):
     - CocoaLumberjack/Default
-  - HockeySDK (4.0.2):
-    - HockeySDK/AllFeaturesLib (= 4.0.2)
-  - HockeySDK/AllFeaturesLib (4.0.2)
+  - HockeySDK (4.1.3):
+    - HockeySDK/DefaultLib (= 4.1.3)
+  - HockeySDK/DefaultLib (4.1.3)
   - NSObject-SafeExpectations (0.0.2)
-  - WordPress-iOS-Shared (0.6.0):
+  - WordPress-iOS-Shared (0.7.0):
     - CocoaLumberjack (~> 2.2.0)
-  - WordPressCom-Analytics-iOS (0.1.17)
+  - WordPressCom-Analytics-iOS (0.1.21)
   - WordPressCom-Stats-iOS (0.8.0):
     - AFNetworking (~> 3.1.0)
     - CocoaLumberjack (~> 2.2.0)
@@ -42,15 +42,15 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   WordPressCom-Stats-iOS:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
-  HockeySDK: ebaabf41808b4e4ea85b4d5266d425aef0d19c88
+  HockeySDK: 7dd8d7f5a4d71b7a5eebb320c8515cb22e99221b
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
-  WordPress-iOS-Shared: f799334b41f3af509ccb76d7970f8c74a7716f14
-  WordPressCom-Analytics-iOS: 02c94167d80f43684bdc83cf8df2f4b6fc0909ba
+  WordPress-iOS-Shared: 4bec543bac6543480b10d904bea122dcba43cc37
+  WordPressCom-Analytics-iOS: ee6cc3a4feb63cebba167ce762c6e12c0b7b6671
   WordPressCom-Stats-iOS: 7c961a7780a695f54db5431537c16615682cdf32
 
 PODFILE CHECKSUM: 370d0f0593d313302b1555d22d18108c29964011

--- a/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
+++ b/WordPressCom-Stats-iOS.xcodeproj/project.pbxproj
@@ -964,7 +964,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		92826B9E13226588A5E0E57F /* [CP] Embed Pods Frameworks */ = {
@@ -994,7 +994,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		EF49D0784889E0A466363629 /* [CP] Copy Pods Resources */ = {

--- a/WordPressCom-Stats-iOS/UI/WPStatsGraphViewController.m
+++ b/WordPressCom-Stats-iOS/UI/WPStatsGraphViewController.m
@@ -157,8 +157,8 @@ static NSInteger const RecommendedYAxisTicks = 2;
     CGRect rect = UIEdgeInsetsInsetRect(collectionView.bounds, collectionView.contentInset);
     CGFloat width = floor((CGRectGetWidth(rect) / self.numberOfXValues) - 5.0);
     CGFloat height = CGRectGetHeight(rect);
-    
-    CGSize size = CGSizeMake(width, height);
+
+    CGSize size = CGSizeMake(width < 0 ? 0 : width, height < 0 ? 0 : height);
     
     return size;
 }
@@ -170,7 +170,7 @@ static NSInteger const RecommendedYAxisTicks = 2;
 
     CGFloat spacing = floor((CGRectGetWidth(rect) - (width * self.numberOfXValues)) / self.numberOfXValues);
 
-    return spacing;
+    return spacing < 0 ? 0 : spacing;
 }
 
 #pragma mark - Public class methods


### PR DESCRIPTION
Closes #432 

Added some sanity checks around the size calculation in the graph view controller to prevent crashes. It's not really possible to cause this crash to happen with StatsDemo. You'll need to integrate it into WPiOS with a :path => '' reference to the local pod. Testing that crash is also a bit hard.

I'm okay with this being a code-only PR review.

Needs Review: @kurzee